### PR TITLE
Enable Python 3.8 (dev) to preview the upcoming issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ env:
 
 python:
   - "3.7"
+matrix:
+  include:
+    - python: "3.8-dev"
+  allow_failures:
+    - python: "3.8-dev"
 
 before_script:
   - scripts/minikube-for-travis.sh


### PR DESCRIPTION
> Issue : #13

This PR just enables the Python 3.8 (dev) builds, but allows them to fail. 

This is mostly to see if there any upcoming issues before the release of Python 3.8 (scheduled to ~Oct'2019).

