### PR TITLE
Persist the progress status of the last handled event/cause

### DIFF
--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -14,6 +14,7 @@ https://kubernetes.io/docs/concepts/overview/object-management-kubectl/declarati
 """
 
 import copy
+import hashlib
 import json
 
 from kopf.structs.diffs import diff
@@ -72,3 +73,11 @@ def retreive_state(body):
 def refresh_last_seen_state(*, body, patch):
     state = get_state(body)
     patch.setdefault('metadata', {}).setdefault('annotations', {})[LAST_SEEN_ANNOTATION] = json.dumps(state)
+
+
+def get_actual_digest(body):
+    # Any digest with a short str/int result is sufficient. Even CRC. No security is needed.
+    state = get_state(body)
+    hash = hashlib.md5()
+    hash.update(json.dumps(state).encode('utf-8'))
+    return hash.hexdigest()


### PR DESCRIPTION
**DO NOT MERGE:** The idea of persistent status is questionable. Need some feedback from the early usage in our team projects.

---

The status is seen by `kubectl describe ObjType obj-id` or `kubectl describe -f obj.yaml` (in a fancy reformatted capitalised form), or by `kubectl get -f obj.yaml -o yaml` (in the original yaml form).

Unlike the k8s events, which are garbage-collected after some time (~1 hour?), the status is persisted on the object for the whole object lifecycle. Moreover, the status can be used in the [additional CRD "printer columns"](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#additional-printer-columns), as shown by `kubectl get ObjType`.

----

Originally, the handlers status (also called the _"progress"_) was only stored during the handling cycle (there could be multiple handlers/subhandlers, provoking multiple patches & watch-events), and the presence of the progress meant that the handling cycle is ongoing. Once the handling cycle was done, the progress was purged, and the kopf-specific status was removed.

This made the debugging harder, as it required to read the verbose log messages on the handlers/subhandlers progression, rather than checking the object itself.

Now, with this change, the progress of the last handling cycle will be persisted on the object. It will, however, be replaced by the new progress, if the new change happens (e.g. the object is edited or deleted), and the new cycle begins.

----

As a downside of this change, the object remains polluted with the internal states of the framework, which can look not so nice, since it exposes the internal logic and abstractions to the user — i.e. the classical [leaky abstraction anti-pattern](https://en.wikipedia.org/wiki/Leaky_abstraction). On the other hand, this leakage of the abstractions can be helpful to the developers of the operators or of the framework. 

To achieve that goal, the handling logic was changed and complicated: e.g., the "hash-digest of the current state" was introduced to distinguish the real object changes from the internally provoked changes (previously was distinguished by the existence/non-existence of the progress status); and an additional patching cycle was introduced to store the hash-digest on the beginning of each handling cycle. These additional complications also do not feel nice.

This is why it goes as a separate PR — to see, if this approach helps at all, or does not help, and should be avoided.