### PR TITLE
Handle only the latest event with the most up to date state

### DIFF
--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -140,10 +140,17 @@ async def worker(
 
             # Try ASAP, but give it few seconds for the new events to arrive, maybe.
             # If the queue is empty for some time, then indeed finish the object's worker.
+            # If the queue is filled, use the latest event only (within the short timeframe).
             try:
                 event = await asyncio.wait_for(queue.get(), timeout=5.0)
             except asyncio.TimeoutError:
                 break
+            else:
+                try:
+                    while True:
+                        event = await asyncio.wait_for(queue.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    pass
 
             # Try the handler. In case of errors, show the error, but continue the queue processing.
             try:


### PR DESCRIPTION
> Issue : #42 

With this change, if the queue contains a batch of events, react only to the latest one — to follow the "eventual consistency" principle of Kubernetes.

The batch is time-framed to 0.1s, so that it is fast enough for all normal cases when only one event arrives, but slow enough for the initial object listing when multiple events arrive. 

Still, some minimal time-frame is needed, as the streaming and parsing of the events inside of the kubernetes library is not immediate.
