### PR TITLE
Test the callback invocation protocol

### DIFF
--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -1,0 +1,82 @@
+"""
+Invoking the callbacks, including the args/kwargs preparation.
+
+Both sync & async functions are supported, so as their partials.
+Also, decorated wrappers and lambdas are recognized.
+All of this goes via the same invocation logic and protocol.
+"""
+import asyncio
+import concurrent.futures
+import contextvars
+import functools
+from typing import Callable
+
+# The executor for the sync-handlers (i.e. regular functions).
+# TODO: make the limits if sync-handlers configurable?
+executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+# executor = concurrent.futures.ProcessPoolExecutor(max_workers=3)
+
+
+async def invoke(
+        fn: Callable,
+        *args,
+        cause,
+        **kwargs):
+    """
+    Invoke a single function, but safely for the main asyncio process.
+
+    Used both for the handler functions and for the lifecycle callbacks.
+
+    A full set of the arguments is provided, expanding the cause to some easily
+    usable aliases. The function is expected to accept ``**kwargs`` for the args
+    that it does not use -- for forward compatibility with the new features.
+
+    The synchronous methods are executed in the executor (threads or processes),
+    thus making it non-blocking for the main event loop of the operator.
+    See: https://pymotw.com/3/asyncio/executors.html
+    """
+
+    # Add aliases for the kwargs, directly linked to the body, or to the assumed defaults.
+    kwargs.update(
+        cause=cause,
+        event=cause.event,
+        body=cause.body,
+        diff=cause.diff,
+        old=cause.old,
+        new=cause.new,
+        patch=cause.patch,
+        logger=cause.logger,
+        spec=cause.body.setdefault('spec', {}),
+        meta=cause.body.setdefault('metadata', {}),
+        status=cause.body.setdefault('status', {}),
+    )
+
+    if is_async_fn(fn):
+        result = await fn(*args, **kwargs)
+    else:
+
+        # Not that we want to use functools, but for executors kwargs, it is officially recommended:
+        # https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor
+        real_fn = functools.partial(fn, *args, **kwargs)
+
+        # Copy the asyncio context from current thread to the handlr's thread.
+        # It can be copied 2+ times if there are sub-sub-handlers (rare case).
+        context = contextvars.copy_context()
+        real_fn = functools.partial(context.run, real_fn)
+
+        loop = asyncio.get_event_loop()
+        task = loop.run_in_executor(executor, real_fn)
+        await asyncio.wait([task])
+        result = task.result()  # re-raises
+    return result
+
+
+def is_async_fn(fn):
+    if fn is None:
+        return None
+    elif isinstance(fn, functools.partial):
+        return is_async_fn(fn.func)
+    elif hasattr(fn, '__wrapped__'):  # @functools.wraps()
+        return is_async_fn(fn.__wrapped__)
+    else:
+        return asyncio.iscoroutinefunction(fn)

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -1,0 +1,183 @@
+import functools
+import traceback
+
+import pytest
+from asynctest import Mock, MagicMock
+
+from kopf.reactor.invocation import invoke, is_async_fn
+
+STACK_TRACE_MARKER = object()
+
+
+def _find_marker():
+    marker_repr = repr(STACK_TRACE_MARKER)
+    stack = traceback.StackSummary.extract(traceback.walk_stack(None), capture_locals=True)
+    for frame in stack:
+        if 'stack_trace_marker' in frame.locals:
+            if frame.locals['stack_trace_marker'] == marker_repr:
+                return True
+    return False
+
+
+def sync_fn(*args, **kwargs):
+    return _find_marker()
+
+
+async def async_fn(*args, **kwargs):
+    return _find_marker()
+
+
+def partials(fn, n):
+    partial = fn
+    for _ in range(n):
+        partial = functools.partial(partial)
+    return partial
+
+
+def wrappers(fn, n):
+    wrapper = fn
+    for _ in range(n):
+        @functools.wraps(wrapper)
+        def wrapper(*args, wrapper=wrapper, **kwargs):
+            return wrapper(*args, **kwargs)
+    return wrapper
+
+
+def awaiters(fn, n):
+    wrapper = fn
+    for _ in range(n):
+        @functools.wraps(wrapper)
+        async def wrapper(*args, wrapper=wrapper, **kwargs):
+            return await wrapper(*args, **kwargs)
+    return wrapper
+
+
+def partials_wrappers(fn, n):
+    wrapper = fn
+    for _ in range(n):
+        wrapper = functools.partial(wrapper)
+        @functools.wraps(wrapper)
+        def wrapper(*args, wrapper=wrapper, **kwargs):
+            return wrapper(*args, **kwargs)
+    return wrapper
+
+
+def partials_awaiters(fn, n):
+    wrapper = fn
+    for _ in range(n):
+        wrapper = functools.partial(wrapper)
+        @functools.wraps(wrapper)
+        async def wrapper(*args, wrapper=wrapper, **kwargs):
+            return await wrapper(*args, **kwargs)
+    return wrapper
+
+
+fns = pytest.mark.parametrize(
+    'fn', [
+        (sync_fn),
+        (async_fn),
+    ])
+
+# Every combination of partials, sync & async wrappers possible.
+syncasyncparams = pytest.mark.parametrize(
+    'fn, expected', [
+        (sync_fn, False),
+        (async_fn, True),
+        (partials(sync_fn, 1), False),
+        (partials(async_fn, 1), True),
+        (partials(sync_fn, 9), False),
+        (partials(async_fn, 9), True),
+        (wrappers(sync_fn, 1), False),
+        (wrappers(async_fn, 1), True),
+        (wrappers(sync_fn, 9), False),
+        (wrappers(async_fn, 9), True),
+        (awaiters(async_fn, 1), True),
+        (awaiters(async_fn, 9), True),
+        (partials_wrappers(sync_fn, 9), False),
+        (partials_wrappers(async_fn, 9), True),
+        (partials_awaiters(async_fn, 9), True),
+    ], ids=[
+        'sync-direct',
+        'async-direct',
+        'sync-partial-once',
+        'async-partial-once',
+        'sync-partial-many',
+        'async-partial-many',
+        'sync-wrapper-once',
+        'async-wrapper-once',
+        'sync-wrapper-many',
+        'async-wrapper-many',
+        'async-awaiter-once',
+        'async-awaiter-many',
+        'sync-mixed-partials-wrappers',
+        'async-mixed-partials-wrappers',
+        'async-mixed-partials-awaiters',
+    ])
+
+
+async def test_detection_for_none():
+    is_async = is_async_fn(None)
+    assert is_async is None
+
+
+@syncasyncparams
+async def test_async_detection(fn, expected):
+    is_async = is_async_fn(fn)
+    assert is_async is expected
+
+
+@syncasyncparams
+async def test_stacktrace_visibility(fn, expected):
+    stack_trace_marker = STACK_TRACE_MARKER  # searched by fn
+    cause = Mock()
+    found = await invoke(fn, cause=cause)
+    assert found is expected
+
+
+@fns
+async def test_result_returned(fn):
+    fn = MagicMock(fn, return_value=999)
+    cause = Mock()
+    result = await invoke(fn, cause=cause)
+    assert result == 999
+
+
+@fns
+async def test_explicit_args_passed_properly(fn):
+    fn = MagicMock(fn)
+    cause = Mock()
+    await invoke(fn, 100, 200, cause=cause, kw1=300, kw2=400)
+
+    assert fn.called
+    assert fn.call_count == 1
+
+    assert len(fn.call_args[0]) == 2
+    assert fn.call_args[0][0] == 100
+    assert fn.call_args[0][1] == 200
+
+    assert len(fn.call_args[1]) >= 2  # also the magic kwargs
+    assert fn.call_args[1]['kw1'] == 300
+    assert fn.call_args[1]['kw2'] == 400
+
+
+@fns
+async def test_special_kwargs_added(fn):
+    fn = MagicMock(fn)
+    cause = MagicMock(body={})
+    await invoke(fn, cause=cause)
+
+    assert fn.called
+    assert fn.call_count == 1
+
+    assert len(fn.call_args[1]) >= 2
+    assert fn.call_args[1]['cause'] is cause
+    assert fn.call_args[1]['event'] is cause.event
+    assert fn.call_args[1]['body'] is cause.body
+    assert fn.call_args[1]['spec'] is cause.body['spec']
+    assert fn.call_args[1]['meta'] is cause.body['metadata']
+    assert fn.call_args[1]['status'] is cause.body['status']
+    assert fn.call_args[1]['diff'] is cause.diff
+    assert fn.call_args[1]['old'] is cause.old
+    assert fn.call_args[1]['new'] is cause.new
+    assert fn.call_args[1]['patch'] is cause.patch
+    assert fn.call_args[1]['logger'] is cause.logger


### PR DESCRIPTION
The handlers, both sync and async, so as the lifecycle callbacks are called via the same protocol. This PR extracts this callback invocation protocol into a separate module (to reduce the complexity of `kopf.reactor.handling`), and add some tests for the invocation protocol. 

> Issue : #13 

The "invocation protocol" means that all expected kwargs (a dozen of them) will be indeed passed to the handlers, and that none of them will ever be accidentally "lost", thus breaking the operators — the framework's public promise (https://kopf.readthedocs.io/en/latest/handlers/#arguments).

In addition, sync & async callbacks are tested to behave as promised in the documentation (https://kopf.readthedocs.io/en/latest/async/): 

* The async callbacks are expected to be called in the same asyncio loop, which means in the same thread and the full stack is available to the debuggers and exceptions.
* The sync callbacks are called from the default executor (usually a thread pool) to prevent blocking of the asyncio loop, so they do not see the stack.

The partials and wrappers are unfolded to their real functions if possible.  These ones are actually used and are really needed (especially the decorated wrappers).

The lambdas are also supported, but limited. The lambdas are not yet used in the operators or docs or examples, but it is better to not be surprised and not to fail when and if they are used (as they are, technically, also the _callables_).

The module extracted is performed "as is", no logic is changed.
