### PR TITLE
Docs: use stable Workloads API (apps/v1)

### DIFF
--- a/docs/deployment-depl.yaml
+++ b/docs/deployment-depl.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kopfexample-operator


### PR DESCRIPTION
> Issue: #12 

Use the stable Kubernetes workloads API version, see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/