### PR TITLE
Provide the basic testing tools for the operator developers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Kopf: Kubernetes Operators Framework
    scopes
    errors
    events
+   testing
 
 .. toctree::
    :maxdepth: 2

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,42 @@
+================
+Operator testing
+================
+
+Kopf provides some tools to test the Kopf-based operators
+via `kopf.testing` module (requires explicit importing).
+
+
+Background runner
+=================
+
+`kopf.testing.KopfRunner` runs an arbitrary operator in the background,
+while the original testing thread does the object manipulation and assertions:
+
+When the ``with`` block exits, the operator stops, and its exceptions,
+exit code, and output are available to the test (for additional assertions).
+
+.. code-block:: python
+    :caption: test_example_operator.py
+
+    import shlex
+    import subprocess
+    from kopf.testing import KopfRunner
+
+    def test_operator():
+        with KopfRunner(['run', '--verbose', 'examples/01-minimal/example.py']) as runner:
+            # do something while the operator is running.
+
+            subprocess.run("kubectl apply -f examples/obj.yaml", shell=True, check=True)
+            time.sleep(1)  # give it some time to react and to sleep and to retry
+
+            subprocess.run("kubectl delete -f examples/obj.yaml", shell=True, check=True)
+            time.sleep(1)  # give it some time to react
+
+        assert runner.exit_code == 0
+        assert runner.exception is None
+        assert 'And here we are!' in runner.stdout
+        assert 'Deleted, really deleted' in runner.stdout
+
+.. note::
+    The operator runs against the cluster which is currently authenticated ---
+    same as if would be executed with `kopf run`.

--- a/kopf/testing/__init__.py
+++ b/kopf/testing/__init__.py
@@ -1,0 +1,8 @@
+"""
+Helper tools to test the Kopf-based operators.
+"""
+from kopf.testing.runner import KopfRunner
+
+__all__ = [
+    'KopfRunner',
+]

--- a/kopf/testing/runner.py
+++ b/kopf/testing/runner.py
@@ -8,7 +8,7 @@ from kopf.cli import main
 
 class KopfRunner:
     """
-    A context manager to run Kopf-based operator in parallel with the tests.
+    A context manager to run a Kopf-based operator in parallel with the tests.
 
     Usage::
 
@@ -22,19 +22,19 @@ class KopfRunner:
         assert runner.exception is None
         assert 'And here we are!' in runner.stdout
 
-    All the args & kwargs are passed directly to the Click's invocation method.
+    All the args & kwargs are passed directly to Click's invocation method.
     See: `click.testing.CliRunner`.
-    All properties proxy directly to the Click's `click.testing.Result` object
+    All properties proxy directly to Click's `click.testing.Result` object
     when it is available (i.e. after the context manager exits).
 
     CLI commands have to be invoked in parallel threads, never in processes:
 
     First, with multiprocessing, they are unable to pickle and pass
-    the exceptions (specifically, their traceback objects)
+    exceptions (specifically, their traceback objects)
     from a child thread (Kopf's CLI) to the parent thread (pytest).
 
     Second, mocking works within one process (all threads),
-    but not across the processes --- the mock's calls (counts, arrgs) are lost.
+    but not across processes --- the mock's calls (counts, arrgs) are lost.
     """
 
     def __init__(self, *args, reraise=True, **kwargs):

--- a/kopf/testing/runner.py
+++ b/kopf/testing/runner.py
@@ -1,0 +1,140 @@
+import asyncio
+import threading
+
+import click.testing
+
+from kopf.cli import main
+
+
+class KopfRunner:
+    """
+    A context manager to run Kopf-based operator in parallel with the tests.
+
+    Usage::
+
+        from kopf.testing import KopfRunner
+
+        with KopfRunner(['run', '--verbose', 'examples/01-minimal/example.py']) as runner:
+            # do something while the operator is running.
+            time.sleep(3)
+
+        assert runner.exit_code == 0
+        assert runner.exception is None
+        assert 'And here we are!' in runner.stdout
+
+    All the args & kwargs are passed directly to the Click's invocation method.
+    See: `click.testing.CliRunner`.
+    All properties proxy directly to the Click's `click.testing.Result` object
+    when it is available (i.e. after the context manager exits).
+
+    CLI commands have to be invoked in parallel threads, never in processes:
+
+    First, with multiprocessing, they are unable to pickle and pass
+    the exceptions (specifically, their traceback objects)
+    from a child thread (Kopf's CLI) to the parent thread (pytest).
+
+    Second, mocking works within one process (all threads),
+    but not across the processes --- the mock's calls (counts, arrgs) are lost.
+    """
+
+    def __init__(self, *args, reraise=True, **kwargs):
+        super().__init__()
+        self.args = args
+        self.kwargs = kwargs
+        self.reraise = reraise
+        self._loop = None
+        self._loop_set = None
+        self._thread = None
+        self._result = None
+        self._invoke_exception = None
+
+    def __enter__(self):
+        self._loop_set = threading.Event()  # NB: not asyncio.Event!
+        self._thread = threading.Thread(target=self._target)
+        self._thread.start()
+        self._loop_set.wait()  # should be nanosecond-fast
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+
+        # A coroutine that is injected into the loop to cancel everything in it.
+        # Cancellations are caught in `run`, so that it exits gracefully.
+        # TODO: also cancel/stop the streaming API calls in the thread executor.
+        async def shutdown():
+            current_task = asyncio.current_task()
+            tasks = [task for task in asyncio.all_tasks() if task is not current_task]
+            for task in tasks:
+                task.cancel()
+
+        # When the `with` block ends, shut down the parallel thread & loop
+        # by cancelling all the tasks. Do not wait for the tasks to finish,
+        # but instead wait for the thread+loop (CLI command) to finish.
+        if self._loop.is_running():
+            asyncio.run_coroutine_threadsafe(shutdown(), self._loop)
+        self._thread.join()
+        if self._thread.is_alive():
+            raise Exception("The operator didn't stop, still running.")
+
+        # Re-raise the exceptions of the threading & invocation logic.
+        if self._invoke_exception is not None:
+            if exc_val is None:
+                raise self._invoke_exception
+            else:
+                raise self._invoke_exception from exc_val
+        if self._result.exception is not None and self.reraise:
+            if exc_val is None:
+                raise self._result.exception
+            else:
+                raise self._result.exception from exc_val
+
+    def _target(self):
+
+        # Every thread must have its own loop. The parent thread (pytest)
+        # needs to know when the loop is set up, to be able to shut it down.
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._loop_set.set()
+
+        # Execute the requested CLI command in the thread & thread's loop.
+        # Remember the result & exception for re-raising in the parent thread.
+        try:
+            runner = click.testing.CliRunner()
+            result = runner.invoke(main, *self.args, **self.kwargs)
+        except BaseException as e:
+            self._result = None
+            self._invoke_exception = e
+        else:
+            self._result = result
+            self._invoke_exception = None
+
+    @property
+    def output(self):
+        return self._result.output
+
+    @property
+    def stdout(self):
+        return self._result.stdout
+
+    @property
+    def stdout_bytes(self):
+        return self._result.stdout_bytes
+
+    @property
+    def stderr(self):
+        return self._result.stderr
+
+    @property
+    def stderr_bytes(self):
+        return self._result.stderr_bytes
+
+    @property
+    def exit_code(self):
+        return self._result.exit_code
+
+    @property
+    def exception(self):
+        return self._result.exception
+
+    @property
+    def exc_info(self):
+        return self._result.exc_info

--- a/tests/testing/test_runner.py
+++ b/tests/testing/test_runner.py
@@ -1,0 +1,71 @@
+import pytest
+
+from kopf.testing import KopfRunner
+
+
+def test_command_invocation_works():
+    with KopfRunner(['--help']) as runner:
+        pass
+    assert runner.exc_info
+    assert runner.exc_info[0] is SystemExit
+    assert runner.exc_info[1].code == 0
+    assert runner.exit_code == 0
+    assert runner.exception is None
+    assert runner.output.startswith("Usage:")
+    assert runner.stdout.startswith("Usage:")
+    assert runner.stdout_bytes.startswith(b"Usage:")
+    # Note: stderr is not captured, it is mixed with stdout.
+
+
+def test_exception_from_runner_suppressed_with_no_reraise():
+    with KopfRunner(['run', 'non-existant.py', '--standalone'], reraise=False) as runner:
+        pass
+    assert runner.exception is not None
+    assert isinstance(runner.exception, FileNotFoundError)
+
+
+def test_exception_from_runner_escalates_with_reraise():
+    with pytest.raises(FileNotFoundError):
+        with KopfRunner(['run', 'non-existant.py', '--standalone'], reraise=True):
+            pass
+
+
+def test_exception_from_runner_escalates_by_default():
+    with pytest.raises(FileNotFoundError):
+        with KopfRunner(['run', 'non-existant.py', '--standalone']):
+            pass
+
+
+@pytest.mark.parametrize('kwargs',[
+    dict(reraise=False),
+    dict(reraise=True),
+    dict(),
+], ids=['reraise=False', 'reraise=True', 'no-reraise'])
+def test_exception_from_invoke_escalates(mocker, kwargs):
+    class SampleError(Exception): pass
+    mocker.patch('click.testing.CliRunner.invoke', side_effect=SampleError)
+
+    with pytest.raises(SampleError):
+        with KopfRunner(['run', 'non-existant.py', '--standalone'], **kwargs):
+            pass
+
+
+def test_wrong_command_fails():
+    with pytest.raises(SystemExit) as e:
+        with KopfRunner(['unexistent-command']):
+            pass
+    assert e.value.code == 2
+
+
+def test_absent_file_fails():
+    with pytest.raises(FileNotFoundError):
+        with KopfRunner(['run', 'non-existent.py', '--standalone']):
+            pass
+
+
+def test_bad_syntax_file_fails(tmpdir):
+    path = tmpdir.join('handlers.py')
+    path.write("""This is a Python syntax error!""")
+    with pytest.raises((IndentationError, SyntaxError)):
+        with KopfRunner(['run', str(path), '--standalone']):
+            pass

--- a/tests/testing/test_runner.py
+++ b/tests/testing/test_runner.py
@@ -3,6 +3,13 @@ import pytest
 from kopf.testing import KopfRunner
 
 
+@pytest.fixture(autouse=True)
+def no_config_needed(mocker):
+    mocker.patch('kubernetes.config.load_incluster_config')
+    mocker.patch('kubernetes.config.load_kube_config')
+    mocker.patch('kubernetes.client.CoreApi')  # for login self-check
+
+
 def test_command_invocation_works():
     with KopfRunner(['--help']) as runner:
         pass

--- a/tests/testing/test_runner.py
+++ b/tests/testing/test_runner.py
@@ -25,7 +25,7 @@ def test_command_invocation_works():
 
 
 def test_exception_from_runner_suppressed_with_no_reraise():
-    with KopfRunner(['run', 'non-existant.py', '--standalone'], reraise=False) as runner:
+    with KopfRunner(['run', 'non-existent.py', '--standalone'], reraise=False) as runner:
         pass
     assert runner.exception is not None
     assert isinstance(runner.exception, FileNotFoundError)
@@ -33,13 +33,13 @@ def test_exception_from_runner_suppressed_with_no_reraise():
 
 def test_exception_from_runner_escalates_with_reraise():
     with pytest.raises(FileNotFoundError):
-        with KopfRunner(['run', 'non-existant.py', '--standalone'], reraise=True):
+        with KopfRunner(['run', 'non-existent.py', '--standalone'], reraise=True):
             pass
 
 
 def test_exception_from_runner_escalates_by_default():
     with pytest.raises(FileNotFoundError):
-        with KopfRunner(['run', 'non-existant.py', '--standalone']):
+        with KopfRunner(['run', 'non-existent.py', '--standalone']):
             pass
 
 
@@ -53,7 +53,7 @@ def test_exception_from_invoke_escalates(mocker, kwargs):
     mocker.patch('click.testing.CliRunner.invoke', side_effect=SampleError)
 
     with pytest.raises(SampleError):
-        with KopfRunner(['run', 'non-existant.py', '--standalone'], **kwargs):
+        with KopfRunner(['run', 'non-existent.py', '--standalone'], **kwargs):
             pass
 
 


### PR DESCRIPTION
> Issue : #52 

Provide the basic tools for the operator developers to test their Kopf-based operators.

This feature will be used also to run end2end tests in the following PRs (e.g. #54).

## Checklist

- [x] Tests
- [x] Documentation
