### PR TITLE
Enable asyncio tests & mocks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,7 @@
 -e .
 
 # Everything needed to develop (test, debug) the framework.
+pytest-asyncio
+pytest-mock
 pytest
+asynctest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import asyncio
+
+import asynctest
+import pytest
+import pytest_mock
+
+
+# Make all tests in this directory and below asyncio-compatible by default.
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if asyncio.iscoroutinefunction(item.function):
+            item.add_marker('asyncio')
+
+
+# Substitute the regular mock with the async-aware mock in the `mocker` fixture.
+@pytest.fixture(scope='session', autouse=True)
+def enforce_asyncio_mocker():
+    pytest_mock._get_mock_module = lambda config: asynctest

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,30 @@
+"""
+Just to make sure that asyncio tests are configured properly.
+"""
+import asyncio
+
+_async_was_executed = False
+
+
+async def test_async_tests_are_enabled(timer):
+    global _async_was_executed
+    _async_was_executed = True  # asserted in a sync-test below.
+
+    with timer as t:
+        await asyncio.sleep(0.5)
+
+    assert t.seconds > 0.5  # real sleep
+
+
+async def test_async_mocks_are_enabled(timer, mocker):
+    p = mocker.patch('asyncio.sleep')
+    with timer as t:
+        await asyncio.sleep(1.0)
+
+    assert p.called
+    assert p.awaited
+    assert t.seconds < 0.01  # mocked sleep
+
+
+def test_async_test_was_executed_and_awaited():
+    assert _async_was_executed


### PR DESCRIPTION
> Issue : #13 (needed for #25)

Since Kopf is mostly asyncio-based, there will be a lot of async/await & asyncio tests, which also do the asyncio mocks. They behave differently than the regular (sync) tests & mocks, so some little magic is needed to enable them.

Here, we configure the asyncio environment to transparently run all `async def` test-functions as the asyncio tests, and the `mocker` fixture to support the async-compatible `CoroutineMock`.

These changes do not belong to any other task-specific PR, as they are generic.
