### PR TITLE
Fix the detection of field deletion in diffs

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -454,8 +454,8 @@ async def _call_handler(
     """
 
     # For the field-handlers, the old/new/diff values must match the field, not the whole object.
-    old = cause.old if handler.field is None else resolve(cause.old, handler.field)
-    new = cause.new if handler.field is None else resolve(cause.new, handler.field)
+    old = cause.old if handler.field is None else resolve(cause.old, handler.field, None)
+    new = cause.new if handler.field is None else resolve(cause.new, handler.field, None)
     diff = cause.diff if handler.field is None else reduce(cause.diff, handler.field)
     cause = cause._replace(old=old, new=new, diff=diff)
 

--- a/kopf/structs/diffs.py
+++ b/kopf/structs/diffs.py
@@ -11,12 +11,20 @@ DiffPath = Tuple[str, ...]
 DiffItem = Tuple[DiffOp, DiffPath, Any, Any]
 Diff = Sequence[DiffItem]
 
+_UNSET = object()
 
-def resolve(d: Mapping, path: DiffPath):
-    result = d
-    for key in path:
-        result = result[key]
-    return result
+
+def resolve(d: Mapping, path: DiffPath, default=_UNSET):
+    try:
+        result = d
+        for key in path:
+            result = result[key]
+        return result
+    except KeyError:
+        if default is _UNSET:
+            raise
+        else:
+            return default
 
 
 def reduce_iter(d: Diff, path: DiffPath) -> Generator[DiffItem, None, None]:

--- a/tests/diffs/test_resolving.py
+++ b/tests/diffs/test_resolving.py
@@ -9,10 +9,23 @@ def test_existing_key():
     assert r == 'val'
 
 
-def test_unexisting_key():
+def test_unexisting_key_with_no_default():
     d = {'abc': {'def': {'hij': 'val'}}}
     with pytest.raises(KeyError):
         resolve(d, ['abc', 'def', 'xyz'])
+
+
+def test_unexisting_key_with_default_none():
+    d = {'abc': {'def': {'hij': 'val'}}}
+    r = resolve(d, ['abc', 'def', 'xyz'], None)
+    assert r is None
+
+
+def test_unexisting_key_with_default_value():
+    default = object()
+    d = {'abc': {'def': {'hij': 'val'}}}
+    r = resolve(d, ['abc', 'def', 'xyz'], default)
+    assert r is default
 
 
 def test_nonmapping_key():


### PR DESCRIPTION
> Issue : #13

As accidentally detected during #69 — this fixes a little issue with `KeyError` raised when the field is removed from the object, and a field-handler is called for that event, and fails to "resolve" the old/new value for the field-handler (i.e. a subset of a bigger diff-object), as the field is not in one of those per-object old/new structs.
