### PR TITLE
Enable Travis with an empty library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+sudo: required
+dist: xenial
+python:
+  - "3.7"
+
+script:
+  - pytest
+
+deploy:
+  provider: pypi
+  user: nolar
+  password:
+    secure: "hvXIiqAAzsB5p++rv12XJM6WtuUHa9YnvoY12HfdZeLcim+/TQpMM0qThF0Y7tLcgAq/CqIOVoawOxDU+yKtzEbDqOd7wVIu8Z9tlnaIXIobV7BmLqeeqHAWNRB95fbkPWVUp0Ff0pdV4lvNwzw9qI4sB4J+x3k5sgiLKGh/JIxJpMxZTpQzsaxPsbIh4nbTebysdKfRsBbtUGx6Z1JK9vlK+a+fTho3hpmbv5Ku6z8JZePx2Ox0hugTCak556lDy4Psa6Hhnf69Rm05wfr7n4zIkU1/0zt1q+ggPs6L+Hc5PbBxWw1zUWn8YvNiSpEqiwuRZ9rgJl396g2ge2eUNwTjnc7qmbxgO8Ue3GuqRzokXzeAlS6MNSFfjzENrL+FjMUiHEWiP8HOpWfd2vVSK7Sp2HLE0NKWIhn38w3VhMz++rOPn8OdL4+K48BUSYod051+CJnjczcCWYyfoK4pvajOtsTgswnJvVG1it2iEdS/j7U1KslKfR3A38ojzwyrFb3F4XQ4D4yZxYIz0E0xl3X0q63vGibvGsFLgnD4okUq6r3k4TvoWn5rbN4039CcQbhVZrAaDzdvrTGiSTXMEMklr0G8rQEq6SQOsclMB6Db4ttnLOj5rk14gs0FvhvR/R4wF1SMAK2IzhgEx1S78xIvralrk+anHIWydhm+P8A="
+  distributions: sdist bdist_wheel
+  skip_existing: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# The runtime dependencies of the framework, as if via `pip install kopf`.
+-e .
+
+# Everything needed to develop (test, debug) the framework.
+pytest

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='kopf',
+    use_scm_version=True,
+
+    packages=find_packages(),
+    include_package_data=True,
+
+    setup_requires=[
+        'setuptools_scm',
+    ],
+    install_requires=[
+    ],
+)

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -1,0 +1,5 @@
+
+
+def test_importing_works():
+    import kopf
+    assert kopf


### PR DESCRIPTION
Issue #5

Configure Travis CI and prepare a dummy library and versioning schema before the initial import.

Currently, under my personal account (nolar), with the permissions granted to other maintainers as needed.

Tasks after the merge:

* [ ] Put a 0.0 tag in the git repo to mark a versioning baseline.