### PR TITLE
Ignore metadata.generation in last-seen state checks and diffs

### DIFF
--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -41,6 +41,8 @@ def get_state(body):
         del body['metadata']['uid']
     if 'resourceVersion' in body.get('metadata', {}):
         del body['metadata']['resourceVersion']
+    if 'generation' in body.get('metadata', {}):
+        del body['metadata']['generation']
     if 'status' in body:
         del body['status']
     return body


### PR DESCRIPTION
> Issue : #64

Ignore the incremental changes of `metadata.generation`, which automatically happen on any PATCH operation.

There are no unit-tests on this module yet, to be done in #13.
