### PR TITLE
Refactor the FIELD pseudo-cause into the catch-all events and a field filter

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -80,7 +80,7 @@ def field(
     def decorator(fn):
         registry.register(
             group=group, version=version, plural=plural,
-            event=registries.FIELD, field=field, id=id, timeout=timeout,
+            event=None, field=field, id=id, timeout=timeout,
             fn=fn)
         return fn
     return decorator

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -2,7 +2,7 @@ import pytest
 
 import kopf
 from kopf.reactor.handling import subregistry_var
-from kopf.reactor.registries import CREATE, UPDATE, DELETE, FIELD
+from kopf.reactor.registries import CREATE, UPDATE, DELETE
 from kopf.reactor.registries import Resource, SimpleRegistry, GlobalRegistry
 
 
@@ -70,7 +70,7 @@ def test_on_field_minimal(mocker):
     handlers = registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event == FIELD
+    assert handlers[0].event is None
     assert handlers[0].field == ('field', 'subfield')
     assert handlers[0].timeout is None
 
@@ -153,7 +153,7 @@ def test_on_field_with_all_kwargs(mocker):
     handlers = registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event == FIELD
+    assert handlers[0].event is None
     assert handlers[0].field ==('field', 'subfield')
     assert handlers[0].id == 'id/field.subfield'
     assert handlers[0].timeout == 123

--- a/tests/registries/test_id_detection.py
+++ b/tests/registries/test_id_detection.py
@@ -101,10 +101,11 @@ def test_with_prefix(mocker):
 
 def test_with_suffix(mocker, field):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+    diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
     registry = SimpleRegistry()
     registry.register(some_fn, field=field)
-    handlers = registry.get_handlers(mocker.MagicMock())
+    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -115,10 +116,11 @@ def test_with_suffix(mocker, field):
 
 def test_with_prefix_and_suffix(mocker, field):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+    diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn, field=field)
-    handlers = registry.get_handlers(mocker.MagicMock())
+    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -129,10 +131,11 @@ def test_with_prefix_and_suffix(mocker, field):
 
 def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+    diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn, id='explicit-id', field=field)
-    handlers = registry.get_handlers(mocker.MagicMock())
+    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
 
     assert not get_fn_id.called
 


### PR DESCRIPTION
> Issue : #13 

The `FIELD` pseudo-cause was introduced as an easy way to mark the per-field handlers (`@kopf.on.field`), and then to select them on the event handling. The field handlers were handled separately, after all the object handlers.

Over time, this pseudo-cause was merged into the overall handling routine, and has become a problem: it prevents further refactoring (of event/cause detection and handling), which in turn is needed for the test coverage.

----

This PR is a set of changes extracted from a bigger branch for the ease of code review (one small part at a time). It does NOT change the behaviour of the framework or of any handlers; it just changes the internal implementation of it:

* No more `FIELD` pseudo-causes in the code.
* The catch-all handlers (`event==None`) with `field` property set are now used — i.e. any event as long as this field is in the diff. Efficiently, it means only the `UPDATE` events — same as before.

----

In addition, the tests of handler selection were improved to reflect all cases; and to make the test ids more readable.
