### PR TITLE
Tests for object hierarchies

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -38,6 +38,8 @@ from kopf.reactor.queueing import (
 from kopf.structs.hierarchies import (
     adopt,
     label,
+    harmonize_naming,
+    adjust_namespace,
     build_object_reference,
     build_owner_reference,
     append_owner_reference,

--- a/tests/hierarchies/conftest.py
+++ b/tests/hierarchies/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+class CustomIterable:
+    def __init__(self, objs):
+        self._objs = objs
+
+    def __iter__(self):
+        for obj in self._objs:
+            yield obj
+
+
+@pytest.fixture(params=[list, tuple, CustomIterable],
+                ids=['list', 'tuple', 'custom'])
+def multicls(request):
+    return request.param

--- a/tests/hierarchies/test_labelling.py
+++ b/tests/hierarchies/test_labelling.py
@@ -1,0 +1,56 @@
+import kopf
+
+
+def test_adding_to_dict():
+    obj = {}
+
+    kopf.label(obj, {'label-1': 'value-1', 'label-2': 'value-2'})
+
+    assert 'metadata' in obj
+    assert 'labels' in obj['metadata']
+    assert isinstance(obj['metadata']['labels'], dict)
+    assert len(obj['metadata']['labels']) == 2
+    assert 'label-1' in obj['metadata']['labels']
+    assert 'label-2' in obj['metadata']['labels']
+    assert obj['metadata']['labels']['label-1'] == 'value-1'
+    assert obj['metadata']['labels']['label-2'] == 'value-2'
+
+
+def test_adding_to_multiple_objects(multicls):
+    obj1 = {}
+    obj2 = {}
+    objs = multicls([obj1, obj2])
+
+    kopf.label(objs, {'label-1': 'value-1', 'label-2': 'value-2'})
+
+    assert isinstance(obj1['metadata']['labels'], dict)
+    assert len(obj1['metadata']['labels']) == 2
+    assert 'label-1' in obj1['metadata']['labels']
+    assert 'label-2' in obj1['metadata']['labels']
+    assert obj1['metadata']['labels']['label-1'] == 'value-1'
+    assert obj1['metadata']['labels']['label-2'] == 'value-2'
+
+    assert isinstance(obj2['metadata']['labels'], dict)
+    assert len(obj2['metadata']['labels']) == 2
+    assert 'label-1' in obj2['metadata']['labels']
+    assert 'label-2' in obj2['metadata']['labels']
+    assert obj2['metadata']['labels']['label-1'] == 'value-1'
+    assert obj2['metadata']['labels']['label-2'] == 'value-2'
+
+
+def test_forcing_true():
+    obj = {'metadata': {'labels': {'label': 'old-value'}}}
+    kopf.label(obj, {'label': 'new-value'}, force=True)
+    assert obj['metadata']['labels']['label'] == 'new-value'
+
+
+def test_forcing_false():
+    obj = {'metadata': {'labels': {'label': 'old-value'}}}
+    kopf.label(obj, {'label': 'new-value'}, force=False)
+    assert obj['metadata']['labels']['label'] == 'old-value'
+
+
+def test_forcing_default():
+    obj = {'metadata': {'labels': {'label': 'old-value'}}}
+    kopf.label(obj, {'label': 'new-value'})
+    assert obj['metadata']['labels']['label'] == 'old-value'

--- a/tests/hierarchies/test_name_harmonizing.py
+++ b/tests/hierarchies/test_name_harmonizing.py
@@ -1,0 +1,114 @@
+import pytest
+
+import kopf
+
+
+@pytest.fixture(params=[
+    dict(strict=True),
+    dict(strict=False),
+    dict(),
+], ids=['strict', 'relaxed', 'default'])
+def all_modes_kwargs(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    dict(strict=True),
+], ids=['strict'])
+def strict_kwargs(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    dict(strict=False),
+    dict(),  # no kwargs, the function defaults are used.
+], ids=['relaxed', 'default'])
+def relaxed_kwargs(request):
+    return request.param
+
+#
+# No matter what `strict` mode is, the pre-existing names are preserved.
+#
+
+def test_preserved_name_of_dict(all_modes_kwargs):
+    obj = {'metadata': {'name': 'preexisting-name'}}
+
+    kopf.harmonize_naming(obj, name='provided-name', **all_modes_kwargs)
+
+    assert 'name' in obj['metadata']
+    assert 'generateName' not in obj['metadata']
+    assert obj['metadata']['name'] == 'preexisting-name'
+
+
+def test_preserved_names_of_multiple_objects(all_modes_kwargs, multicls):
+    obj1 = {'metadata': {'name': 'preexisting-name-1'}}
+    obj2 = {'metadata': {'name': 'preexisting-name-2'}}
+    objs = multicls([obj1, obj2])
+
+    kopf.harmonize_naming(objs, name='provided-name', **all_modes_kwargs)
+
+    assert 'name' in obj1['metadata']
+    assert 'generateName' not in obj1['metadata']
+    assert obj1['metadata']['name'] == 'preexisting-name-1'
+
+    assert 'name' in obj2['metadata']
+    assert 'generateName' not in obj2['metadata']
+    assert obj2['metadata']['name'] == 'preexisting-name-2'
+
+#
+# In strict mode and with the absent names, the provided name is used.
+#
+
+def test_assigned_name_of_dict(strict_kwargs):
+    obj = {}
+
+    kopf.harmonize_naming(obj, name='provided-name', **strict_kwargs)
+
+    assert 'name' in obj['metadata']
+    assert 'generateName' not in obj['metadata']
+    assert obj['metadata']['name'] == 'provided-name'
+
+
+def test_assigned_names_of_multiple_objects(strict_kwargs, multicls):
+    obj1 = {'metadata': {'name': 'preexisting-name-1'}}
+    obj2 = {'metadata': {'name': 'preexisting-name-2'}}
+    objs = multicls([obj1, obj2])
+
+    kopf.harmonize_naming(objs, name='provided-name', **strict_kwargs)
+
+    assert 'name' in obj1['metadata']
+    assert 'generateName' not in obj1['metadata']
+    assert obj1['metadata']['name'] == 'preexisting-name-1'
+
+    assert 'name' in obj2['metadata']
+    assert 'generateName' not in obj2['metadata']
+    assert obj2['metadata']['name'] == 'preexisting-name-2'
+
+#
+# In relaxed mode, if the names are absent, they are auto-generated.
+#
+
+def test_prefixed_name_of_dict(relaxed_kwargs):
+    obj = {}
+
+    kopf.harmonize_naming(obj, name='provided-name', **relaxed_kwargs)
+
+    assert 'name' not in obj['metadata']
+    assert 'generateName' in obj['metadata']
+    assert obj['metadata']['generateName'] == 'provided-name-'
+
+
+def test_prefixed_names_of_multiple_objects(relaxed_kwargs, multicls):
+    obj1 = {}
+    obj2 = {}
+    objs = multicls([obj1, obj2])
+
+    kopf.harmonize_naming(objs, name='provided-name', **relaxed_kwargs)
+
+    assert 'name' not in obj1['metadata']
+    assert 'generateName' in obj1['metadata']
+    assert obj1['metadata']['generateName'] == 'provided-name-'
+
+    assert 'name' not in obj2['metadata']
+    assert 'generateName' in obj2['metadata']
+    assert obj2['metadata']['generateName'] == 'provided-name-'

--- a/tests/hierarchies/test_namespace_adjusting.py
+++ b/tests/hierarchies/test_namespace_adjusting.py
@@ -1,0 +1,54 @@
+import kopf
+
+
+#
+# If namespace is set, it should be preserved, unmodified.
+#
+
+def test_preserved_namespace_of_dict():
+    obj = {'metadata': {'namespace': 'preexisting-namespace'}}
+
+    kopf.adjust_namespace(obj, namespace='provided-namespace')
+
+    assert 'namespace' in obj['metadata']
+    assert obj['metadata']['namespace'] == 'preexisting-namespace'
+
+
+def test_preserved_namespace_of_multiple_objects(multicls):
+    obj1 = {'metadata': {'namespace': 'preexisting-namespace-1'}}
+    obj2 = {'metadata': {'namespace': 'preexisting-namespace-2'}}
+    objs = multicls([obj1, obj2])
+
+    kopf.adjust_namespace(objs, namespace='provided-namespace')
+
+    assert 'namespace' in obj1['metadata']
+    assert obj1['metadata']['namespace'] == 'preexisting-namespace-1'
+
+    assert 'namespace' in obj2['metadata']
+    assert obj2['metadata']['namespace'] == 'preexisting-namespace-2'
+
+#
+# If the namespace is absent, it should be assigned as provided.
+#
+
+def test_assigned_namespace_of_dict():
+    obj = {}
+
+    kopf.adjust_namespace(obj, namespace='provided-namespace')
+
+    assert 'namespace' in obj['metadata']
+    assert obj['metadata']['namespace'] == 'provided-namespace'
+
+
+def test_assigned_namespace_of_multiple_objects(multicls):
+    obj1 = {}
+    obj2 = {}
+    objs = multicls([obj1, obj2])
+
+    kopf.adjust_namespace(objs, namespace='provided-namespace')
+
+    assert 'namespace' in obj1['metadata']
+    assert obj1['metadata']['namespace'] == 'provided-namespace'
+
+    assert 'namespace' in obj2['metadata']
+    assert obj2['metadata']['namespace'] == 'provided-namespace'

--- a/tests/hierarchies/test_owner_referencing.py
+++ b/tests/hierarchies/test_owner_referencing.py
@@ -1,0 +1,206 @@
+import copy
+
+from unittest.mock import call, Mock
+
+import kopf
+
+OWNER_API_VERSION = 'owner-api-version'
+OWNER_NAMESPACE = 'owner-namespace'
+OWNER_KIND = 'OwnerKind'
+OWNER_NAME = 'owner-name'
+OWNER_UID = 'owner-uid'
+OWNER_LABELS = {'label-1': 'value-1', 'label-2': 'value-2'}
+OWNER = {
+    'apiVersion': OWNER_API_VERSION,
+    'kind': OWNER_KIND,
+    'metadata': {
+        'namespace': OWNER_NAMESPACE,
+        'name': OWNER_NAME,
+        'uid': OWNER_UID,
+        'labels': OWNER_LABELS,
+    },
+}
+
+
+def test_appending_to_dict():
+    obj = {}
+
+    kopf.append_owner_reference(obj, owner=OWNER)
+
+    assert 'metadata' in obj
+    assert 'ownerReferences' in obj['metadata']
+    assert isinstance(obj['metadata']['ownerReferences'], list)
+    assert len(obj['metadata']['ownerReferences']) == 1
+    assert isinstance(obj['metadata']['ownerReferences'][0], dict)
+    assert obj['metadata']['ownerReferences'][0]['apiVersion'] == OWNER_API_VERSION
+    assert obj['metadata']['ownerReferences'][0]['kind'] == OWNER_KIND
+    assert obj['metadata']['ownerReferences'][0]['name'] == OWNER_NAME
+    assert obj['metadata']['ownerReferences'][0]['uid'] == OWNER_UID
+
+
+def test_appending_to_multiple_objects(multicls):
+    obj1 = {}
+    obj2 = {}
+    objs = multicls([obj1, obj2])
+
+    kopf.append_owner_reference(objs, owner=OWNER)
+
+    assert isinstance(obj1['metadata']['ownerReferences'], list)
+    assert len(obj1['metadata']['ownerReferences']) == 1
+    assert obj1['metadata']['ownerReferences'][0]['apiVersion'] == OWNER_API_VERSION
+    assert obj1['metadata']['ownerReferences'][0]['kind'] == OWNER_KIND
+    assert obj1['metadata']['ownerReferences'][0]['name'] == OWNER_NAME
+    assert obj1['metadata']['ownerReferences'][0]['uid'] == OWNER_UID
+
+    assert isinstance(obj2['metadata']['ownerReferences'], list)
+    assert len(obj2['metadata']['ownerReferences']) == 1
+    assert obj2['metadata']['ownerReferences'][0]['apiVersion'] == OWNER_API_VERSION
+    assert obj2['metadata']['ownerReferences'][0]['kind'] == OWNER_KIND
+    assert obj2['metadata']['ownerReferences'][0]['name'] == OWNER_NAME
+    assert obj2['metadata']['ownerReferences'][0]['uid'] == OWNER_UID
+
+
+def test_appending_deduplicates_by_uid():
+    """
+    The uid is the only necessary criterion to identify same objects.
+    No matter how we change the irrelevant non-id fields, they must be ignored.
+    """
+    owner1 = copy.deepcopy(OWNER)
+    owner2 = copy.deepcopy(OWNER)
+    owner3 = copy.deepcopy(OWNER)
+    owner1['kind'] = 'KindA'
+    owner2['kind'] = 'KindA'
+    owner3['kind'] = 'KindB'
+    owner1['metadata']['name'] = 'name-a'
+    owner2['metadata']['name'] = 'name-b'
+    owner3['metadata']['name'] = 'name-b'
+    owner1['metadata']['uid'] = 'uid-0'
+    owner2['metadata']['uid'] = 'uid-0'
+    owner3['metadata']['uid'] = 'uid-0'
+    obj = {}
+
+    kopf.append_owner_reference(obj, owner=owner1)
+    kopf.append_owner_reference(obj, owner=owner2)
+    kopf.append_owner_reference(obj, owner=owner3)
+
+    assert len(obj['metadata']['ownerReferences']) == 1
+    assert obj['metadata']['ownerReferences'][0]['uid'] == 'uid-0'
+
+
+def test_appending_distinguishes_by_uid():
+    """
+    Changing only the uid should be sufficient to consider a new owner.
+    Here, all other non-id fields are the same, and must be ignored.
+    """
+    owner1 = copy.deepcopy(OWNER)
+    owner2 = copy.deepcopy(OWNER)
+    owner1['metadata']['uid'] = 'uid-a'
+    owner2['metadata']['uid'] = 'uid-b'
+    obj = {}
+
+    kopf.append_owner_reference(obj, owner=owner1)
+    kopf.append_owner_reference(obj, owner=owner2)
+
+    uids = {ref['uid'] for ref in obj['metadata']['ownerReferences']}
+    assert uids == {'uid-a', 'uid-b'}
+
+
+def test_removal_from_dict():
+    obj = {}
+
+    kopf.append_owner_reference(obj, owner=OWNER)  # assumed to work, tested above
+    kopf.remove_owner_reference(obj, owner=OWNER)  # this one is being tested here
+
+    assert 'metadata' in obj
+    assert 'ownerReferences' in obj['metadata']
+    assert isinstance(obj['metadata']['ownerReferences'], list)
+    assert len(obj['metadata']['ownerReferences']) == 0
+
+
+def test_removal_from_multiple_objects(multicls):
+    obj1 = {}
+    obj2 = {}
+    objs = multicls([obj1, obj2])
+
+    kopf.append_owner_reference(objs, owner=OWNER)  # assumed to work, tested above
+    kopf.remove_owner_reference(objs, owner=OWNER)  # this one is being tested here
+
+    assert 'metadata' in obj1
+    assert 'ownerReferences' in obj1['metadata']
+    assert isinstance(obj1['metadata']['ownerReferences'], list)
+    assert len(obj1['metadata']['ownerReferences']) == 0
+
+    assert 'metadata' in obj2
+    assert 'ownerReferences' in obj2['metadata']
+    assert isinstance(obj2['metadata']['ownerReferences'], list)
+    assert len(obj2['metadata']['ownerReferences']) == 0
+
+
+def test_removal_identifies_by_uid():
+    owner1 = copy.deepcopy(OWNER)
+    owner2 = copy.deepcopy(OWNER)
+    owner3 = copy.deepcopy(OWNER)
+    owner1['kind'] = 'KindA'
+    owner2['kind'] = 'KindA'
+    owner3['kind'] = 'KindB'
+    owner1['metadata']['name'] = 'name-a'
+    owner2['metadata']['name'] = 'name-b'
+    owner3['metadata']['name'] = 'name-b'
+    owner1['metadata']['uid'] = 'uid-0'
+    owner2['metadata']['uid'] = 'uid-0'
+    owner3['metadata']['uid'] = 'uid-0'
+    obj = {}
+
+    # Three different owners added, but all have the same uid.
+    # One is removed and only once, all must be gone (due to same uids).
+    kopf.append_owner_reference(obj, owner=owner1)  # assumed to work, tested above
+    kopf.append_owner_reference(obj, owner=owner2)  # assumed to work, tested above
+    kopf.append_owner_reference(obj, owner=owner3)  # assumed to work, tested above
+    kopf.remove_owner_reference(obj, owner=owner1)  # this one is being tested here
+
+    assert len(obj['metadata']['ownerReferences']) == 0
+
+
+def test_removal_distinguishes_by_uid():
+    owner1 = copy.deepcopy(OWNER)
+    owner2 = copy.deepcopy(OWNER)
+    owner3 = copy.deepcopy(OWNER)
+    owner1['metadata']['uid'] = 'uid-a'
+    owner2['metadata']['uid'] = 'uid-b'
+    owner3['metadata']['uid'] = 'uid-c'
+    obj = {}
+
+    # Three very similar owners added, different only by uid.
+    # One is removed, others must stay (even if kinds/names are the same).
+    kopf.append_owner_reference(obj, owner=owner1)  # assumed to work, tested above
+    kopf.append_owner_reference(obj, owner=owner2)  # assumed to work, tested above
+    kopf.append_owner_reference(obj, owner=owner3)  # assumed to work, tested above
+    kopf.remove_owner_reference(obj, owner=owner1)  # this one is being tested here
+
+    uids = {ref['uid'] for ref in obj['metadata']['ownerReferences']}
+    assert uids == {'uid-b', 'uid-c'}
+
+#
+# Not related to owner references only, but uses the OWNER constants.
+#
+
+def test_adopting(mocker):
+    # These methods are tested in their own tests.
+    # We just check that they are called at all.
+    append_owner_ref = mocker.patch('kopf.structs.hierarchies.append_owner_reference')
+    harmonize_naming = mocker.patch('kopf.structs.hierarchies.harmonize_naming')
+    adjust_namespace = mocker.patch('kopf.structs.hierarchies.adjust_namespace')
+    label = mocker.patch('kopf.structs.hierarchies.label')
+
+    obj = Mock()
+    kopf.adopt(obj, owner=OWNER)
+
+    assert append_owner_ref.called
+    assert harmonize_naming.called
+    assert adjust_namespace.called
+    assert label.called
+
+    assert append_owner_ref.call_args_list == [call(obj, owner=OWNER)]
+    assert harmonize_naming.call_args_list == [call(obj, name=OWNER_NAME)]
+    assert adjust_namespace.call_args_list == [call(obj, namespace=OWNER_NAMESPACE)]
+    assert label.call_args_list == [call(obj, labels=OWNER_LABELS)]


### PR DESCRIPTION
These tests "freeze" the public interface of the library regarding the hierarchy management — to prevent accidental regressions.

> Issue : #13 

Few fixes are added just to pass the tests. They slightly extend the behavior: instead of purely `list` & `tuple` classes, any iterables are accepted.

Mostly for the purpose of testing, but also as a possibility, the public interface was also extended by the namespace adjustments (move objects to the requested namespace if it is not yet set) and name harmonizing (setting either the names or the name prefixes for the objects if they are not yet set).

These two additions are directly used in the object "adoption" (i.e. assignment as a children of another parent object, and aligning all of its properties: labels, names, namespaces, etc).