### PR TITLE
Pass the field diff to the field handlers, not the obj diff

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -37,6 +37,7 @@ from kopf.reactor.registry import (
 from kopf.structs.diffs import (
     Diff,
     resolve,
+    reduce,
 )
 from kopf.structs.finalizers import (
     is_deleted,
@@ -461,7 +462,7 @@ async def _call_handler(
     # For the field-handlers, the old/new/diff values must match the field, not the whole object.
     old = cause.old if handler.field is None else resolve(cause.old, handler.field)
     new = cause.new if handler.field is None else resolve(cause.new, handler.field)
-    diff = cause.diff  # TODO: pass the relevant diff-records for the field, not global.
+    diff = cause.diff if handler.field is None else reduce(cause.diff, handler.field)
     cause = cause._replace(old=old, new=new, diff=diff)
 
     # Store the context of the current resource-object-event-handler, to be used in `@kopf.on.this`,

--- a/kopf/structs/diffs.py
+++ b/kopf/structs/diffs.py
@@ -19,6 +19,16 @@ def resolve(d: Mapping, path: DiffPath):
     return result
 
 
+def reduce_iter(d: Diff, path: DiffPath) -> Generator[DiffItem, None, None]:
+    for op, field, old, new in d:
+        if field[:len(path)] == path:
+            yield (op, field[len(path):], old, new)
+
+
+def reduce(d: Diff, path: DiffPath) -> Diff:
+    return type(d)(reduce_iter(d, path))
+
+
 def diff(a: Any, b: Any, path: DiffPath = ()) -> Generator[DiffItem, None, None]:
     """
     Calculate the diff between two dicts.


### PR DESCRIPTION
The diff field for the `@kopf.on.field` handler contains the whole obj diff, but should contain the field diff: i.e. only the records related to the handled field, with the field names relative to the field's root, not to the object's root.

> Issue : #21
