### PR TITLE
Test the lifecycles

### DIFF
--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -12,6 +12,8 @@ execute in the order they are registered, one by one.
 import logging
 import random
 
+from kopf.structs.progress import get_retry_count
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,8 +39,7 @@ def shuffled(handlers, **kwargs):
 
 def asap(handlers, *, body, **kwargs):
     """ Execute one handler at a time, skip on failure, try the next one, retry after the full cycle. """
-    retries = body.get('status', {}).get('kopf', {}).get('retries', {})
-    retryfn = lambda handler: retries.get(handler.id, 0)
+    retryfn = lambda handler: get_retry_count(body=body, handler=handler)
     return sorted(handlers, key=retryfn)[:1]
 
 

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -53,5 +53,5 @@ def get_default_lifecycle():
 def set_default_lifecycle(lifecycle):
     global _default_lifecycle
     if _default_lifecycle is not None:
-        logger.warn(f"The default lifecycle is already set to {_default_lifecycle}, overriding it to {lifecycle}.")
+        logger.warning(f"The default lifecycle is already set to {_default_lifecycle}, overriding it to {lifecycle}.")
     _default_lifecycle = lifecycle

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -27,12 +27,12 @@ def one_by_one(handlers, **kwargs):
 
 def randomized(handlers, **kwargs):
     """ Execute one handler at a time, in the random order. """
-    return random.choice(handlers)
+    return [random.choice(handlers)] if handlers else []
 
 
 def shuffled(handlers, **kwargs):
     """ Execute all handlers at once, but in the random order. """
-    return random.sample(handlers, k=len(handlers))
+    return random.sample(handlers, k=len(handlers)) if handlers else []
 
 
 def asap(handlers, *, body, **kwargs):

--- a/tests/lifecycles/conftest.py
+++ b/tests/lifecycles/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+import kopf
+
+
+@pytest.fixture(autouse=True)
+def clear_default_lifecycle():
+    try:
+        yield
+    finally:
+        kopf.set_default_lifecycle(None)

--- a/tests/lifecycles/test_global_defaults.py
+++ b/tests/lifecycles/test_global_defaults.py
@@ -1,0 +1,21 @@
+import kopf
+
+
+def test_getting_default_lifecycle():
+    lifecycle = kopf.get_default_lifecycle()
+    assert lifecycle is kopf.lifecycles.asap
+
+
+def test_setting_default_lifecycle():
+    lifecycle_expected = lambda *args, **kwargs: None
+    kopf.set_default_lifecycle(lifecycle_expected)
+    lifecycle_actual = kopf.get_default_lifecycle()
+    assert lifecycle_actual is lifecycle_expected
+
+
+def test_resetting_default_lifecycle():
+    lifecycle_distracting = lambda *args, **kwargs: None
+    kopf.set_default_lifecycle(lifecycle_distracting)
+    kopf.set_default_lifecycle(None)
+    lifecycle_actual = kopf.get_default_lifecycle()
+    assert lifecycle_actual is kopf.lifecycles.asap

--- a/tests/lifecycles/test_handler_selection.py
+++ b/tests/lifecycles/test_handler_selection.py
@@ -1,0 +1,111 @@
+import pytest
+
+import kopf
+from kopf.structs.progress import set_retry_time, get_retry_count
+
+
+@pytest.mark.parametrize('lifecycle', [
+    kopf.lifecycles.all_at_once,
+    kopf.lifecycles.one_by_one,
+    kopf.lifecycles.randomized,
+    kopf.lifecycles.shuffled,
+    kopf.lifecycles.asap,
+])
+def test_with_empty_input(lifecycle):
+    handlers = []
+    selected = lifecycle(handlers, body={})
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 0
+
+
+def test_all_at_once_respects_order():
+    handler1 = object()
+    handler2 = object()
+    handler3 = object()
+
+    handlers = [handler1, handler2, handler3]
+    selected = kopf.lifecycles.all_at_once(handlers)
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 3
+    assert list(selected) == handlers
+
+    handlers = [handler3, handler2, handler1]
+    selected = kopf.lifecycles.all_at_once(handlers)
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 3
+    assert list(selected) == handlers
+
+
+def test_one_by_one_respects_order():
+    handler1 = object()
+    handler2 = object()
+    handler3 = object()
+
+    handlers = [handler1, handler2, handler3]
+    selected = kopf.lifecycles.one_by_one(handlers)
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 1
+    assert selected[0] is handler1
+
+    handlers = [handler3, handler2, handler1]
+    selected = kopf.lifecycles.one_by_one(handlers)
+    assert len(selected) == 1
+    assert selected[0] is handler3
+
+
+def test_randomized_takes_only_one():
+    handler1 = object()
+    handler2 = object()
+    handler3 = object()
+
+    handlers = [handler1, handler2, handler3]
+    selected = kopf.lifecycles.randomized(handlers)
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 1
+    assert selected[0] in {handler1, handler2, handler3}
+
+
+def test_shuffled_takes_them_all():
+    handler1 = object()
+    handler2 = object()
+    handler3 = object()
+
+    handlers = [handler1, handler2, handler3]
+    selected = kopf.lifecycles.shuffled(handlers)
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 3
+    assert set(selected) == {handler1, handler2, handler3}
+
+
+def test_asap_takes_the_first_one_when_no_retries(mocker):
+    body = {}
+    handler1 = mocker.Mock(id='id1', spec_set=['id'])
+    handler2 = mocker.Mock(id='id2', spec_set=['id'])
+    handler3 = mocker.Mock(id='id3', spec_set=['id'])
+
+    handlers = [handler1, handler2, handler3]
+    selected = kopf.lifecycles.asap(handlers, body=body)
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 1
+    assert selected[0] is handler1
+
+
+def test_asap_takes_the_least_retried(mocker):
+    body = {}
+    handler1 = mocker.Mock(id='id1', spec_set=['id'])
+    handler2 = mocker.Mock(id='id2', spec_set=['id'])
+    handler3 = mocker.Mock(id='id3', spec_set=['id'])
+
+    # Set the pre-existing state, and verify that it was set properly.
+    set_retry_time(body=body, patch=body, handler=handler1)
+    set_retry_time(body=body, patch=body, handler=handler1)
+    set_retry_time(body=body, patch=body, handler=handler3)
+    assert get_retry_count(body=body, handler=handler1) == 2
+    assert get_retry_count(body=body, handler=handler2) == 0
+    assert get_retry_count(body=body, handler=handler3) == 1
+
+    handlers = [handler1, handler2, handler3]
+    selected = kopf.lifecycles.asap(handlers, body=body)
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 1
+    assert selected[0] is handler2

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -1,0 +1,24 @@
+import pytest
+
+import kopf
+from kopf.reactor.handling import Cause
+from kopf.reactor.invocation import invoke
+
+
+@pytest.mark.parametrize('lifecycle', [
+    kopf.lifecycles.all_at_once,
+    kopf.lifecycles.one_by_one,
+    kopf.lifecycles.randomized,
+    kopf.lifecycles.shuffled,
+    kopf.lifecycles.asap,
+])
+async def test_protocol_invocation(mocker, lifecycle):
+    """
+    To be sure that all kwargs are accepted properly.
+    Especially when the new kwargs are added or an invocation protocol changed.
+    """
+    cause = mocker.Mock(spec=Cause)
+    handlers = []
+    selected = await invoke(lifecycle, handlers, cause=cause)
+    assert isinstance(selected, (tuple, list))
+    assert len(selected) == 0


### PR DESCRIPTION
> Issue : #13 

Test and fix the lifecycle callbacks. They are used to select the handlers to be executed on each handling cycle.

By default, `asap` is used, and it was slightly broken due to hard-coded structure of the `status` field (the change was done before importing to GitHub, but not reflected in this line). Now, it uses the provided function to get the retry count — from the same module where this value is set/updated.

