### PR TITLE
Test registry and matching of handlers by causes

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -35,6 +35,13 @@ from kopf.reactor.queueing import (
     run,
     create_tasks,
 )
+from kopf.reactor.registry import (
+    BaseRegistry,
+    SimpleRegistry,
+    GlobalRegistry,
+    get_default_registry,
+    set_default_registry,
+)
 from kopf.structs.hierarchies import (
     adopt,
     label,
@@ -56,4 +63,9 @@ __all__ = [
     'HandlerRetryError',
     'HandlerFatalError',
     'HandlerTimeoutError',
+    'BaseRegistry',
+    'SimpleRegistry',
+    'GlobalRegistry',
+    'get_default_registry',
+    'set_default_registry',
 ]

--- a/kopf/reactor/registry.py
+++ b/kopf/reactor/registry.py
@@ -116,7 +116,7 @@ class GlobalRegistry(BaseRegistry):
         super().__init__()
         self._handlers = {}  # {Resource: SimpleRegistry[Handler, ...]}
 
-    def register(self, group, version, plural, event, fn, id=None, field=None, timeout=None):
+    def register(self, group, version, plural, fn, id=None, event=None, field=None, timeout=None):
         """
         Register an additional handler function for the specific resource and specific event.
         """

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -1,0 +1,60 @@
+import pytest
+
+from kopf.reactor.handling import Cause
+
+
+def test_no_args():
+    with pytest.raises(TypeError):
+        Cause()
+
+
+def test_all_args(mocker):
+    logger = mocker.Mock()
+    resource = mocker.Mock()
+    event = mocker.Mock()
+    body = mocker.Mock()
+    patch = mocker.Mock()
+    diff = mocker.Mock()
+    old = mocker.Mock()
+    new = mocker.Mock()
+    cause = Cause(
+        resource=resource,
+        logger=logger,
+        event=event,
+        body=body,
+        patch=patch,
+        diff=diff,
+        old=old,
+        new=new,
+    )
+    assert cause.resource is resource
+    assert cause.logger is logger
+    assert cause.event is event
+    assert cause.body is body
+    assert cause.patch is patch
+    assert cause.diff is diff
+    assert cause.old is old
+    assert cause.new is new
+
+
+def test_required_args(mocker):
+    logger = mocker.Mock()
+    resource = mocker.Mock()
+    event = mocker.Mock()
+    body = mocker.Mock()
+    patch = mocker.Mock()
+    cause = Cause(
+        resource=resource,
+        logger=logger,
+        event=event,
+        body=body,
+        patch=patch,
+    )
+    assert cause.resource is resource
+    assert cause.logger is logger
+    assert cause.event is event
+    assert cause.body is body
+    assert cause.patch is patch
+    assert cause.diff is None
+    assert cause.old is None
+    assert cause.new is None

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -1,0 +1,28 @@
+import pytest
+
+from kopf.reactor.registry import Handler
+
+
+def test_no_args():
+    with pytest.raises(TypeError):
+        Handler()
+
+
+def test_all_args(mocker):
+    fn = mocker.Mock()
+    id = mocker.Mock()
+    event = mocker.Mock()
+    field = mocker.Mock()
+    timeout  = mocker.Mock()
+    handler = Handler(
+        fn=fn,
+        id=id,
+        event=event,
+        field=field,
+        timeout=timeout,
+    )
+    assert handler.fn is fn
+    assert handler.id is id
+    assert handler.event is event
+    assert handler.field is field
+    assert handler.timeout is timeout

--- a/tests/basic-structs/test_resource.py
+++ b/tests/basic-structs/test_resource.py
@@ -1,0 +1,22 @@
+import pytest
+
+from kopf.reactor.registry import Resource
+
+
+def test_no_args():
+    with pytest.raises(TypeError):
+        Resource()
+
+
+def test_all_args(mocker):
+    group = mocker.Mock()
+    version = mocker.Mock()
+    plural = mocker.Mock()
+    resource = Resource(
+        group=group,
+        version=version,
+        plural=plural,
+    )
+    assert resource.group is group
+    assert resource.version is version
+    assert resource.plural is plural

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import asynctest
 import pytest
 import pytest_mock
 
+from kopf.reactor.registry import Resource
+
 
 # Make all tests in this directory and below asyncio-compatible by default.
 def pytest_collection_modifyitems(items):
@@ -17,6 +19,12 @@ def pytest_collection_modifyitems(items):
 @pytest.fixture(scope='session', autouse=True)
 def enforce_asyncio_mocker():
     pytest_mock._get_mock_module = lambda config: asynctest
+
+
+@pytest.fixture()
+def resource():
+    """ The resource used in the tests. Usually mocked, so it does not matter. """
+    return Resource('zalando.org', 'v1', 'kopfexamples')
 
 
 @pytest.fixture()

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+import kopf
+
+
+@pytest.fixture(autouse=True)
+def clear_default_registry():
+    registry = kopf.get_default_registry()
+    kopf.set_default_registry(kopf.GlobalRegistry())
+    try:
+        yield
+    finally:
+        kopf.set_default_registry(registry)
+

--- a/tests/registries/test_creation.py
+++ b/tests/registries/test_creation.py
@@ -1,0 +1,24 @@
+from kopf import BaseRegistry, SimpleRegistry, GlobalRegistry
+
+
+def test_creation_of_simple_no_prefix():
+    registry = SimpleRegistry()
+    assert isinstance(registry, BaseRegistry)
+    assert isinstance(registry, SimpleRegistry)
+    assert registry.prefix is None
+
+
+def test_creation_of_simple_with_prefix_argument():
+    registry = SimpleRegistry('hello')
+    assert registry.prefix == 'hello'
+
+
+def test_creation_of_simple_with_prefix_keyword():
+    registry = SimpleRegistry(prefix='hello')
+    assert registry.prefix == 'hello'
+
+
+def test_creation_of_global():
+    registry = GlobalRegistry()
+    assert isinstance(registry, BaseRegistry)
+    assert isinstance(registry, GlobalRegistry)

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -1,0 +1,189 @@
+import pytest
+
+import kopf
+from kopf.reactor.handling import subregistry_var
+from kopf.reactor.registry import CREATE, UPDATE, DELETE, FIELD
+from kopf.reactor.registry import Resource, SimpleRegistry, GlobalRegistry
+
+
+def test_on_create_minimal(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, event=CREATE)
+
+    @kopf.on.create('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].event == CREATE
+    assert handlers[0].field is None
+    assert handlers[0].timeout is None
+
+
+def test_on_update_minimal(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, event=UPDATE)
+
+    @kopf.on.update('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].event == UPDATE
+    assert handlers[0].field is None
+    assert handlers[0].timeout is None
+
+
+def test_on_delete_minimal(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, event=DELETE)
+
+    @kopf.on.delete('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].event == DELETE
+    assert handlers[0].field is None
+    assert handlers[0].timeout is None
+
+
+def test_on_field_minimal(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    diff = [('op', ('field', 'subfield'), 'old', 'new')]
+    cause = mocker.MagicMock(resource=resource, event=UPDATE, diff=diff)
+
+    @kopf.on.field('group', 'version', 'plural', 'field.subfield')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].event == FIELD
+    assert handlers[0].field == ('field', 'subfield')
+    assert handlers[0].timeout is None
+
+
+def test_on_field_fails_without_field():
+    with pytest.raises(TypeError):
+        @kopf.on.field('group', 'version', 'plural')
+        def fn(**_):
+            pass
+
+
+def test_on_create_with_all_kwargs(mocker):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, event=CREATE)
+
+    @kopf.on.create('group', 'version', 'plural',
+                    id='id', timeout=123, registry=registry)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].event == CREATE
+    assert handlers[0].field is None
+    assert handlers[0].id == 'id'
+    assert handlers[0].timeout == 123
+
+
+def test_on_update_with_all_kwargs(mocker):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, event=UPDATE)
+
+    @kopf.on.update('group', 'version', 'plural',
+                    id='id', timeout=123, registry=registry)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].event == UPDATE
+    assert handlers[0].field is None
+    assert handlers[0].id == 'id'
+    assert handlers[0].timeout == 123
+
+
+def test_on_delete_with_all_kwargs(mocker):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, event=DELETE)
+
+    @kopf.on.delete('group', 'version', 'plural',
+                    id='id', timeout=123, registry=registry)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].event == DELETE
+    assert handlers[0].field is None
+    assert handlers[0].id == 'id'
+    assert handlers[0].timeout == 123
+
+
+def test_on_field_with_all_kwargs(mocker):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+    diff = [('op', ('field', 'subfield'), 'old', 'new')]
+    cause = mocker.MagicMock(resource=resource, event=UPDATE, diff=diff)
+
+    @kopf.on.field('group', 'version', 'plural', 'field.subfield',
+                   id='id', timeout=123, registry=registry)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].event == FIELD
+    assert handlers[0].field ==('field', 'subfield')
+    assert handlers[0].id == 'id/field.subfield'
+    assert handlers[0].timeout == 123
+
+
+def test_subhandler_declaratively(mocker):
+    cause = mocker.MagicMock(event=UPDATE, diff=None)
+
+    registry = SimpleRegistry()
+    subregistry_var.set(registry)
+
+    @kopf.on.this()
+    def fn(**_):
+        pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+
+
+def test_subhandler_imperatively(mocker):
+    cause = mocker.MagicMock(event=UPDATE, diff=None)
+
+    registry = SimpleRegistry()
+    subregistry_var.set(registry)
+
+    def fn(**_):
+        pass
+    kopf.register(fn)
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn

--- a/tests/registries/test_default_registry.py
+++ b/tests/registries/test_default_registry.py
@@ -1,0 +1,13 @@
+import kopf
+
+
+def test_getting_default_registry():
+    registry = kopf.get_default_registry()
+    assert isinstance(registry, kopf.GlobalRegistry)
+
+
+def test_setting_default_registry():
+    registry_expected = kopf.GlobalRegistry()
+    kopf.set_default_registry(registry_expected)
+    registry_actual = kopf.get_default_registry()
+    assert registry_actual is registry_expected

--- a/tests/registries/test_global_registry.py
+++ b/tests/registries/test_global_registry.py
@@ -1,0 +1,25 @@
+import collections
+
+from kopf import GlobalRegistry
+from kopf.reactor.registry import Resource
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn():
+    pass
+
+
+def test_resources():
+    registry = GlobalRegistry()
+    registry.register('group1', 'version1', 'plural1', some_fn)
+    registry.register('group2', 'version2', 'plural2', some_fn)
+
+    resources = registry.resources
+
+    assert isinstance(resources, collections.abc.Collection)
+    assert len(resources) == 2
+
+    resource1 = Resource('group1', 'version1', 'plural1')
+    resource2 = Resource('group2', 'version2', 'plural2')
+    assert resource1 in resources
+    assert resource2 in resources

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -1,0 +1,101 @@
+import functools
+from unittest.mock import Mock
+
+import pytest
+
+from kopf import SimpleRegistry, GlobalRegistry
+from kopf.reactor.registry import FIELD
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn():
+    pass
+
+
+@pytest.fixture(params=['simple', 'global'])
+def registry(request):
+    if request.param == 'simple':
+        return SimpleRegistry()
+    if request.param == 'global':
+        return GlobalRegistry()
+    raise Exception(f"Unsupported registry type: {request.param}")
+
+
+@pytest.fixture()
+def register_fn(registry, resource):
+    if isinstance(registry, SimpleRegistry):
+        return registry.register
+    if isinstance(registry, GlobalRegistry):
+        return functools.partial(registry.register, resource.group, resource.version, resource.plural)
+    raise Exception(f"Unsupported registry type: {registry}")
+
+
+@pytest.fixture()
+def cause_no_diff(resource):
+    return Mock(resource=resource, event='some-event', diff=None)
+
+
+@pytest.fixture()
+def cause_with_diff(resource):
+    diff = [('op', ('some-field',), 'old', 'new')]
+    return Mock(resource=resource, event='some-event', diff=diff)
+
+
+def test_catch_all_handlers_found(registry, register_fn, cause_no_diff):
+    register_fn(some_fn, event=None)
+    handlers = registry.get_handlers(cause_no_diff)
+    assert handlers
+
+
+def test_relevant_event_handlers_found(registry, register_fn, cause_no_diff):
+    register_fn(some_fn, event='some-event')
+    handlers = registry.get_handlers(cause_no_diff)
+    assert handlers
+
+
+def test_relevant_field_handlers_found(registry, register_fn, cause_with_diff):
+    register_fn(some_fn, event=FIELD, field='some-field')
+    handlers = registry.get_handlers(cause_with_diff)
+    assert handlers
+
+
+def test_irrelevant_event_handlers_ignored(registry, register_fn, cause_no_diff):
+    register_fn(some_fn, event='another-event')
+    handlers = registry.get_handlers(cause_no_diff)
+    assert not handlers
+
+
+def test_irrelevant_field_handlers_ignored(registry, register_fn, cause_with_diff):
+    register_fn(some_fn, event=FIELD, field='another-field')
+    handlers = registry.get_handlers(cause_with_diff)
+    assert not handlers
+
+
+def test_order_persisted_a(registry, register_fn, cause_with_diff):
+    register_fn(some_fn, event=None)
+    register_fn(some_fn, event='some-event')
+    register_fn(some_fn, event=FIELD, field='another-field')
+    register_fn(some_fn, event=FIELD, field='some-field')
+
+    handlers = registry.get_handlers(cause_with_diff)
+
+    # Order must be preserved -- same as registered.
+    assert len(handlers) == 3
+    assert handlers[0].event is None
+    assert handlers[1].field is None
+    assert handlers[2].field == ('some-field',)
+
+
+def test_order_persisted_b(registry, register_fn, cause_with_diff):
+    register_fn(some_fn, event=FIELD, field='some-field')
+    register_fn(some_fn, event=FIELD, field='another-field')
+    register_fn(some_fn, event='some-event')
+    register_fn(some_fn, event=None)
+
+    handlers = registry.get_handlers(cause_with_diff)
+
+    # Order must be preserved -- same as registered.
+    assert len(handlers) == 3
+    assert handlers[0].field == ('some-field',)
+    assert handlers[1].field is None
+    assert handlers[2].event is None

--- a/tests/registries/test_id_detection.py
+++ b/tests/registries/test_id_detection.py
@@ -1,0 +1,141 @@
+import functools
+
+import pytest
+
+from kopf import SimpleRegistry
+from kopf.reactor.registry import get_callable_id
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn():
+    pass
+
+
+@pytest.fixture(params=[
+    'some-field.sub-field',
+    ['some-field', 'sub-field'],
+    ('some-field', 'sub-field'),
+], ids=['str', 'list', 'tuple'])
+def field(request):
+    return request.param
+
+
+def test_id_of_simple_function():
+    fn_id = get_callable_id(some_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_single_partial():
+    partial_fn = functools.partial(some_fn)
+
+    fn_id = get_callable_id(partial_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_double_partial():
+    partial1_fn = functools.partial(some_fn)
+    partial2_fn = functools.partial(partial1_fn)
+
+    fn_id = get_callable_id(partial2_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_single_wrapper():
+
+    @functools.wraps(some_fn)
+    def wrapped_fn():
+        pass
+
+    fn_id = get_callable_id(wrapped_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_double_wrapper():
+
+    @functools.wraps(some_fn)
+    def wrapped1_fn():
+        pass
+
+    @functools.wraps(wrapped1_fn)
+    def wrapped2_fn():
+        pass
+
+    fn_id = get_callable_id(wrapped2_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_lambda():
+    some_lambda = lambda: None
+
+    fn_id = get_callable_id(some_lambda)
+    assert fn_id.startswith(f'lambda:{__file__}:')
+
+
+def test_with_no_hints(mocker):
+    get_fn_id = mocker.patch('kopf.reactor.registry.get_callable_id', return_value='some-id')
+
+    registry = SimpleRegistry()
+    registry.register(some_fn)
+    handlers = registry.get_handlers(mocker.MagicMock())
+
+    assert get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-id'
+
+
+def test_with_prefix(mocker):
+    get_fn_id = mocker.patch('kopf.reactor.registry.get_callable_id', return_value='some-id')
+
+    registry = SimpleRegistry(prefix='some-prefix')
+    registry.register(some_fn)
+    handlers = registry.get_handlers(mocker.MagicMock())
+
+    assert get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-prefix/some-id'
+
+
+def test_with_suffix(mocker, field):
+    get_fn_id = mocker.patch('kopf.reactor.registry.get_callable_id', return_value='some-id')
+
+    registry = SimpleRegistry()
+    registry.register(some_fn, field=field)
+    handlers = registry.get_handlers(mocker.MagicMock())
+
+    assert get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-id/some-field.sub-field'
+
+
+def test_with_prefix_and_suffix(mocker, field):
+    get_fn_id = mocker.patch('kopf.reactor.registry.get_callable_id', return_value='some-id')
+
+    registry = SimpleRegistry(prefix='some-prefix')
+    registry.register(some_fn, field=field)
+    handlers = registry.get_handlers(mocker.MagicMock())
+
+    assert get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-prefix/some-id/some-field.sub-field'
+
+
+def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
+    get_fn_id = mocker.patch('kopf.reactor.registry.get_callable_id', return_value='some-id')
+
+    registry = SimpleRegistry(prefix='some-prefix')
+    registry.register(some_fn, id='explicit-id', field=field)
+    handlers = registry.get_handlers(mocker.MagicMock())
+
+    assert not get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-prefix/explicit-id/some-field.sub-field'

--- a/tests/registries/test_registering.py
+++ b/tests/registries/test_registering.py
@@ -1,0 +1,85 @@
+import collections.abc
+
+from kopf import SimpleRegistry, GlobalRegistry
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn():
+    pass
+
+
+def test_simple_registry_via_iter(mocker):
+    cause = mocker.Mock(event=None, diff=None)
+
+    registry = SimpleRegistry()
+    iterator = registry.iter_handlers(cause)
+
+    assert isinstance(iterator, collections.abc.Iterator)
+    assert not isinstance(iterator, collections.abc.Collection)
+    assert not isinstance(iterator, collections.abc.Container)
+    assert not isinstance(iterator, (list, tuple))
+
+    handlers = list(iterator)
+    assert not handlers
+
+
+def test_simple_registry_via_list(mocker):
+    cause = mocker.Mock(event=None, diff=None)
+
+    registry = SimpleRegistry()
+    handlers = registry.get_handlers(cause)
+
+    assert isinstance(handlers, collections.abc.Iterable)
+    assert isinstance(handlers, collections.abc.Container)
+    assert isinstance(handlers, collections.abc.Collection)
+    assert not handlers
+
+
+def test_simple_registry_with_minimal_signature(mocker):
+    cause = mocker.Mock(event=None, diff=None)
+
+    registry = SimpleRegistry()
+    registry.register(some_fn)
+    handlers = registry.get_handlers(cause)
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+
+
+def test_global_registry_via_iter(mocker, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = GlobalRegistry()
+    iterator = registry.iter_handlers(cause)
+
+    assert isinstance(iterator, collections.abc.Iterator)
+    assert not isinstance(iterator, collections.abc.Collection)
+    assert not isinstance(iterator, collections.abc.Container)
+    assert not isinstance(iterator, (list, tuple))
+
+    handlers = list(iterator)
+    assert not handlers
+
+
+def test_global_registry_via_list(mocker, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = GlobalRegistry()
+    handlers = registry.get_handlers(cause)
+
+    assert isinstance(handlers, collections.abc.Iterable)
+    assert isinstance(handlers, collections.abc.Container)
+    assert isinstance(handlers, collections.abc.Collection)
+    assert not handlers
+
+
+def test_global_registry_with_minimal_signature(mocker, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = GlobalRegistry()
+    registry.register(resource.group, resource.version, resource.plural, some_fn)
+    handlers = registry.get_handlers(cause)
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+


### PR DESCRIPTION
These tests "freeze" the public interface of the library regarding the registries and matching of handlers  by causes (i.e. resources-events-fields) — to prevent accidental regressions.

> Issue : #13 
