### PR TITLE
Test the event handling; and separate the cause detection from handling

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -13,6 +13,7 @@ The decorators for the event handlers. Usually used as::
 
 from typing import Optional, Union, Tuple, List
 
+from kopf.reactor import causation
 from kopf.reactor import handling
 from kopf.reactor import registries
 
@@ -28,7 +29,7 @@ def create(
     def decorator(fn):
         registry.register(
             group=group, version=version, plural=plural,
-            event=registries.CREATE, id=id, timeout=timeout,
+            event=causation.CREATE, id=id, timeout=timeout,
             fn=fn)
         return fn
     return decorator
@@ -45,7 +46,7 @@ def update(
     def decorator(fn):
         registry.register(
             group=group, version=version, plural=plural,
-            event=registries.UPDATE, id=id, timeout=timeout,
+            event=causation.UPDATE, id=id, timeout=timeout,
             fn=fn)
         return fn
     return decorator
@@ -62,7 +63,7 @@ def delete(
     def decorator(fn):
         registry.register(
             group=group, version=version, plural=plural,
-            event=registries.DELETE, id=id, timeout=timeout,
+            event=causation.DELETE, id=id, timeout=timeout,
             fn=fn)
         return fn
     return decorator

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -74,11 +74,10 @@ def detect_cause(
     which performs the actual handler invocation, logging, patching,
     and other side-effects.
     """
-    etyp = event['type']  # e.g. ADDED, MODIFIED, DELETED.
     body = event['object']
 
     # The object was really deleted from the cluster. But we do not care anymore.
-    if etyp == 'DELETED':
+    if event['type'] == 'DELETED':
         return Cause(
             event=GONE,
             body=body,

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -1,14 +1,41 @@
+"""
+Detection of the event causes, based on the resource state.
+
+The low-level watch-events are highly limited in information on what
+caused them, and they only notify that the object was changed somehow:
+
+* ``ADDED`` for the newly created objects (or for the first-time listing).
+* ``MODIFIED`` for the changes of any field, be that metainfo, spec, or status.
+* ``DELETED`` for the actual deletion of the object post-factum.
+
+The conversion of the low-level *events* to the high-level *causes* is done by
+checking the object's state and comparing it to the saved last-seen state.
+
+This allows to track which specific fields were changed, and are those changes
+important enough to call the handlers: e.g. the ``status`` changes are ignored,
+so as some selected system fields of the ``metainfo``.
+
+For deletion, the cause is detected when the object is just marked for deletion,
+not when it is actually deleted (as the events notify): so that the handlers
+could execute on the yet-existing object (and its children, if created).
+"""
 import logging
-from typing import NamedTuple, Text, MutableMapping, Optional, Any, Union
+from typing import NamedTuple, Text, Mapping, MutableMapping, Optional, Any, Union
 
 from kopf.reactor import registries
 from kopf.structs import diffs
+from kopf.structs import finalizers
+from kopf.structs import lastseen
 
 # The constants for the event types, to prevent the direct string usage and typos.
 # They are not exposed by the framework, but are used internally. See also: `kopf.on`.
+NEW = 'new'
 CREATE = 'create'
 UPDATE = 'update'
 DELETE = 'delete'
+NOOP = 'noop'
+FREE = 'free'
+GONE = 'gone'
 
 
 class Cause(NamedTuple):
@@ -26,3 +53,73 @@ class Cause(NamedTuple):
     diff: Optional[diffs.Diff] = None
     old: Optional[Any] = None
     new: Optional[Any] = None
+
+
+def detect_cause(
+        event: Mapping,
+        **kwargs
+) -> Cause:
+    """
+    Detect the cause of the event to be handled.
+
+    This is a purely computational function with no side-effects.
+    The causes are then consumed by `custom_object_handler`,
+    which performs the actual handler invocation, logging, patching,
+    and other side-effects.
+    """
+    etyp = event['type']  # e.g. ADDED, MODIFIED, DELETED.
+    body = event['object']
+
+    # The object was really deleted from the cluster. But we do not care anymore.
+    if etyp == 'DELETED':
+        return Cause(
+            event=GONE,
+            body=body,
+            **kwargs)
+
+    # The finalizer has been just removed. We are fully done.
+    if finalizers.is_deleted(body) and not finalizers.has_finalizers(body):
+        return Cause(
+            event=FREE,
+            body=body,
+            **kwargs)
+
+    if finalizers.is_deleted(body):
+        return Cause(
+            event=DELETE,
+            body=body,
+            **kwargs)
+
+    # For a fresh new object, first block it from accidental deletions without our permission.
+    # The actual handler will be called on the next call.
+    if not finalizers.has_finalizers(body):
+        return Cause(
+            event=NEW,
+            body=body,
+            **kwargs)
+
+    # For the object seen for the first time (i.e. just-created), call the creation handlers,
+    # then mark the state as if it was seen when the creation has finished.
+    if not lastseen.has_state(body):
+        return Cause(
+            event=CREATE,
+            body=body,
+            **kwargs)
+
+    # The previous step triggers one more patch operation without actual change. Ignore it.
+    # Either the last-seen state or the status field has changed.
+    if not lastseen.is_state_changed(body):
+        return Cause(
+            event=NOOP,
+            body=body,
+            **kwargs)
+
+    # And what is left, is the update operation on one of the useful fields of the existing object.
+    old, new, diff = lastseen.get_state_diffs(body)
+    return Cause(
+        event=UPDATE,
+        body=body,
+        diff=diff,
+        old=old,
+        new=new,
+        **kwargs)

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -8,12 +8,12 @@ caused them, and they only notify that the object was changed somehow:
 * ``MODIFIED`` for the changes of any field, be that metainfo, spec, or status.
 * ``DELETED`` for the actual deletion of the object post-factum.
 
-The conversion of the low-level *events* to the high-level *causes* is done by
+The conversion of low-level *events* to high level *causes* is done by
 checking the object's state and comparing it to the saved last-seen state.
 
-This allows to track which specific fields were changed, and are those changes
-important enough to call the handlers: e.g. the ``status`` changes are ignored,
-so as some selected system fields of the ``metainfo``.
+This allows to track which specific fields were changed, and if are those
+changes are important enough to call the handlers: e.g. the ``status`` changes
+are ignored, so as some selected system fields of the ``metainfo``.
 
 For deletion, the cause is detected when the object is just marked for deletion,
 not when it is actually deleted (as the events notify): so that the handlers
@@ -27,7 +27,7 @@ from kopf.structs import diffs
 from kopf.structs import finalizers
 from kopf.structs import lastseen
 
-# The constants for the event types, to prevent the direct string usage and typos.
+# Constants for event types, to prevent a direct usage of strings, and typos.
 # They are not exposed by the framework, but are used internally. See also: `kopf.on`.
 NEW = 'new'
 CREATE = 'create'
@@ -50,7 +50,7 @@ class Cause(NamedTuple):
     The cause is what has caused the whole reaction as a chain of handlers.
 
     Unlike the low-level Kubernetes watch-events, the cause is aware
-    of the actual field changes, including the multi-handlers changes.
+    of actual field changes, including multi-handler changes.
     """
     logger: Union[logging.Logger, logging.LoggerAdapter]
     resource: registries.Resource
@@ -105,7 +105,7 @@ def detect_cause(
             body=body,
             **kwargs)
 
-    # For the object seen for the first time (i.e. just-created), call the creation handlers,
+    # For an object seen for the first time (i.e. just-created), call the creation handlers,
     # then mark the state as if it was seen when the creation has finished.
     if not lastseen.has_state(body):
         return Cause(
@@ -113,7 +113,7 @@ def detect_cause(
             body=body,
             **kwargs)
 
-    # The previous step triggers one more patch operation without actual change. Ignore it.
+    # The previous step triggers one more patch operation without actual changes. Ignore it.
     # Either the last-seen state or the status field has changed.
     if not lastseen.is_state_changed(body):
         return Cause(

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -37,6 +37,13 @@ NOOP = 'noop'
 FREE = 'free'
 GONE = 'gone'
 
+# The human-readable names of these causes. Will be capitalised when needed.
+TITLES = {
+    CREATE: 'creation',
+    UPDATE: 'update',
+    DELETE: 'deletion',
+}
+
 
 class Cause(NamedTuple):
     """

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -1,0 +1,28 @@
+import logging
+from typing import NamedTuple, Text, MutableMapping, Optional, Any, Union
+
+from kopf.reactor import registries
+from kopf.structs import diffs
+
+# The constants for the event types, to prevent the direct string usage and typos.
+# They are not exposed by the framework, but are used internally. See also: `kopf.on`.
+CREATE = 'create'
+UPDATE = 'update'
+DELETE = 'delete'
+
+
+class Cause(NamedTuple):
+    """
+    The cause is what has caused the whole reaction as a chain of handlers.
+
+    Unlike the low-level Kubernetes watch-events, the cause is aware
+    of the actual field changes, including the multi-handlers changes.
+    """
+    logger: Union[logging.Logger, logging.LoggerAdapter]
+    resource: registries.Resource
+    event: Text
+    body: MutableMapping
+    patch: MutableMapping
+    diff: Optional[diffs.Diff] = None
+    old: Optional[Any] = None
+    new: Optional[Any] = None

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -140,7 +140,8 @@ async def handle_cause(
 
     # Regular causes invoke the handlers.
     if cause.event in [causation.CREATE, causation.UPDATE, causation.DELETE]:
-        logger.debug(f"{cause.event!r} detected: %r", body)
+        title = causation.TITLES.get(cause.event, repr(cause.event))
+        logger.debug(f"{title.capitalize()} event: %r", body)
         try:
             await execute(lifecycle=lifecycle, registry=registry, cause=cause)
         except HandlerChildrenRetry as e:
@@ -148,8 +149,8 @@ async def handle_cause(
             delay = e.delay
             done = False
         else:
-            logger.info(f"All handlers succeeded for {cause.event!r}.")
-            events.info(cause.body, reason='Success', message=f"All handlers succeeded for {cause.event!r}.")
+            logger.info(f"All handlers succeeded for {title}.")
+            events.info(cause.body, reason='Success', message=f"All handlers succeeded for {title}.")
             done = True
 
     # Regular causes also do some implicit post-handling when all handlers are done.

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -169,12 +169,12 @@ async def handle_cause(
         logger.debug("Deleted, really deleted, and we are notified.")
 
     if cause.event == causation.FREE:
-        logger.debug("Deletion event, but we are done with it, but we do not care.")
+        logger.debug("Deletion event, but we are done with it, and we do not care.")
 
     if cause.event == causation.NOOP:
         logger.debug("Something has changed, but we are not interested (state is the same).")
 
-    # For the case of a fresh new created object, lock it to this operator.
+    # For the case of a newly created object, lock it to this operator.
     # TODO: make it conditional.
     if cause.event == causation.NEW:
         logger.debug("Adding the finalizer, thus preventing the actual deletion.")

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -191,7 +191,7 @@ async def custom_object_handler(
     # Provoke a dummy change to trigger the reactor after sleep.
     # TODO: reimplement via the handler delayed statuses properly.
     if delay and not patch:
-        patch.setdefault('kopf', {})['dummy'] = datetime.datetime.utcnow().isoformat()
+        patch.setdefault('status', {}).setdefault('kopf', {})['dummy'] = datetime.datetime.utcnow().isoformat()
 
     # Whatever was done, apply the accumulated changes to the object.
     # But only once, to reduce the number of API calls and the generated irrelevant events.

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -155,12 +155,11 @@ async def handle_cause(
 
     # Regular causes also do some implicit post-handling when all handlers are done.
     if done:
+        status.purge_progress(body=body, patch=patch)
+        lastseen.refresh_state(body=body, patch=patch)
         if cause.event == causation.DELETE:
             logger.debug("Removing the finalizer, thus allowing the actual deletion.")
             finalizers.remove_finalizers(body=body, patch=patch)
-        else:
-            status.purge_progress(body=body, patch=patch)
-            lastseen.refresh_state(body=body, patch=patch)
 
     # Informational causes just print the log lines.
     if cause.event == causation.NEW:

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -346,14 +346,14 @@ async def _execute(
 
         # Definitely retriable error, no matter what is the error-reaction mode.
         except HandlerRetryError as e:
-            logger.exception(f"Handler {handler.id!r} failed with an retry exception. Will retry.")
+            logger.exception(f"Handler {handler.id!r} failed with a retry exception. Will retry.")
             events.exception(cause.body, message=f"Handler {handler.id!r} failed. Will retry.")
             status.set_retry_time(body=cause.body, patch=cause.patch, handler=handler, delay=e.delay)
             handlers_left.append(handler)
 
         # Definitely fatal error, no matter what is the error-reaction mode.
         except HandlerFatalError as e:
-            logger.exception(f"Handler {handler.id!r} failed with an fatal exception. Will stop.")
+            logger.exception(f"Handler {handler.id!r} failed with a fatal exception. Will stop.")
             events.exception(cause.body, message=f"Handler {handler.id!r} failed. Will stop.")
             status.store_failure(body=cause.body, patch=cause.patch, handler=handler, exc=e)
             # TODO: report the handling failure somehow (beside logs/events). persistent status?

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -16,12 +16,6 @@ import collections
 import functools
 from types import FunctionType, MethodType
 
-# The constants for the event types, to prevent the direct string usage and typos.
-# They are not exposed by the framework, but are used internally. See also: `kopf.on`.
-CREATE = 'create'
-UPDATE = 'update'
-DELETE = 'delete'
-
 
 # An immutable reference to a custom resource definition.
 Resource = collections.namedtuple('Resource', 'group version plural')

--- a/kopf/structs/finalizers.py
+++ b/kopf/structs/finalizers.py
@@ -20,12 +20,14 @@ def has_finalizers(body):
 
 
 def append_finalizers(*, body, patch):
-    finalizers = body.get('metadata', {}).get('finalizers', [])
-    patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))
-    patch['metadata']['finalizers'].append(FINALIZER)
+    if not has_finalizers(body=body):
+        finalizers = body.get('metadata', {}).get('finalizers', [])
+        patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))
+        patch['metadata']['finalizers'].append(FINALIZER)
 
 
 def remove_finalizers(*, body, patch):
-    finalizers = body.get('metadata', {}).get('finalizers', [])
-    patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))
-    patch['metadata']['finalizers'].remove(FINALIZER)
+    if has_finalizers(body=body):
+        finalizers = body.get('metadata', {}).get('finalizers', [])
+        patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))
+        patch['metadata']['finalizers'].remove(FINALIZER)

--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -31,6 +31,8 @@ def get_state(body):
         del body['metadata']['annotations'][LAST_SEEN_ANNOTATION]
     if 'kubectl.kubernetes.io/last-applied-configuration' in body.get('metadata', {}).get('annotations', {}):
         del body['metadata']['annotations']['kubectl.kubernetes.io/last-applied-configuration']
+    if 'annotations' in body.get('metadata', {}) and not body['metadata']['annotations']:
+        del body['metadata']['annotations']
     if 'finalizers' in body.get('metadata', {}):
         del body['metadata']['finalizers']
     if 'deletionTimestamp' in body.get('metadata', {}):
@@ -45,6 +47,8 @@ def get_state(body):
         del body['metadata']['resourceVersion']
     if 'generation' in body.get('metadata', {}):
         del body['metadata']['generation']
+    if 'metadata' in body and not body['metadata']:
+        del body['metadata']
     if 'status' in body:
         del body['status']
     return body

--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -33,6 +33,8 @@ def get_state(body):
         del body['metadata']['annotations']['kubectl.kubernetes.io/last-applied-configuration']
     if 'finalizers' in body.get('metadata', {}):
         del body['metadata']['finalizers']
+    if 'deletionTimestamp' in body.get('metadata', {}):
+        del body['metadata']['deletionTimestamp']
     if 'creationTimestamp' in body.get('metadata', {}):
         del body['metadata']['creationTimestamp']
     if 'selfLink' in body.get('metadata', {}):

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kopf.reactor.handling import Cause
+from kopf.reactor.causation import Cause
 
 
 def test_no_args():

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -1,0 +1,218 @@
+import copy
+import json
+
+import pytest
+
+from kopf.reactor.causation import CREATE, UPDATE, DELETE, NEW, NOOP, FREE, GONE
+from kopf.reactor.causation import detect_cause
+from kopf.structs.finalizers import FINALIZER
+from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
+
+# Encoded at runtime, so that we do not make any assumptions on json formatting.
+SPEC_DATA = {'spec': {'field': 'value'}}
+SPEC_JSON = json.dumps((SPEC_DATA))
+ALT_DATA = {'spec': {'field': 'other'}}
+ALT_JSON = json.dumps((ALT_DATA))
+
+#
+# The following factors contribute to the detection of the cause
+# (and we combine all of them with the matching & mismatching fixtures):
+# * Finalizers (presence or absence).
+# * Deletion timestamp (presence or absence).
+# * Annotation with the last-seen state (presence or absence).
+# * Annotation with the last-seen state (difference with the real state).
+#
+
+deleted_events = pytest.mark.parametrize('event', [
+    pytest.param('DELETED'),
+])
+
+regular_events = pytest.mark.parametrize('event', [
+    pytest.param('ADDED'),
+    pytest.param('MODIFIED'),
+    pytest.param('FORWARD-COMPATIBILITY-PSEUDO-EVENT', id='COMPAT'),
+])
+
+
+all_finalizers = pytest.mark.parametrize('finalizers', [
+    pytest.param({}, id='no-finalizers'),
+    pytest.param({'finalizers': [FINALIZER]}, id='own-finalizer'),
+    pytest.param({'finalizers': ['irrelevant', 'another']}, id='other-finalizers'),
+    pytest.param({'finalizers': ['irrelevant', FINALIZER, 'another']}, id='mixed-finalizers'),
+])
+
+our_finalizers = pytest.mark.parametrize('finalizers', [
+    pytest.param({'finalizers': [FINALIZER]}, id='own-finalizer'),
+    pytest.param({'finalizers': ['irrelevant', FINALIZER, 'another']}, id='mixed-finalizers'),
+])
+
+no_finalizers = pytest.mark.parametrize('finalizers', [
+    pytest.param({}, id='no-finalizers'),
+    pytest.param({'finalizers': ['irrelevant', 'another']}, id='other-finalizers'),
+])
+
+
+all_deletions = pytest.mark.parametrize('deletion_ts', [
+    pytest.param({}, id='no-deletion-ts'),
+    pytest.param({'deletionTimestamp': None}, id='empty-deletion-ts'),
+    pytest.param({'deletionTimestamp': 'some'}, id='real-deletion-ts'),
+])
+
+real_deletions = pytest.mark.parametrize('deletion_ts', [
+    pytest.param({'deletionTimestamp': 'some'}, id='real-deletion-ts'),
+])
+
+no_deletions = pytest.mark.parametrize('deletion_ts', [
+    pytest.param({}, id='no-deletion-ts'),
+    pytest.param({'deletionTimestamp': None}, id='empty-deletion-ts'),
+])
+
+
+all_lastseen = pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='no-annotations'),
+    pytest.param({'annotations': {}}, id='no-last-seen'),
+    pytest.param({'annotations': {LAST_SEEN_ANNOTATION: SPEC_JSON}}, id='matching-last-seen'),
+    pytest.param({'annotations': {LAST_SEEN_ANNOTATION: SPEC_JSON}}, id='mismatching-last-seen'),
+])
+
+absent_lastseen = pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='no-annotations'),
+    pytest.param({'annotations': {}}, id='no-last-seen'),
+])
+
+matching_lastseen = pytest.mark.parametrize('annotations', [
+    pytest.param({'annotations': {LAST_SEEN_ANNOTATION: SPEC_JSON}}, id='matching-last-seen'),
+])
+
+mismatching_lastseen = pytest.mark.parametrize('annotations', [
+    pytest.param({'annotations': {LAST_SEEN_ANNOTATION: ALT_JSON}}, id='mismatching-last-seen'),
+])
+
+
+@pytest.fixture
+def content():
+    return copy.deepcopy(SPEC_DATA)
+
+
+#
+# kwargs helpers -- to test them for all causes.
+#
+
+@pytest.fixture()
+def kwargs():
+    return dict(
+        resource=object(),
+        logger=object(),
+        patch=object(),
+    )
+
+def check_kwargs(cause, kwargs):
+    __traceback_hide__ = True
+    assert cause.resource is kwargs['resource']
+    assert cause.logger is kwargs['logger']
+    assert cause.patch is kwargs['patch']
+
+
+#
+# The tests.
+#
+
+@all_finalizers
+@all_deletions
+@deleted_events
+def test_for_gone(kwargs, event, finalizers, deletion_ts):
+    event = {'type': event, 'object': {'metadata': {}}}
+    event['object']['metadata'].update(finalizers)
+    event['object']['metadata'].update(deletion_ts)
+    cause = detect_cause(event=event, **kwargs)
+    assert cause.event == GONE
+    check_kwargs(cause, kwargs)
+
+
+@no_finalizers
+@real_deletions
+@regular_events
+def test_for_free(kwargs, event, finalizers, deletion_ts):
+    event = {'type': event, 'object': {'metadata': {}}}
+    event['object']['metadata'].update(finalizers)
+    event['object']['metadata'].update(deletion_ts)
+    cause = detect_cause(event=event, **kwargs)
+    assert cause.event == FREE
+    check_kwargs(cause, kwargs)
+
+
+@our_finalizers
+@real_deletions
+@regular_events
+def test_for_delete(kwargs, event, finalizers, deletion_ts):
+    event = {'type': event, 'object': {'metadata': {}}}
+    event['object']['metadata'].update(finalizers)
+    event['object']['metadata'].update(deletion_ts)
+    cause = detect_cause(event=event, **kwargs)
+    assert cause.event == DELETE
+    check_kwargs(cause, kwargs)
+
+
+@no_finalizers
+@no_deletions
+@regular_events
+def test_for_new(kwargs, event, finalizers, deletion_ts):
+    event = {'type': event, 'object': {'metadata': {}}}
+    event['object']['metadata'].update(finalizers)
+    event['object']['metadata'].update(deletion_ts)
+    cause = detect_cause(event=event, **kwargs)
+    assert cause.event == NEW
+    check_kwargs(cause, kwargs)
+
+
+@absent_lastseen
+@our_finalizers
+@no_deletions
+@regular_events
+def test_for_create(kwargs, event, finalizers, deletion_ts, annotations, content):
+    event = {'type': event, 'object': {'metadata': {}}}
+    event['object'].update(content)
+    event['object']['metadata'].update(finalizers)
+    event['object']['metadata'].update(deletion_ts)
+    event['object']['metadata'].update(annotations)
+    cause = detect_cause(event=event, **kwargs)
+    assert cause.event == CREATE
+    check_kwargs(cause, kwargs)
+
+
+@matching_lastseen
+@our_finalizers
+@no_deletions
+@regular_events
+def test_for_no_op(kwargs, event, finalizers, deletion_ts, annotations, content):
+    event = {'type': event, 'object': {'metadata': {}}}
+    event['object'].update(content)
+    event['object']['metadata'].update(finalizers)
+    event['object']['metadata'].update(deletion_ts)
+    event['object']['metadata'].update(annotations)
+    cause = detect_cause(event=event, **kwargs)
+    assert cause.event == NOOP
+    check_kwargs(cause, kwargs)
+
+
+@mismatching_lastseen
+@our_finalizers
+@no_deletions
+@regular_events
+def test_for_update(kwargs, event, finalizers, deletion_ts, annotations, content):
+    event = {'type': event, 'object': {'metadata': {}}}
+    event['object'].update(content)
+    event['object']['metadata'].update(finalizers)
+    event['object']['metadata'].update(deletion_ts)
+    event['object']['metadata'].update(annotations)
+    cause = detect_cause(event=event, **kwargs)
+    assert cause.event == UPDATE
+    check_kwargs(cause, kwargs)
+
+    # Diffs are tested elsewhere, but quickly check the absence of meta-fields.
+    assert cause.diff
+    assert len(cause.diff) == 1
+    assert cause.diff[0][0] == 'change'
+    assert cause.diff[0][1] == ('spec', 'field')
+    assert cause.diff[0][2] == 'other'
+    assert cause.diff[0][3] == 'value'

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -1,0 +1,189 @@
+"""
+Testing the handling of events on the top level.
+
+As the input:
+
+* Mocked cause detection, with the cause artificially simulated for each test.
+  The proper cause detection is tested elsewhere (see ``test_detection.py``).
+* Registered handlers in a global registry. Each handler is a normal function,
+  which calls a mock -- to ease the assertions.
+
+As the output, we check the mocked calls on the following:
+
+* ``asyncio.sleep()`` -- for delays.
+* ``kopf.k8s.patching.patch_obj()`` -- for patch content.
+* ``kopf.k8s.events.post_event()`` -- for events posted.
+* Handler mocks -- whether they were or were not called with specific arguments.
+* Captured logs.
+
+The above inputs & outputs represent the expected user scenario
+rather than the specific implementation of it.
+Therefore, we do not mock/spy/intercept anything within the handling routines
+(except for cause detection), leaving it as the implementation details.
+Specifically, this internal chain of calls happens on every event:
+
+* ``causation.detect_cause()`` -- tested separately in ``/tests/causation/``.
+* ``handle_cause()``
+* ``execute()``
+* ``_execute()``
+* ``_call_handler()``
+* ``invocation.invoke()`` -- tested separately in ``/tests/invocations/``.
+
+Some of these aspects are tested separately to be sure they indeed execute
+all possible cases properly. In the top-level event handling, we assume they do,
+and only check for the upper-level behaviour, not all of the input combinations.
+"""
+import copy
+import dataclasses
+from typing import Callable
+from unittest.mock import Mock
+
+import pytest
+from kubernetes.client.rest import ApiException  # to avoid mocking it
+
+import kopf
+from kopf.reactor.causation import Cause
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class K8sMocks:
+    patch_obj: Mock
+    post_event: Mock
+    asyncio_sleep: Mock
+
+
+@pytest.fixture(autouse=True)
+def k8s_mocked(mocker):
+    """ Prevent any actual K8s calls."""
+
+    # TODO: consolidate with tests/k8s/conftest.py:client_mock()
+    client_mock = mocker.patch('kubernetes.client')
+    client_mock.rest.ApiException = ApiException  # to be raises and caught
+
+    # We mock on the level of our own K8s API wrappers, not the K8s client.
+    return K8sMocks(
+        patch_obj=mocker.patch('kopf.k8s.patching.patch_obj'),
+        post_event=mocker.patch('kopf.k8s.events.post_event'),
+        asyncio_sleep=mocker.patch('asyncio.sleep'),
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_default_registry():
+    old_registry = kopf.get_default_registry()
+    new_registry = kopf.GlobalRegistry()
+    kopf.set_default_registry(new_registry)
+    try:
+        yield new_registry
+    finally:
+        kopf.set_default_registry(old_registry)
+
+
+@pytest.fixture()
+def registry(clear_default_registry):
+    return clear_default_registry
+
+
+@dataclasses.dataclass(frozen=True, eq=False, order=False)
+class HandlersContainer:
+    create_mock: Mock
+    update_mock: Mock
+    delete_mock: Mock
+    create_fn: Callable
+    update_fn: Callable
+    delete_fn: Callable
+
+
+@pytest.fixture()
+def handlers(clear_default_registry):
+    create_mock = Mock(return_value=None)
+    update_mock = Mock(return_value=None)
+    delete_mock = Mock(return_value=None)
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn')
+    async def create_fn(**kwargs):
+        return create_mock(**kwargs)
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', id='update_fn')
+    async def update_fn(**kwargs):
+        return update_mock(**kwargs)
+
+    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples', id='delete_fn')
+    async def delete_fn(**kwargs):
+        return delete_mock(**kwargs)
+
+    return HandlersContainer(
+        create_mock=create_mock,
+        update_mock=update_mock,
+        delete_mock=delete_mock,
+        create_fn=create_fn,
+        update_fn=update_fn,
+        delete_fn=delete_fn,
+    )
+
+
+@pytest.fixture()
+def extrahandlers(clear_default_registry, handlers):
+    create_mock = Mock(return_value=None)
+    update_mock = Mock(return_value=None)
+    delete_mock = Mock(return_value=None)
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn2')
+    async def create_fn2(**kwargs):
+        return create_mock(**kwargs)
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', id='update_fn2')
+    async def update_fn2(**kwargs):
+        return update_mock(**kwargs)
+
+    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples', id='delete_fn2')
+    async def delete_fn2(**kwargs):
+        return delete_mock(**kwargs)
+
+    return HandlersContainer(
+        create_mock=create_mock,
+        update_mock=update_mock,
+        delete_mock=delete_mock,
+        create_fn=create_fn2,
+        update_fn=update_fn2,
+        delete_fn=delete_fn2,
+    )
+
+
+@pytest.fixture()
+def cause_mock(mocker, resource):
+
+    # Use everything from a mock, but use the passed `patch` dict as is.
+    # The event handler passes its own accumulator, and checks/applies it later.
+    def new_detect_fn(**kwargs):
+
+        # Avoid collision of our mocked values with the passed kwargs.
+        original_event = kwargs.pop('event', None)
+        original_body = kwargs.pop('body', None)
+        event = mock.event if mock.event is not None else original_event
+        body = copy.deepcopy(mock.body) if mock.body is not None else original_body
+
+        # Pass through kwargs: resource, logger, patch, diff, old, new.
+        # I.e. everything except what we mock: event & body.
+        cause = Cause(
+            event=event,
+            body=body,
+            **kwargs)
+
+        # Needed for the k8s-event creation, as they are attached to objects.
+        body.setdefault('apiVersion', f'{resource.group}/{resource.version}')
+        body.setdefault('kind', 'KopfExample')  # TODO: resource.???
+        body.setdefault('metadata', {}).setdefault('namespace', 'some-namespace')
+        body.setdefault('metadata', {}).setdefault('name', 'some-name')
+        body.setdefault('metadata', {}).setdefault('uid', 'some-uid')
+
+        return cause
+
+    # Substitute the real cause detector with out own mock-based one.
+    mocker.patch('kopf.reactor.causation.detect_cause', new=new_detect_fn)
+
+    # The mock object stores some values later used by the factory substitute.
+    mock = mocker.Mock(spec_set=['event', 'body'])
+    mock.event = None
+    mock.body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    return mock

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -100,15 +100,15 @@ def handlers(clear_default_registry):
     update_mock = Mock(return_value=None)
     delete_mock = Mock(return_value=None)
 
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn')
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn', timeout=600)
     async def create_fn(**kwargs):
         return create_mock(**kwargs)
 
-    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', id='update_fn')
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', id='update_fn', timeout=600)
     async def update_fn(**kwargs):
         return update_mock(**kwargs)
 
-    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples', id='delete_fn')
+    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples', id='delete_fn', timeout=600)
     async def delete_fn(**kwargs):
         return delete_mock(**kwargs)
 

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -1,14 +1,14 @@
 """
 Testing the handling of events on the top level.
 
-As the input:
+As input:
 
 * Mocked cause detection, with the cause artificially simulated for each test.
   The proper cause detection is tested elsewhere (see ``test_detection.py``).
 * Registered handlers in a global registry. Each handler is a normal function,
   which calls a mock -- to ease the assertions.
 
-As the output, we check the mocked calls on the following:
+As output, we check mocked calls on the following:
 
 * ``asyncio.sleep()`` -- for delays.
 * ``kopf.k8s.patching.patch_obj()`` -- for patch content.

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -1,0 +1,97 @@
+import asyncio
+import logging
+
+import freezegun
+import pytest
+
+import kopf
+from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.handling import HandlerRetryError
+from kopf.reactor.handling import WAITING_KEEPALIVE_INTERVAL
+from kopf.reactor.handling import custom_object_handler
+
+
+@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('now, ts, delay', [
+    ['2020-01-01T00:00:00', '2020-01-01T00:04:56.789000', 4 * 60 + 56.789],
+], ids=['fast'])
+async def test_delayed_handlers_progress(
+        registry, handlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked, now, ts, delay):
+    caplog.set_level(logging.DEBUG)
+
+    handlers.create_mock.side_effect = HandlerRetryError("oops", delay=delay)
+    handlers.update_mock.side_effect = HandlerRetryError("oops", delay=delay)
+    handlers.delete_mock.side_effect = HandlerRetryError("oops", delay=delay)
+
+    cause_mock.event = cause_type
+
+    with freezegun.freeze_time(now):
+        await custom_object_handler(
+            lifecycle=kopf.lifecycles.all_at_once,
+            registry=registry,
+            resource=resource,
+            event={'type': 'irrelevant', 'object': cause_mock.body},
+            freeze=asyncio.Event(),
+        )
+
+    assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
+    assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
+    assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.patch_obj.called
+
+    fname = f'{cause_type}_fn'
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert patch['status']['kopf']['progress'][fname]['delayed'] == ts
+
+    assert_logs([
+        "Invoking handler .+",
+        "Handler .+ failed with a retry exception. Will retry.",
+    ])
+
+
+@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('now, ts, delay', [
+    ['2020-01-01T00:00:00', '2020-01-01T00:04:56.789000', 4 * 60 + 56.789],
+    ['2020-01-01T00:00:00', '2099-12-31T23:59:59.000000', WAITING_KEEPALIVE_INTERVAL],
+], ids=['fast', 'slow'])
+async def test_delayed_handlers_sleep(
+        registry, handlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked, now, ts, delay):
+    caplog.set_level(logging.DEBUG)
+
+    cause_mock.event = cause_type
+    cause_mock.body.update({
+        'status': {'kopf': {'progress': {
+            'create_fn': {'delayed': ts},
+            'update_fn': {'delayed': ts},
+            'delete_fn': {'delayed': ts},
+        }}}
+    })
+
+    with freezegun.freeze_time(now):
+        await custom_object_handler(
+            lifecycle=kopf.lifecycles.all_at_once,
+            registry=registry,
+            resource=resource,
+            event={'type': 'irrelevant', 'object': cause_mock.body},
+            freeze=asyncio.Event(),
+        )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+
+    # The dummy patch is needed to trigger the further changes. The value is irrelevant.
+    assert k8s_mocked.patch_obj.called
+    assert 'dummy' in k8s_mocked.patch_obj.call_args_list[0][1]['patch']['status']['kopf']
+
+    # The duration of sleep should be as expected.
+    assert k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.asyncio_sleep.call_args_list[0][0][0] == delay
+
+    assert_logs([
+        "Sleeping for [\d\.]+ seconds",
+    ])

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -1,0 +1,125 @@
+import asyncio
+import logging
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.handling import HandlerFatalError, HandlerRetryError
+from kopf.reactor.handling import custom_object_handler
+
+
+# The extrahandlers are needed to prevent the cycle ending and status purging.
+@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+async def test_fatal_error_stops_handler(
+        registry, handlers, extrahandlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    name1 = f'{cause_type}_fn'
+
+    cause_mock.event = cause_type
+    handlers.create_mock.side_effect = HandlerFatalError("oops")
+    handlers.update_mock.side_effect = HandlerFatalError("oops")
+    handlers.delete_mock.side_effect = HandlerFatalError("oops")
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.one_by_one,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
+    assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
+    assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.patch_obj.called
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert patch['status']['kopf']['progress'] is not None
+    assert patch['status']['kopf']['progress'][name1]['failure'] is True
+    assert patch['status']['kopf']['progress'][name1]['message'] == 'oops'
+
+    assert_logs([
+        "Handler .+ failed with a fatal exception. Will stop.",
+    ])
+
+
+# The extrahandlers are needed to prevent the cycle ending and status purging.
+@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+async def test_retry_error_delays_handler(
+        registry, handlers, extrahandlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    name1 = f'{cause_type}_fn'
+
+    cause_mock.event = cause_type
+    handlers.create_mock.side_effect = HandlerRetryError("oops")
+    handlers.update_mock.side_effect = HandlerRetryError("oops")
+    handlers.delete_mock.side_effect = HandlerRetryError("oops")
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.one_by_one,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
+    assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
+    assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.patch_obj.called
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert patch['status']['kopf']['progress'] is not None
+    assert 'failure' not in patch['status']['kopf']['progress'][name1]
+    assert 'success' not in patch['status']['kopf']['progress'][name1]
+    assert 'delayed' in patch['status']['kopf']['progress'][name1]
+
+    assert_logs([
+        "Handler .+ failed with a retry exception. Will retry.",
+    ])
+
+
+# The extrahandlers are needed to prevent the cycle ending and status purging.
+@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+async def test_arbitrary_error_delays_handler(
+        registry, handlers, extrahandlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    name1 = f'{cause_type}_fn'
+
+    cause_mock.event = cause_type
+    handlers.create_mock.side_effect = Exception("oops")
+    handlers.update_mock.side_effect = Exception("oops")
+    handlers.delete_mock.side_effect = Exception("oops")
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.one_by_one,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
+    assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
+    assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.patch_obj.called
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert patch['status']['kopf']['progress'] is not None
+    assert 'failure' not in patch['status']['kopf']['progress'][name1]
+    assert 'success' not in patch['status']['kopf']['progress'][name1]
+    assert 'delayed' in patch['status']['kopf']['progress'][name1]
+
+    assert_logs([
+        "Handler .+ failed with an exception. Will retry.",
+    ])

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -1,0 +1,41 @@
+import asyncio
+import logging
+
+import kopf
+from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.registries import GlobalRegistry
+
+
+async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, assert_logs):
+    detect_cause = mocker.patch('kopf.reactor.causation.detect_cause')
+    handle_cause = mocker.patch('kopf.reactor.handling.handle_cause')
+    patch_obj = mocker.patch('kopf.k8s.patching.patch_obj')
+    asyncio_sleep = mocker.patch('asyncio.sleep')
+
+    # Nothing of these is actually used, but we need to feed something.
+    # Except for namespace+name, which are used for the logger prefixes.
+    lifecycle = kopf.lifecycles.all_at_once
+    registry = GlobalRegistry()
+    event = {'object': {'metadata': {'namespace': 'ns1', 'name': 'name1'}}}
+
+    # This is what makes it frozen.
+    freeze = asyncio.Event()
+    freeze.set()
+
+    caplog.set_level(logging.DEBUG)
+    await custom_object_handler(
+        lifecycle=lifecycle,
+        registry=registry,
+        resource=resource,
+        event=event,
+        freeze=freeze,
+    )
+
+    assert not detect_cause.called
+    assert not handle_cause.called
+    assert not patch_obj.called
+    assert not asyncio_sleep.called
+
+    assert_logs([
+        r"\[ns1/name1\] Ignoring the events due to freeze.",
+    ])

--- a/tests/handling/test_handling.py
+++ b/tests/handling/test_handling.py
@@ -1,0 +1,255 @@
+import asyncio
+import logging
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import CREATE, UPDATE, DELETE, NEW, GONE, FREE, NOOP
+from kopf.reactor.handling import custom_object_handler
+from kopf.structs.finalizers import FINALIZER
+from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
+
+
+@pytest.mark.parametrize('cause_type', [NEW, CREATE, UPDATE, DELETE, NOOP, FREE, GONE])
+async def test_all_logs_are_prefixed(registry, resource, caplog, cause_type, cause_mock):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = cause_type
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+    assert all(message.startswith('[ns1/name1] ') for message in caplog.messages)
+
+
+async def test_new(registry, handlers, resource, cause_mock,
+                   caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = NEW
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+
+    assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.post_event.call_count == 0
+    assert k8s_mocked.patch_obj.call_count == 1
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert 'metadata' in patch
+    assert 'finalizers' in patch['metadata']
+    assert FINALIZER in patch['metadata']['finalizers']
+
+    assert_logs([
+        "First appearance",
+        "Adding the finalizer",
+        "Patching with",
+    ], strict=True)
+
+
+async def test_create(registry, handlers, resource, cause_mock,
+                      caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = CREATE
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert handlers.create_mock.call_count == 1
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+
+    assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.post_event.call_count >= 1
+    assert k8s_mocked.patch_obj.call_count == 1
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert 'metadata' in patch
+    assert 'annotations' in patch['metadata']
+    assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
+    assert 'status' in patch
+    assert 'kopf' in patch['status']
+    assert 'progress' in patch['status']['kopf']
+    assert patch['status']['kopf']['progress'] is None  # 1 out of 1 handlers done
+
+    assert_logs([
+        "Creation event:",
+        "Invoking handler 'create_fn'",
+        "Handler 'create_fn' succeeded",
+        "All handlers succeeded",
+        "Patching with",
+    ], strict=True)
+
+
+async def test_update(registry, handlers, resource, cause_mock,
+                      caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = UPDATE
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert not handlers.create_mock.called
+    assert handlers.update_mock.call_count == 1
+    assert not handlers.delete_mock.called
+
+    assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.post_event.call_count >= 1
+    assert k8s_mocked.patch_obj.call_count == 1
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert 'metadata' in patch
+    assert 'annotations' in patch['metadata']
+    assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
+    assert 'status' in patch
+    assert 'kopf' in patch['status']
+    assert 'progress' in patch['status']['kopf']
+    assert patch['status']['kopf']['progress'] is None  # 1 out of 1 handlers done
+
+    assert_logs([
+        "Update event:",
+        "Invoking handler 'update_fn'",
+        "Handler 'update_fn' succeeded",
+        "All handlers succeeded",
+        "Patching with",
+    ], strict=True)
+
+
+async def test_delete(registry, handlers, resource, cause_mock,
+                      caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = DELETE
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert handlers.delete_mock.call_count == 1
+
+    assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.post_event.call_count >= 1
+    assert k8s_mocked.patch_obj.call_count == 1
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert 'status' in patch
+    assert 'kopf' in patch['status']
+    assert 'progress' in patch['status']['kopf']
+    assert patch['status']['kopf']['progress'] is None  # 1 out of 1 handlers done
+
+    assert_logs([
+        "Deletion event",
+        "Invoking handler 'delete_fn'",
+        "Handler 'delete_fn' succeeded",
+        "All handlers succeeded",
+        "Removing the finalizer",
+        "Patching with",
+    ], strict=True)
+
+
+#
+# Informational causes: just log, and do nothing else.
+#
+
+async def test_gone(registry, handlers, resource, cause_mock,
+                    caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = GONE
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.post_event.called
+    assert not k8s_mocked.patch_obj.called
+
+    assert_logs([
+        "Deleted, really deleted",
+    ], strict=True)
+
+
+async def test_free(registry, handlers, resource, cause_mock,
+                    caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = FREE
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.post_event.called
+    assert not k8s_mocked.patch_obj.called
+
+    assert_logs([
+        "Deletion event, but we are done with it",
+    ], strict=True)
+
+
+async def test_noop(registry, handlers, resource, cause_mock,
+                    caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = NOOP
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.post_event.called
+    assert not k8s_mocked.patch_obj.called
+
+    assert_logs([
+        "Something has changed, but we are not interested",
+    ], strict=True)

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -1,0 +1,78 @@
+import asyncio
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.handling import custom_object_handler
+
+
+@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+async def test_1st_step_stores_progress_by_patching(
+        registry, handlers, extrahandlers,
+        resource, cause_mock, cause_type, k8s_mocked):
+    name1 = f'{cause_type}_fn'
+    name2 = f'{cause_type}_fn2'
+
+    cause_mock.event = cause_type
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.asap,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
+    assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
+    assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.patch_obj.called
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert patch['status']['kopf']['progress'] is not None
+
+    assert patch['status']['kopf']['progress'][name1]['retries'] == 1
+    assert patch['status']['kopf']['progress'][name1]['success'] is True
+
+    assert 'retries' not in patch['status']['kopf']['progress'][name2]
+    assert 'success' not in patch['status']['kopf']['progress'][name2]
+
+    assert 'started' in patch['status']['kopf']['progress'][name1]
+    assert 'started' in patch['status']['kopf']['progress'][name2]
+
+
+@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+async def test_2nd_step_finishes_the_handlers(
+        registry, handlers, extrahandlers,
+        resource, cause_mock, cause_type, k8s_mocked):
+    name1 = f'{cause_type}_fn'
+    name2 = f'{cause_type}_fn2'
+
+    cause_mock.event = cause_type
+    cause_mock.body.update({
+        'status': {'kopf': {'progress': {
+            name1: {'started': '1979-01-01T00:00:00', 'success': True},
+            name2: {'started': '1979-01-01T00:00:00'},
+        }}}
+    })
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.one_by_one,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert extrahandlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
+    assert extrahandlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
+    assert extrahandlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.patch_obj.called
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert patch['status']['kopf']['progress'] is None

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -1,0 +1,56 @@
+import asyncio
+import logging
+
+import freezegun
+import pytest
+
+import kopf
+from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.handling import custom_object_handler
+
+
+# The timeout is hard-coded in conftest.py:handlers().
+# The extrahandlers are needed to prevent the cycle ending and status purging.
+@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('now, ts', [
+    ['2099-12-31T23:59:59', '2020-01-01T00:00:00'],
+], ids=['slow'])
+async def test_timed_out_handler_fails(
+        registry, handlers, extrahandlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked, now, ts):
+    caplog.set_level(logging.DEBUG)
+    name1 = f'{cause_type}_fn'
+
+    cause_mock.event = cause_type
+    cause_mock.body.update({
+        'status': {'kopf': {'progress': {
+            'create_fn': {'started': ts},
+            'update_fn': {'started': ts},
+            'delete_fn': {'started': ts},
+        }}}
+    })
+
+    with freezegun.freeze_time(now):
+        await custom_object_handler(
+            lifecycle=kopf.lifecycles.one_by_one,
+            registry=registry,
+            resource=resource,
+            event={'type': 'irrelevant', 'object': cause_mock.body},
+            freeze=asyncio.Event(),
+        )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+
+    # Progress is reset, as the handler is not going to retry.
+    assert not k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.patch_obj.called
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert patch['status']['kopf']['progress'] is not None
+    assert patch['status']['kopf']['progress'][name1]['failure'] is True
+
+    assert_logs([
+        "Handler .+ failed with a fatal exception. Will stop.",
+    ])

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.reactor.handling import Cause
+from kopf.reactor.causation import Cause
 from kopf.reactor.invocation import invoke
 
 

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -1,8 +1,8 @@
 import pytest
 
 import kopf
+from kopf.reactor.causation import CREATE, UPDATE, DELETE
 from kopf.reactor.handling import subregistry_var
-from kopf.reactor.registries import CREATE, UPDATE, DELETE
 from kopf.reactor.registries import Resource, SimpleRegistry, GlobalRegistry
 
 


### PR DESCRIPTION
> Issue: #13

**Briefly:** add tests for the core part of Kopf: event handling.

This covers the whole chain of handling: from the raw streaming/watching event reception and down to the handler function invocation.

Two sections are explicitly separated from the previous handling routine — to make them testable:

* Cause detection (`kopf.reactor.causation`) — for converting all possible event type and object fields combinations to the cause objects.
* Cause handling (`kopf.reactor.handling`) — for actual handler invocation, logging, exception handling, status/progress storage, patching, sleeping, etc.

As part of this PR, a refactoring is made to split these two parts into separate modules, so that become testable.
