### PR TITLE
Extract the watching logic into a separate module

### DIFF
--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -29,14 +29,13 @@ import logging
 from typing import Optional, Callable, Tuple, Union, MutableMapping, NewType
 
 import aiojobs
-import kubernetes.watch
 
 from kopf.reactor.handling import custom_object_handler
 from kopf.reactor.lifecycles import get_default_lifecycle
 from kopf.reactor.peering import PEERING_CRD_RESOURCE, PEERING_DEFAULT_NAME
 from kopf.reactor.peering import peers_keepalive, peers_handler, Peer, detect_own_id
 from kopf.reactor.registry import get_default_registry, BaseRegistry, Resource
-from kopf.reactor.watching import streaming_aiter
+from kopf.reactor.watching import infinite_watch
 
 logger = logging.getLogger(__name__)
 
@@ -69,46 +68,16 @@ async def watcher(
     scheduler = await aiojobs.create_scheduler(limit=10)
     queues = {}
     try:
-        while True:
-
-            # Make a Kubernetes call to watch for the events via the API.
-            w = kubernetes.watch.Watch()
-            api = kubernetes.client.CustomObjectsApi()
-            api_fn = api.list_cluster_custom_object
-            stream = w.stream(api_fn, resource.group, resource.version, resource.plural)
-            async for event in streaming_aiter(stream):
-
-                # "410 Gone" is for the "resource version too old" error, we must restart watching.
-                # The resource versions are lost by k8s after few minutes (as per the official doc).
-                # The error occurs when there is nothing happening for few minutes. This is normal.
-                if event['type'] == 'ERROR' and event['object']['code'] == 410:
-                    logger.debug("Restarting the watch-stream for %r", resource)
-                    break  # out of for-cycle, to the while-true-cycle.
-
-                # Other watch errors should be fatal for the operator.
-                if event['type'] == 'ERROR':
-                    raise Exception(f"Error in the watch-stream: {event['object']}")
-
-                # Ensure that the event is something we understand and can handle.
-                if event['type'] not in ['ADDED', 'MODIFIED', 'DELETED']:
-                    logger.warning("Ignoring an unsupported event type: %r", event)
-                    continue
-
-                # Filter out all unrelated events as soon as possible (before queues), and silently.
-                # TODO: Reimplement via api.list_namespaced_custom_object, and API-level filtering.
-                ns = event['object'].get('metadata', {}).get('namespace', None)
-                if namespace is not None and ns is not None and ns != namespace:
-                    continue
-
-                # Either use the existing object's queue, or create a new one together with the per-object job.
-                # "Fire-and-forget": we do not wait for the result; the job destroys itself when it is fully done.
-                key = (resource, event['object']['metadata']['uid'])
-                try:
-                    await queues[key].put(event)
-                except KeyError:
-                    queues[key] = asyncio.Queue()
-                    await queues[key].put(event)
-                    await scheduler.spawn(worker(handler=handler, queues=queues, key=key))
+        # Either use the existing object's queue, or create a new one together with the per-object job.
+        # "Fire-and-forget": we do not wait for the result; the job destroys itself when it is fully done.
+        async for event in infinite_watch(resource=resource, namespace=namespace):
+            key = (resource, event['object']['metadata']['uid'])
+            try:
+                await queues[key].put(event)
+            except KeyError:
+                queues[key] = asyncio.Queue()
+                await queues[key].put(event)
+                await scheduler.spawn(worker(handler=handler, queues=queues, key=key))
 
     finally:
         # Forcedly terminate all the fire-and-forget per-object jobs, of they are still running.

--- a/kopf/reactor/watching.py
+++ b/kopf/reactor/watching.py
@@ -29,6 +29,12 @@ from kopf.reactor.registry import Resource
 logger = logging.getLogger(__name__)
 
 
+class WatchingError(Exception):
+    """
+    Raised when an unexpected error happens in the watch-stream API.
+    """
+
+
 class StopStreaming(RuntimeError):
     """
     Raised when the watch-stream generator ends streaming.
@@ -81,7 +87,7 @@ async def streaming_watch(
 
         # Other watch errors should be fatal for the operator.
         if event['type'] == 'ERROR':
-            raise Exception(f"Error in the watch-stream: {event['object']}")
+            raise WatchingError(f"Error in the watch-stream: {event['object']}")
 
         # Ensure that the event is something we understand and can handle.
         if event['type'] not in ['ADDED', 'MODIFIED', 'DELETED']:


### PR DESCRIPTION
> Issue : #13

It is done as a preparation for the tests of watch-streaming & event multiplexing tests — just to make both change-sets easier to review.

This extraction is same-for-same, no changes in the logic. Only the code cohesion is adjusted: the watch-calls are now next to the streaming/iterating routines, away from queueing part.
