### PR TITLE
Peering scopes

### DIFF
--- a/docs/deployment-rbac.yaml
+++ b/docs/deployment-rbac.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: "{{NAMESPACE}}"
   name: kopfexample-account
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -12,10 +13,10 @@ rules:
 
   # Framework: knowing which other operators are running (i.e. peering).
   - apiGroups: [zalando.org]
-    resources: [kopfpeerings]
+    resources: [clusterkopfpeerings]
     verbs: [list, watch, patch, get]
 
-  # Application: watching & handling for the custom resource we declare.
+  # Application: read-only access for watching cluster-wide.
   - apiGroups: [zalando.org]
     resources: [kopfexamples]
     verbs: [list, watch]
@@ -23,8 +24,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
+  namespace: "{{NAMESPACE}}"
   name: kopfexample-role-namespaced
 rules:
+
+  # Framework: knowing which other operators are running (i.e. peering).
+  - apiGroups: [zalando.org]
+    resources: [namespacedkopfpeerings]
+    verbs: [list, watch, patch, get]
 
   # Framework: posting the events about the handlers progress/errors.
   - apiGroups: [events.k8s.io]
@@ -61,6 +68,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
+  namespace: "{{NAMESPACE}}"
   name: kopfexample-rolebinding-namespaced
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/docs/deployment-rbac.yaml
+++ b/docs/deployment-rbac.yaml
@@ -30,7 +30,7 @@ rules:
 
   # Framework: knowing which other operators are running (i.e. peering).
   - apiGroups: [zalando.org]
-    resources: [namespacedkopfpeerings]
+    resources: [kopfpeerings]
     verbs: [list, watch, patch, get]
 
   # Framework: posting the events about the handlers progress/errors.

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -78,7 +78,7 @@ and to manipulate the objects, both domain-specific and the built-in ones.
 For the example operator, those are:
 
 * ``kind: ClusterKopfPeering`` for the cross-operator awareness (cluster-wide).
-* ``kind: NamespacedKopfPeering`` for the cross-operator awareness (namespace-wide).
+* ``kind: KopfPeering`` for the cross-operator awareness (namespace-wide).
 * ``kind: KopfExample`` for the example operator objects.
 * ``kind: Pod/CluJob/PersistentVolumeClaim`` as the children objects.
 * And others as needed.

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -77,9 +77,10 @@ The pod where the operator runs must have the permissions to access
 and to manipulate the objects, both domain-specific and the built-in ones.
 For the example operator, those are:
 
-* ``kind: KopfPeering`` for the cross-operator awareness.
+* ``kind: ClusterKopfPeering`` for the cross-operator awareness (cluster-wide).
+* ``kind: NamespacedKopfPeering`` for the cross-operator awareness (namespace-wide).
 * ``kind: KopfExample`` for the example operator objects.
-* ``kind: Pod/Job/PersistentVolumeClaim`` as the children objects.
+* ``kind: Pod/CluJob/PersistentVolumeClaim`` as the children objects.
 * And others as needed.
 
 For that, the RBAC_ (Role-Based Access Control) could be used
@@ -87,7 +88,9 @@ and attached to the operator's pod via a service account.
 
 .. _RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 
-Here is an example of what a RBAC config should look like:
+Here is an example of what a RBAC config should look like
+(remove the parts which are not needed: e.g. the cluster roles/bindings
+for the strictly namespace-bound operator):
 
 .. literalinclude:: deployment-rbac.yaml
     :caption: rbac.yaml
@@ -104,7 +107,7 @@ And the created service account is attached to the pods as follows:
     :name: deployment-service-account-yaml
 
 
-The service accounts are always namespace-scoped.
+Please note that the service accounts are always namespace-scoped.
 There are no cluster-wide service accounts.
 They must be created in the same namespace as the operator is going to run in
-(even if it is going to server the whole cluster).
+(even if it is going to serve the whole cluster).

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -80,7 +80,7 @@ For the example operator, those are:
 * ``kind: ClusterKopfPeering`` for the cross-operator awareness (cluster-wide).
 * ``kind: KopfPeering`` for the cross-operator awareness (namespace-wide).
 * ``kind: KopfExample`` for the example operator objects.
-* ``kind: Pod/CluJob/PersistentVolumeClaim`` as the children objects.
+* ``kind: Pod/Job/PersistentVolumeClaim`` as the children objects.
 * And others as needed.
 
 For that, the RBAC_ (Role-Based Access Control) could be used

--- a/docs/peering.rst
+++ b/docs/peering.rst
@@ -3,28 +3,132 @@ Peering
 =======
 
 All running operators communicate with each other via peering objects
-(also custom resources), so they know about each other.
+(additional kind of custom resources), so they know about each other.
+
+
+Priorities
+==========
+
+Each operator has a priority (the default is 0). Whenever the operator
+notices that other operators start with a higher priority, it freezes
+its operation until those operators stop working.
+
+This is done to prevent collisions of multiple operators handling
+the same objects.
+
+To set the operator's priority, use :option:`--priority`:
+
+.. code-block:: bash
+
+    kopf run --priority=100 ...
+
+As a shortcut, there is a :option:`--dev` option, which sets
+the priority to ``666``, and is intended for the development mode.
+
+
+Scopes
+======
+
+There are two types of custom resources used for peering:
+
+* ``ClusterKopfPeering`` for the cluster-scoped operators.
+* ``NamespacedKopfPeering`` for the namespace-scoped operators.
+
+Kopf automatically chooses which one to use, depending on whether
+the operator is restricted to a namespace with :option:`--namespace`,
+or it is running unrestricted and cluster-wide.
+
+Create the peering objects as needed with one of:
+
+.. code-block:: yaml
+
+    apiVersion: zalando.org/v1
+    kind: ClusterKopfPeering
+    metadata:
+      name: default
+
+.. code-block:: yaml
+
+    apiVersion: zalando.org/v1
+    kind: NamespacedKopfPeering
+    metadata:
+      namespace: default
+      name: default
+
+
+.. deprecated:: 0.11
+    Previously, ``KopfPeering`` was the only kind, and it was cluster-scoped.
+    It is now abandoned and not supported.
+
+
+Custom peering
+==============
 
 The operator can be instructed to use alternative peering objects::
 
     kopf run --peering=another ...
+    kopf run --peering=another --namespace=some-ns ...
+
+Depending on :option:`--namespace`, either ``ClusterKopfPeering``
+or ``NamespacedKopfPeering`` will be used (in the operator's namespace).
+
+If the peering object does not exist, the operator will fail to start.
+Using :option:`--peering` assumes that the peering is required.
 
 The operators from different peering objects do not see each other.
 
-Default behavior
-----------------
+This is especially useful for the cluster-scoped operators for different
+resource kinds, which should not worry about other operators for other kinds.
 
-If there is a peering object with name `default` then it's been used by default as the peering object. Otherwise kopf will run the operator in mode `Standalone`.
 
 Standalone mode
----------------
+===============
 
 To prevent an operator from peering and talking to other operators,
 the standalone mode can be enabled::
 
     kopf run --standalone ...
 
-In that case, the operator will not freeze of other operators with
+In that case, the operator will not freeze if other operators with
 the higher priority will start handling the objects, which may lead
 to the conflicting changes and reactions from multiple operators
 for the same events.
+
+
+Automatic peering
+=================
+
+If there is a peering object detected with name `default` (either
+cluster-scoped or namespace-scoped, depending on :option:`--namespace`),
+then it is used by default as the peering object.
+
+Otherwise, Kopf will issue a warning and will run the operator
+in the standalone mode.
+
+
+Multi-pod operators
+===================
+
+Usually, one and only one operator instance should be deployed for the resource.
+If that operator's pod dies, the handling of the resource of this type
+will stop until the operator's pod is restarted (and if restarted at all).
+
+To start multiple operator pods, they must be distinctly prioritised.
+In that case, only one operator will be active --- the one with the highest
+priority. All other operators will freeze and wait until this operator dies.
+Once it dies, the second highest priority operator will come into play.
+And so on.
+
+For this, assign a monotonically growing or random priority to each
+operator in the deployment or replicaset:
+
+.. code-block:: bash
+
+    kopf run --priority=$RANDOM ...
+
+``$RANDOM`` is a feature of bash (if you use another shell, find your own way).
+It returns a random integer in the range 0..32767.
+With high probability, 2-3 pods will get their unique priorities.
+
+You can also use the pod's IP address in its numeric form as the priority,
+or any other source of integers.

--- a/docs/peering.rst
+++ b/docs/peering.rst
@@ -144,7 +144,8 @@ operator in the deployment or replicaset:
 
     kopf run --priority=$RANDOM ...
 
-``$RANDOM`` is a feature of bash (if you use another shell, find your own way).
+``$RANDOM`` is a feature of bash
+(if you use another shell, see its man page for an equivalent).
 It returns a random integer in the range 0..32767.
 With high probability, 2-3 pods will get their unique priorities.
 

--- a/docs/peering.rst
+++ b/docs/peering.rst
@@ -32,7 +32,7 @@ Scopes
 There are two types of custom resources used for peering:
 
 * ``ClusterKopfPeering`` for the cluster-scoped operators.
-* ``NamespacedKopfPeering`` for the namespace-scoped operators.
+* ``KopfPeering`` for the namespace-scoped operators.
 
 Kopf automatically chooses which one to use, depending on whether
 the operator is restricted to a namespace with :option:`--namespace`,
@@ -45,20 +45,38 @@ Create the peering objects as needed with one of:
     apiVersion: zalando.org/v1
     kind: ClusterKopfPeering
     metadata:
-      name: default
+      name: example
 
 .. code-block:: yaml
 
     apiVersion: zalando.org/v1
-    kind: NamespacedKopfPeering
+    kind: KopfPeering
     metadata:
       namespace: default
-      name: default
+      name: example
 
 
-.. deprecated:: 0.11
-    Previously, ``KopfPeering`` was the only kind, and it was cluster-scoped.
-    It is now abandoned and not supported.
+.. note::
+
+    Previously, ``KopfPeering`` was the only CRD, and it was cluster-scoped.
+    Now, it is namespaced. For the new users, it all will be fine and working.
+
+    If the old ``KopfPeering`` CRD is already deployed to your cluster,
+    it will also continue to work as before without re-configuration:
+    though there will be no namespace isolation as documented here ---
+    it will be cluster peering regardless of :option:`--namespace`
+    (as it was before the changes).
+
+    When possible (but strictly after the Kopf's version upgrade),
+    please delete the old CRD, and re-create from scratch:
+
+    .. code-block:: bash
+
+        kubectl delete crd kopfpeerings.zalando.org
+        # give it 1-2 minutes to cleanup, or repeat until succeeded:
+        kubectl create -f peering.yaml
+
+    Then re-deploy your custom peering objects of your apps.
 
 
 Custom peering
@@ -66,11 +84,11 @@ Custom peering
 
 The operator can be instructed to use alternative peering objects::
 
-    kopf run --peering=another ...
-    kopf run --peering=another --namespace=some-ns ...
+    kopf run --peering=example ...
+    kopf run --peering=example --namespace=some-ns ...
 
 Depending on :option:`--namespace`, either ``ClusterKopfPeering``
-or ``NamespacedKopfPeering`` will be used (in the operator's namespace).
+or ``KopfPeering`` will be used (in the operator's namespace).
 
 If the peering object does not exist, the operator will fail to start.
 Using :option:`--peering` assumes that the peering is required.

--- a/kopf/reactor/peering.py
+++ b/kopf/reactor/peering.py
@@ -17,7 +17,7 @@ and detection of other operators hard termination (by timeout rather than by cle
 The peers monitoring covers both the in-cluster operators running,
 and the dev-mode operators running in the dev workstations.
 
-For this, special CRDs ``kind: ClusterKopfPeering`` & ``kind: NamespacedKopfPeering``
+For this, special CRDs ``kind: ClusterKopfPeering`` & ``kind: KopfPeering``
 should be registered in the cluster, and their ``status`` field is used
 by all the operators to sync their keep-alive info.
 
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 # The CRD info on the special sync-object.
 CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings')
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'namespacedkopfpeerings')
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings')
 PEERING_DEFAULT_NAME = 'default'
 
 

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -32,8 +32,8 @@ import aiojobs
 
 from kopf.reactor.handling import custom_object_handler
 from kopf.reactor.lifecycles import get_default_lifecycle
-from kopf.reactor.peering import PEERING_CRD_RESOURCE, PEERING_DEFAULT_NAME
 from kopf.reactor.peering import peers_keepalive, peers_handler, Peer, detect_own_id
+from kopf.reactor.peering import PEERING_DEFAULT_NAME
 from kopf.reactor.registry import get_default_registry, BaseRegistry, Resource
 from kopf.reactor.watching import infinite_watch
 
@@ -159,12 +159,15 @@ def create_tasks(
     tasks = []
 
     # Monitor the peers, unless explicitly disabled.
-    ourselves: Optional[Peer] = Peer.detect(standalone, peering, id=detect_own_id(), priority=priority, namespace=namespace)
+    ourselves: Optional[Peer] = Peer.detect(
+        id=detect_own_id(), priority=priority,
+        standalone=standalone, namespace=namespace, peering=peering,
+    )
     if ourselves:
         tasks.extend([
             asyncio.Task(peers_keepalive(ourselves=ourselves)),
-            asyncio.Task(watcher(namespace=None,  # peering is cluster-object
-                                 resource=PEERING_CRD_RESOURCE,
+            asyncio.Task(watcher(namespace=namespace,
+                                 resource=ourselves.resource,
                                  handler=functools.partial(peers_handler,
                                                            ourselves=ourselves,
                                                            freeze=freeze))),  # freeze is set/cleared

--- a/peering.yaml
+++ b/peering.yaml
@@ -2,21 +2,43 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kopfpeerings.zalando.org
+  name: clusterkopfpeerings.zalando.org
 spec:
+  scope: Cluster
   group: zalando.org
   versions:
     - name: v1
       served: true
       storage: true
   names:
-    kind: KopfPeering
-    plural: kopfpeerings
-    singular: kopfpeering
-  scope: Cluster
-
+    kind: ClusterKopfPeering
+    plural: clusterkopfpeerings
+    singular: clusterkopfpeering
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: namespacedkopfpeerings.zalando.org
+spec:
+  scope: Namespaced
+  group: zalando.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: NamespacedKopfPeering
+    plural: namespacedkopfpeerings
+    singular: namespacedkopfpeering
 ---
 apiVersion: zalando.org/v1
-kind: KopfPeering
+kind: ClusterKopfPeering
 metadata:
   name: default
+---
+apiVersion: zalando.org/v1
+kind: NamespacedKopfPeering
+metadata:
+  namespace: default
+  name: default
+---

--- a/peering.yaml
+++ b/peering.yaml
@@ -18,7 +18,7 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: namespacedkopfpeerings.zalando.org
+  name: kopfpeerings.zalando.org
 spec:
   scope: Namespaced
   group: zalando.org
@@ -27,9 +27,9 @@ spec:
       served: true
       storage: true
   names:
-    kind: NamespacedKopfPeering
-    plural: namespacedkopfpeerings
-    singular: namespacedkopfpeering
+    kind: KopfPeering
+    plural: kopfpeerings
+    singular: kopfpeering
 ---
 apiVersion: zalando.org/v1
 kind: ClusterKopfPeering
@@ -37,7 +37,7 @@ metadata:
   name: default
 ---
 apiVersion: zalando.org/v1
-kind: NamespacedKopfPeering
+kind: KopfPeering
 metadata:
   namespace: default
   name: default


### PR DESCRIPTION
> Issue : #32, related #31, #17

For the purpose of strict namespace isolation of the operators, the peering objects must be cluster- or namespace-scoped (previously: always cluster-scoped). 

For this, split the old cluster-wide `KopfPeering` resource into the new `ClusterKopfPeering` & namespaced `KopfPeering`, and use one of them depending on the `--namespace` option.

The testing of peering is performed manually — it works. More tests will be added when the whole peering subsystem will be covered with tests (as part of #13).

Docs preview:

* https://kopf.readthedocs.io/en/peering-scopes/peering/
* https://kopf.readthedocs.io/en/peering-scopes/deployment/#rbac

See also: #37 for the namespace isolation of the listing/watching API calls.

TODO:

* [x] Manually test how do the operators react to changes in the `kind: KopfPeering` when re-created from the cluster to the namespaced scope — in different running modes (with/without `--peering`, with/without `--namespace`). Ensure that the operators actually behave as before and as expected.
* [x] Fallback to the old CRD `KopfPeering` if that CRD is cluster-scoped (but not if namespaced).
* [x] Document the upgrade scenario to code first, CRDs second, never vice versa.
