### PR TITLE
Replace built-in StopIteration with custom StopStreaming for API calls

### DIFF
--- a/kopf/reactor/watching.py
+++ b/kopf/reactor/watching.py
@@ -5,8 +5,17 @@ Kubernetes client's watching streams are synchronous. To make them asynchronous,
 we put them into a `concurrent.futures.ThreadPoolExecutor`,
 and yield from there asynchronously.
 
+However, async/await coroutines misbehave with `StopIteration` exceptions
+as raise by the `next` method: see `PEP-479`_.
+
+As a workaround, we replace `StopIteration` with our custom `StopStreaming`
+inherited from `RuntimeError` (as suggested by `PEP-479`_),
+and re-implement the generators to make them async.
+
 All of this is a workaround for the standard Kubernetes client's limitations.
 They are not needed if the client library is natively asynchronous.
+
+.. _PEP-479: https://www.python.org/dev/peps/pep-0479/
 """
 
 import asyncio
@@ -15,10 +24,30 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class StopStreaming(RuntimeError):
+    """
+    Raised when the watch-stream generator ends streaming.
+    Replaces `StopIteration`.
+    """
+
+
+def streaming_next(src):
+    """
+    Same as `next`, but replaces the `StopIteration` with `StopStreaming`.
+    """
+    try:
+        return next(src)
+    except StopIteration as e:
+        raise StopStreaming(str(e))
+
+
 async def streaming_aiter(src, loop=None, executor=None):
     """
     Same as `iter`, but asynchronous and stops on `StopStreaming`, not on `StopIteration`.
     """
     loop = loop if loop is not None else asyncio.get_event_loop()
     while True:
-        yield await loop.run_in_executor(executor, next, src)
+        try:
+            yield await loop.run_in_executor(executor, streaming_next, src)
+        except StopStreaming:
+            return

--- a/kopf/reactor/watching.py
+++ b/kopf/reactor/watching.py
@@ -1,0 +1,24 @@
+"""
+Watching & streaming of the watch-events.
+
+Kubernetes client's watching streams are synchronous. To make them asynchronous,
+we put them into a `concurrent.futures.ThreadPoolExecutor`,
+and yield from there asynchronously.
+
+All of this is a workaround for the standard Kubernetes client's limitations.
+They are not needed if the client library is natively asynchronous.
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def streaming_aiter(src, loop=None, executor=None):
+    """
+    Same as `iter`, but asynchronous and stops on `StopStreaming`, not on `StopIteration`.
+    """
+    loop = loop if loop is not None else asyncio.get_event_loop()
+    while True:
+        yield await loop.run_in_executor(executor, next, src)

--- a/kopf/reactor/watching.py
+++ b/kopf/reactor/watching.py
@@ -1,19 +1,19 @@
 """
-Watching & streaming of the watch-events.
+Watching and streaming watch-events.
 
 Kubernetes client's watching streams are synchronous. To make them asynchronous,
 we put them into a `concurrent.futures.ThreadPoolExecutor`,
 and yield from there asynchronously.
 
 However, async/await coroutines misbehave with `StopIteration` exceptions
-as raise by the `next` method: see `PEP-479`_.
+raised by the `next` method: see `PEP-479`_.
 
 As a workaround, we replace `StopIteration` with our custom `StopStreaming`
 inherited from `RuntimeError` (as suggested by `PEP-479`_),
 and re-implement the generators to make them async.
 
 All of this is a workaround for the standard Kubernetes client's limitations.
-They are not needed if the client library is natively asynchronous.
+They would not be needed if the client library were natively asynchronous.
 
 .. _PEP-479: https://www.python.org/dev/peps/pep-0479/
 """

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,77 @@
+import collections.abc
+
+import pytest
+
+from kopf.reactor.watching import StopStreaming, streaming_next, streaming_aiter
+
+
+async def test_streaming_next_never_ends_with_stopiteration():
+    lst = []
+    src = iter(lst)
+
+    with pytest.raises(StopStreaming) as e:
+        streaming_next(src)
+
+    assert not isinstance(e, StopIteration)
+    assert not isinstance(e, StopAsyncIteration)
+
+
+async def test_streaming_next_yields_and_ends():
+    lst = [1, 2, 3]
+    src = iter(lst)
+
+    val1 = streaming_next(src)
+    val2 = streaming_next(src)
+    val3 = streaming_next(src)
+    assert val1 == 1
+    assert val2 == 2
+    assert val3 == 3
+
+    with pytest.raises(StopStreaming):
+        streaming_next(src)
+
+
+async def test_streaming_iterator_with_regular_next_yields_and_ends():
+    lst = [1, 2, 3]
+    src = iter(lst)
+
+    itr = streaming_aiter(src)
+    assert isinstance(itr, collections.abc.AsyncIterator)
+    assert isinstance(itr, collections.abc.AsyncGenerator)
+
+    val1 = next(src)
+    val2 = next(src)
+    val3 = next(src)
+    assert val1 == 1
+    assert val2 == 2
+    assert val3 == 3
+
+    with pytest.raises(StopIteration):
+        next(src)
+
+
+async def test_streaming_iterator_with_asyncfor_works():
+    lst = [1, 2, 3]
+    src = iter(lst)
+
+    itr = streaming_aiter(src)
+    assert isinstance(itr, collections.abc.AsyncIterator)
+    assert isinstance(itr, collections.abc.AsyncGenerator)
+
+    vals = []
+    async for val in itr:
+        vals.append(val)
+    assert vals == lst
+
+
+async def test_streaming_iterator_with_syncfor_fails():
+    lst = [1, 2, 3]
+    src = iter(lst)
+
+    itr = streaming_aiter(src)
+    assert isinstance(itr, collections.abc.AsyncIterator)
+    assert isinstance(itr, collections.abc.AsyncGenerator)
+
+    with pytest.raises(TypeError):
+        for _ in itr:
+            pass


### PR DESCRIPTION
Prevent the operator from freezing on the end of the watch-event stream.

> Issue : #25 

Python3 has issues with `StopIteration` exception from inside the async coroutines. This issue is addressed in [PEP-479](https://www.python.org/dev/peps/pep-0479/).

Briefly, this code works and raises a `RuntimeError` as per PEP-479:

```
import asyncio

async def fn(src):
    print(next(src))
    print(next(src))  # raises StopIteration

loop = asyncio.get_event_loop()
coro = fn(iter([100]))
loop.run_until_complete(coro)
```

```
RuntimeError: coroutine raised StopIteration
```

But this code prints an exception and hangs forever (here, we execute synchronous `next` in a thread pool aka asyncio "executor"):

```
import asyncio

async def fn(src):
    print(await loop.run_in_executor(None, next, src))
    print(await loop.run_in_executor(None, next, src))  # raises StopIteration

loop = asyncio.get_event_loop()
coro = fn(iter([100]))
loop.run_until_complete(coro)
```

```
TypeError: StopIteration interacts badly with generators and cannot be raised into a Future
```

After which it hangs forever. Therefore, using this `next`-in-executor technique is not safe and should be avoided.

This PR replaces the `StopIteration` with custom `StopStreaming`, and handles it accordingly.