### PR TITLE
React on the errors and unknown events from k8s API

### DIFF
--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -81,6 +81,10 @@ async def watcher(
         stream = w.stream(api.list_cluster_custom_object, resource.group, resource.version, resource.plural)
         async for event in _async_wrapper(stream):
 
+            # Other watch errors should be fatal for the operator.
+            if event['type'] == 'ERROR':
+                raise Exception(f"Error in the watch-stream: {event['object']}")
+
             # Ensure that the event is something we understand and can handle.
             if event['type'] not in ['ADDED', 'MODIFIED', 'DELETED']:
                 logger.warn("Unsupported event type received, ignoring: %r", event)

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -74,37 +74,46 @@ async def watcher(
     scheduler = await aiojobs.create_scheduler(limit=10)
     queues = {}
     try:
+        while True:
 
-        # Make a Kubernetes call to watch for the events via the API.
-        w = kubernetes.watch.Watch()
-        api = kubernetes.client.CustomObjectsApi()
-        stream = w.stream(api.list_cluster_custom_object, resource.group, resource.version, resource.plural)
-        async for event in _async_wrapper(stream):
+            # Make a Kubernetes call to watch for the events via the API.
+            w = kubernetes.watch.Watch()
+            api = kubernetes.client.CustomObjectsApi()
+            api_fn = api.list_cluster_custom_object
+            stream = w.stream(api_fn, resource.group, resource.version, resource.plural)
+            async for event in _async_wrapper(stream):
 
-            # Other watch errors should be fatal for the operator.
-            if event['type'] == 'ERROR':
-                raise Exception(f"Error in the watch-stream: {event['object']}")
+                # "410 Gone" is for the "resource version too old" error, we must restart watching.
+                # The resource versions are lost by k8s after few minutes (as per the official doc).
+                # The error occurs when there is nothing happening for few minutes. This is normal.
+                if event['type'] == 'ERROR' and event['object']['code'] == 410:
+                    logger.debug("Restarting the watch-stream for %r", resource)
+                    break  # out of for-cycle, to the while-true-cycle.
 
-            # Ensure that the event is something we understand and can handle.
-            if event['type'] not in ['ADDED', 'MODIFIED', 'DELETED']:
-                logger.warn("Unsupported event type received, ignoring: %r", event)
-                continue
+                # Other watch errors should be fatal for the operator.
+                if event['type'] == 'ERROR':
+                    raise Exception(f"Error in the watch-stream: {event['object']}")
 
-            # Filter out all unrelated events as soon as possible (before queues), and silently.
-            # TODO: Reimplement via api.list_namespaced_custom_object, and API-level filtering.
-            ns = event['object'].get('metadata', {}).get('namespace', None)
-            if namespace is not None and ns is not None and ns != namespace:
-                continue
+                # Ensure that the event is something we understand and can handle.
+                if event['type'] not in ['ADDED', 'MODIFIED', 'DELETED']:
+                    logger.warn("Ignoring an unsupported event type: %r", event)
+                    continue
 
-            # Either use the existing object's queue, or create a new one together with the per-object job.
-            # "Fire-and-forget": we do not wait for the result; the job destroys itself when it is fully done.
-            key = (resource, event['object']['metadata']['uid'])
-            try:
-                await queues[key].put(event)
-            except KeyError:
-                queues[key] = asyncio.Queue()
-                await queues[key].put(event)
-                await scheduler.spawn(worker(handler=handler, queues=queues, key=key))
+                # Filter out all unrelated events as soon as possible (before queues), and silently.
+                # TODO: Reimplement via api.list_namespaced_custom_object, and API-level filtering.
+                ns = event['object'].get('metadata', {}).get('namespace', None)
+                if namespace is not None and ns is not None and ns != namespace:
+                    continue
+
+                # Either use the existing object's queue, or create a new one together with the per-object job.
+                # "Fire-and-forget": we do not wait for the result; the job destroys itself when it is fully done.
+                key = (resource, event['object']['metadata']['uid'])
+                try:
+                    await queues[key].put(event)
+                except KeyError:
+                    queues[key] = asyncio.Queue()
+                    await queues[key].put(event)
+                    await scheduler.spawn(worker(handler=handler, queues=queues, key=key))
 
     finally:
         # Forcedly terminate all the fire-and-forget per-object jobs, of they are still running.


### PR DESCRIPTION
> Issues: #10

There is an exception sporadically happening for the objects:

```
Traceback (most recent call last):
  ………
  File "/usr/local/lib/python3.7/dist-packages/kopf/reactor/queueing.py", line 83, in watcher
    key = (resource, event['object']['metadata']['uid'])
KeyError: 'uid'
```

It is, in turn, is caused by the unexpected event types coming from the Kubernetes API, specifically from the watch call (note that the object has the metadata, but no uid or standard k8s-object fields):

```python
{'object': {'apiVersion': 'v1',
            'code': 410,
            'kind': 'Status',
            'message': 'too old resource version: 190491269 (208223535)',
            'metadata': {},
            'reason': 'Gone',
            'status': 'Failure'},
 'raw_object': {'apiVersion': 'v1',
                'code': 410,
                'kind': 'Status',
                'message': 'too old resource version: 190491269 (208223535)',
                'metadata': {},
                'reason': 'Gone',
                'status': 'Failure'},
 'type': 'ERROR'}
```

This ERROR event, in turn, is caused by how the watch-calls to the API are implemented in the Kubernetes library (be that Python or any other language):

* A GET call is made to get a list of objects, with the `?watch=true` argument.
* The response for the watch-calls is the JSON-stream (one JSON per line) of events.
* The library parses ("unmarshalls") the events and yields them to the caller.
* The `resourceVersion` is remembered from the latest event (technically, for every event, but the latest one overrides).
* When one GET call is terminated by the server (usually in few second), a new one is made, and this continues forever.
* The latest known `resourceVersion` is passed to the next GET-call, so that the stream continues from that point only.

However, due nothing is happening for few minutes, the `resourceVersion` somehow becomes "too old", i.e. not remembered by Kubernetes already. This behaviour is documented in the k8s docs (https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes):

> A given Kubernetes server will only preserve a historical list of changes for a limited time. Clusters using etcd3 preserve changes in the last 5 minutes by default. When the requested watch operations fail because the historical version of that resource is not available, clients must handle the case by recognizing the status code 410 Gone, clearing their local cache, performing a list operation, and starting the watch from the resourceVersion returned by that new list operation. 

So, the Kubernetes API returns and yields these ERROR events. In theory, it should die with an exception (I would expect that instead of the "normal" ERROR events). As observed, these  "too old resource version" errors are streamed very fast, non-stop (also strange).

The only valid way here is to restart the watch call from scratch, i.e. no `resourceVersion` provided.

This is an equivalent of the operator restart: every object is listed again, and goes through the handling cycle (usually a do-nothing handling). But the restart is "soft": the queues, the ascyncio tasks, and generally the state of the operator is not lost, and the time is not wasted (for the pod allocation).

This PR does these 3 things:

* Soft-restarts the watching cycle on the "too old resource version" errors.
* Fails on the ERROR event types for the unknown errors.
* Warns about the unknown event types, which can appear in the future, and ignores them.
