### PR TITLE
Add few missing kwargs to the handler invocation (used in docs)

### DIFF
--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -49,6 +49,9 @@ async def invoke(
         spec=cause.body.setdefault('spec', {}),
         meta=cause.body.setdefault('metadata', {}),
         status=cause.body.setdefault('status', {}),
+        uid=cause.body.get('metadata', {}).get('uid'),
+        name=cause.body.get('metadata', {}).get('name'),
+        namespace=cause.body.get('metadata', {}).get('namespace'),
     )
 
     if is_async_fn(fn):

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -163,7 +163,7 @@ async def test_explicit_args_passed_properly(fn):
 @fns
 async def test_special_kwargs_added(fn):
     fn = MagicMock(fn)
-    cause = MagicMock(body={})
+    cause = MagicMock(body={'metadata': {'uid': 'uid', 'name': 'name', 'namespace': 'ns'}})
     await invoke(fn, cause=cause)
 
     assert fn.called
@@ -181,3 +181,6 @@ async def test_special_kwargs_added(fn):
     assert fn.call_args[1]['new'] is cause.new
     assert fn.call_args[1]['patch'] is cause.patch
     assert fn.call_args[1]['logger'] is cause.logger
+    assert fn.call_args[1]['uid'] is cause.body['metadata']['uid']
+    assert fn.call_args[1]['name'] is cause.body['metadata']['name']
+    assert fn.call_args[1]['namespace'] is cause.body['metadata']['namespace']


### PR DESCRIPTION
> Issue : #79 

Add the missing kwargs to the handler functions for the commonly used metadata fields. Specifically, `namespace` was mentioned in the docs, but absent in the code.
