### PR TITLE
Document the operator maintenance

### DIFF
--- a/docs/continuity.rst
+++ b/docs/continuity.rst
@@ -1,0 +1,58 @@
+==========
+Continuity
+==========
+
+Persistence
+===========
+
+Kopf does not have any database. It stores all the information directly
+on the objects in the Kubernetes cluster (which means `etcd` usually).
+All information is retrieved and stored via the Kubernetes API.
+
+Specifically:
+
+* The cross-operator exchange is performed via the peering objects.
+  See :doc:`peering` for more info.
+* The last handled state of the object is stored in ``metadata.annotations``.
+  It is used for the diff calculation on the changes.
+* The handler status (failures, successes, retries, delays) is stored
+  in ``status.kopf.progress`` (with ``status.kopf`` reserved for any
+  framework-related information in the future).
+
+
+Restarts
+========
+
+It is safe to kill the operator's pod (or process), and allow it to restart.
+
+The handlers that succeeded previously, will not be re-executed.
+The handlers that did not execute yet, or were scheduled for retrying,
+will be retried by a new operators pod/process from the point where
+the old pod/process was terminated.
+
+The restart of an operator will only affect the handlers currently being
+executed in that operator at the moment of termination, as there is
+no record that they have succeeded.
+
+
+Downtime
+========
+
+If the operator is down and not running, any changes to the objects
+are ignored and not handled. They will be handled when the operator starts:
+every time a Kopf-based operator starts, it lists all objects of the served
+resource kind, and checks for their state; if the state has changed since
+the object was last handled (no matter how long time ago),
+a new handling cycle starts.
+
+Only the last state is taken into account. All the intermenient changes
+are accumulated and handled together.
+This corresponds to the Kubernetes'es concept of eventual consistency
+and level triggering (as opposed to edge triggering).
+
+.. warning::
+    If the operator is down, the objects cannot be deleted,
+    as they contain the Kopf's finalizers in ``metadata.finalizers``,
+    and Kubernetes blocks the deletion until all finalizers are removed.
+    If the operator is not running, the finalizers will never be removed.
+    See: :ref:`finalizers-blocking-deletion` for a work-around.

--- a/docs/continuity.rst
+++ b/docs/continuity.rst
@@ -14,7 +14,7 @@ Specifically:
 * The cross-operator exchange is performed via the peering objects.
   See :doc:`peering` for more info.
 * The last handled state of the object is stored in ``metadata.annotations``.
-  It is used for the diff calculation on the changes.
+  It is used to calculate diffs upon changes.
 * The handler status (failures, successes, retries, delays) is stored
   in ``status.kopf.progress`` (with ``status.kopf`` reserved for any
   framework-related information in the future).
@@ -25,12 +25,12 @@ Restarts
 
 It is safe to kill the operator's pod (or process), and allow it to restart.
 
-The handlers that succeeded previously, will not be re-executed.
+The handlers that succeeded previously will not be re-executed.
 The handlers that did not execute yet, or were scheduled for retrying,
 will be retried by a new operators pod/process from the point where
 the old pod/process was terminated.
 
-The restart of an operator will only affect the handlers currently being
+Restarting an operator will only affect the handlers currently being
 executed in that operator at the moment of termination, as there is
 no record that they have succeeded.
 
@@ -45,9 +45,9 @@ resource kind, and checks for their state; if the state has changed since
 the object was last handled (no matter how long time ago),
 a new handling cycle starts.
 
-Only the last state is taken into account. All the intermenient changes
+Only the last state is taken into account. All the intermediate changes
 are accumulated and handled together.
-This corresponds to the Kubernetes'es concept of eventual consistency
+This corresponds to the Kubernetes's concept of eventual consistency
 and level triggering (as opposed to edge triggering).
 
 .. warning::

--- a/docs/idempotence.rst
+++ b/docs/idempotence.rst
@@ -1,0 +1,55 @@
+===========
+Idempotence
+===========
+
+Kopf provides the tools to make the handlers idempotent.
+
+`kopf.register` function and `kopf.on.this` decorator allow to schedule
+arbitrary sub-handlers for the execution in the current cycle.
+
+`kopf.execute` coroutine executes arbitrary sub-handlers
+directly in the place of invocation, and returns when all they have succeeded.
+
+Every of the sub-handlers is tracked by Kopf, and will not be executed twice
+within one handling cycle.
+
+.. code-block:: python
+
+    import functools
+    import kopf
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
+    async def create(spec, namespace, **kwargs):
+        print("Entering create()!")  # executed ~7 times.
+        await kopf.execute(fns={
+            'a': create_a,
+            'b': create_b,
+        })
+        print("Leaving create()!")  # executed 1 time only.
+
+    async def create_a(retry, **kwargs):
+        if retry < 2:
+            raise kopf.HandlerRetryError("Not ready yet.", delay=10)
+
+    async def create_b(retry, **kwargs):
+        if retry < 6:
+            raise kopf.HandlerRetryError("Not ready yet.", delay=10)
+
+In this example, both ``create_a`` & ``create_b`` are submitted to Kopf
+as the sub-handlers of ``create`` on every attempt to execute it.
+It means, every ~10 seconds until both of the sub-handlers succeed,
+and the main handler succeeds too.
+
+The first one, ``create_a``, will succeed on the 3rd attempt after ~20s.
+The second one, ``create_b``, will succeed only on the 7th attempt after ~60s.
+
+However, despite ``create_a`` will be submitted every time when ``create``
+and ``create_b`` are retried, it will not be executed in the 20s..60s range,
+as it has succeeded already, and the record about this is stored on the object.
+
+This approach can be used to perform operations, which needs the protection
+from double-execution, such as the children object creation with randomly
+generated names (e.g. Pods, Jobs, PersistentVolumeClaims, etc).
+
+.. seealso::
+    :doc:`persistence`, :ref:`Sub-handlers`.

--- a/docs/idempotence.rst
+++ b/docs/idempotence.rst
@@ -2,7 +2,7 @@
 Idempotence
 ===========
 
-Kopf provides the tools to make the handlers idempotent.
+Kopf provides tools to make the handlers idempotent.
 
 `kopf.register` function and `kopf.on.this` decorator allow to schedule
 arbitrary sub-handlers for the execution in the current cycle.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,14 @@ Kopf: Kubernetes Operators Framework
 
 .. toctree::
    :maxdepth: 2
+   :caption: Maintenance:
+
+   continuity
+   idempotence
+   troubleshooting
+
+.. toctree::
+   :maxdepth: 2
    :caption: Developer Manual:
 
    minikube

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,26 @@
+===============
+Troubleshooting
+===============
+
+.. _finalizers-blocking-deletion:
+
+`kubectl` freezes on object deletion
+====================================
+
+This can happen if the operator is down at the moment of deletion.
+
+The operator puts the finalizers on the objects as soon as it notices
+them for the first time. When the objects are *requested for deletion*,
+Kopf calls the deletion handlers and removes the finalizers,
+thus releasing the object for the *actual deletion* by Kubernetes.
+
+If the object has to be deleted without the operator starting again,
+you can remove the finalizers manually:
+
+.. code-block:: bash
+
+    kubectl patch kopfexample kopf-example-1 -p '{"metadata": {"finalizers": []}}' --type merge
+
+The object will be removed by Kubernetes immediately.
+
+Alternatively, restart the operator, and allow it to remove the finalizers.


### PR DESCRIPTION
> Issue : closes #75, closes #12

Add some pages for the maintenance of the Kopf-based operators, describing their behaviour on downtime, on restarts, how they keep the persistence.

Add the troubleshooting page for some unexpected behaviour, to make it clear (e.g. #75).

_A new section was needed, as this kind of information does not fit to Tutorial, Features, About Kopf, and not even to the Developers Manual (which is about developing Kopf itself, not the Kopf-based operators)._

Preview:

* https://kopf-nolars-fork.readthedocs.io/en/docs-maintenance/continuity.html
* https://kopf-nolars-fork.readthedocs.io/en/docs-maintenance/idempotence.html
* https://kopf-nolars-fork.readthedocs.io/en/docs-maintenance/troubleshooting.html
