### PR TITLE
Measure the code coverage and upload reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+comment:
+  layout: "header, sunburst, diff, tree"
+  flags:
+    - unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - pytest -v
   - coveralls
   - codecov --flags unit
-  - E2E=true pytest -v -k e2e  # NB: after the coverage uploads!
+  - pytest -v --only-e2e  # NB: after the coverage uploads!
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - MINIKUBE_IN_STYLE=true
     - MINIKUBE_HOME=$HOME
     - MINIKUBE_VERSION=1.0.1
-    - E2E=true  # to not skip the e2e tests in pytest
   matrix:
     - KUBERNETES_VERSION=1.14.0
     - KUBERNETES_VERSION=1.13.0
@@ -36,6 +35,9 @@ before_script:
 
 script:
   - pytest -v
+  - coveralls
+  - codecov --flags unit
+  - E2E=true pytest -v -k e2e  # NB: after the coverage uploads!
 
 deploy:
   provider: pypi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Kubernetes Operator Pythonic Framework (Kopf)
 
+[![Build Status](https://travis-ci.org/zalando-incubator/kopf.svg?branch=master)](https://travis-ci.org/zalando-incubator/kopf)
+[![codecov](https://codecov.io/gh/zalando-incubator/kopf/branch/master/graph/badge.svg)](https://codecov.io/gh/zalando-incubator/kopf)
+[![Coverage Status](https://coveralls.io/repos/github/zalando-incubator/kopf/badge.svg?branch=master)](https://coveralls.io/github/zalando-incubator/kopf?branch=master)
+
 **Kopf** —Kubernetes Operator Pythonic Framework— is a framework and a library
 to make Kubernetes operators development easier, just in few lines of Python code. 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts =
+    --cov=kopf/
+    --cov-branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ urllib3<1.25
 # Everything needed to develop (test, debug) the framework.
 pytest-asyncio
 pytest-mock
+pytest-cov
 pytest
 asynctest
 freezegun
+codecov
+coveralls

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,8 +19,8 @@ def exampledir(request):
 
 
 @pytest.fixture(scope='session', autouse=True)
-def autologin():
-    if os.environ.get('E2E'):
+def autologin(request):
+    if request.config.getoption('--with-e2e') or request.config.getoption('--only-e2e'):
         login()  # or anything like that; it is not a unit-under-test
 
 


### PR DESCRIPTION
> Issue : closes #99, previously #13 

_(Playing with CodeCov and branches, need the real PR for this.)_

---

**Tools:**

Few tools are enabled for the same coverage measurements. More can be added over time — to compare and to use the benefits of all of them.

* CodeCov: https://codecov.io/gh/zalando-incubator/kopf (nice graphs, no if-branch coverage).
* Coveralls: https://coveralls.io/github/zalando-incubator/kopf (if-branch coverage, poor graphs).

---

**Historic measurements:**

The code coverage measurements for CodeCov were replayed for the whole git log — i.e. every commit — to render the graph nicely.

Coveralls does not date the coverage uploads to the commit timestamps (or it seems so), so it makes no sense to replay.

The ad-hoc script for replaying the history is here: https://gist.github.com/nolar/35c73e7a0caa37a30f0a37bdebb5d574