### PR TITLE
Add the silent spy-handlers for the raw events, no persistence

### DIFF
--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -65,7 +65,7 @@ The following keyword arguments are available to the handlers
 * ``logger`` is a per-object logger, with the messages prefixed with the object's namespace/name.
 * ``patch`` is a dict with the object changes to be applied after the handler.
 
-The high-level cause-handlers have additional keyword arguments reflecting their status:
+High-level cause-handlers have additional keyword arguments reflecting their status:
 
 * ``cause`` is the processed cause of the handler as detected by the framework (create/update/delete).
 * ``retry`` (``int``) is the sequential number of retry of this handler.
@@ -75,7 +75,7 @@ The high-level cause-handlers have additional keyword arguments reflecting their
 * ``old`` is the old state of the object or a field (only for the update events).
 * ``new`` is the new state of the object or a field (only for the update events).
 
-The low-level event-handlers have a slightly different set of keyword arguments:
+Low-level event-handlers have a slightly different set of keyword arguments:
 
 ** ``event`` for the raw event received; it is a dict with ``['type']`` & ``['object']`` keys.
 
@@ -87,7 +87,7 @@ in the future, and the existing handlers should accept them and not break.
 Event handlers
 ==============
 
-The low-level events can be intercepted and handled silently, without
+Low-level events can be intercepted and handled silently, without
 storing the handlers' status (errors, retries, successes) on the object.
 
 This can be useful if the operator needs to watch over the objects

--- a/examples/08-events/README.md
+++ b/examples/08-events/README.md
@@ -1,0 +1,52 @@
+# Kopf example with spy-handlers for the raw events
+
+Kopf stores its handler status on the objects' status field.
+This can be not desired when the objects do not belong to this operator,
+but a probably served by some other operator, and are just watched
+by the current operator, e.g. for their status fields.
+
+The event-handlers can be used as the silent spies on the raw events:
+they do not store anything on the object, and do not create the k8s-events.
+
+If the event handler fails, the error is logged to the operator's log,
+and then ignored.
+
+Please note that the event handlers are invoked for *every* event received
+from the watching stream. This also includes the first-time listing when
+the operator starts or restarts. It is the developer's responsibility to make
+the handlers idempotent (re-executable with do duplicated side-effects).
+
+Start the operator:
+
+```bash
+kopf run example.py --verbose
+```
+
+Trigger the object creation and monitor the stderr of the operator:
+
+```bash
+$ kubectl apply -f ../obj.yaml
+```
+
+Observe how the event-handlers are invoked.
+
+```
+[2019-05-28 11:03:29,537] kopf.reactor.handlin [DEBUG   ] [default/kopf-example-1] Invoking handler 'event_fn_with_error'.
+[2019-05-28 11:03:29,537] kopf.reactor.handlin [ERROR   ] [default/kopf-example-1] Handler 'event_fn_with_error' failed with an exception. Will ignore.
+Traceback (most recent call last):
+  File ".../kopf/reactor/handling.py", line 159, in handle_event
+  File ".../kopf/reactor/invocation.py", line 64, in invoke
+  File "example.py", line 6, in event_fn_with_error
+    raise Exception("Oops!")
+Exception: Oops!
+
+[2019-05-28 11:03:29,541] kopf.reactor.handlin [DEBUG   ] [default/kopf-example-1] Invoking handler 'normal_event_fn'.
+Event received: {'type': 'ADDED', 'object': {'apiVersion': 'zalando.org/v1', 'kind': 'KopfExample', ...}
+[2019-05-28 11:03:29,541] kopf.reactor.handlin [INFO    ] [default/kopf-example-1] Handler 'normal_event_fn' succeeded.
+```
+
+Cleanup in the end:
+
+```bash
+$ kubectl delete -f ../obj.yaml
+```

--- a/examples/08-events/README.md
+++ b/examples/08-events/README.md
@@ -5,7 +5,7 @@ This can be not desired when the objects do not belong to this operator,
 but a probably served by some other operator, and are just watched
 by the current operator, e.g. for their status fields.
 
-The event-handlers can be used as the silent spies on the raw events:
+Event-handlers can be used as the silent spies on the raw events:
 they do not store anything on the object, and do not create the k8s-events.
 
 If the event handler fails, the error is logged to the operator's log,

--- a/examples/08-events/example.py
+++ b/examples/08-events/example.py
@@ -1,0 +1,14 @@
+import kopf
+
+# Marks for the e2e tests (see tests/e2e/test_examples.py):
+E2E_TRACEBACKS = True
+
+
+@kopf.on.event('zalando.org', 'v1', 'kopfexamples')
+def event_fn_with_error(**kwargs):
+    raise Exception("Oops!")
+
+
+@kopf.on.event('zalando.org', 'v1', 'kopfexamples')
+def normal_event_fn(event, **kwargs):
+    print(f"Event received: {event!r}")

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -27,7 +27,7 @@ def create(
     """ ``@kopf.on.create()`` handler for the object creation. """
     registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn):
-        registry.register(
+        registry.register_cause_handler(
             group=group, version=version, plural=plural,
             event=causation.CREATE, id=id, timeout=timeout,
             fn=fn)
@@ -44,7 +44,7 @@ def update(
     """ ``@kopf.on.update()`` handler for the object update or change. """
     registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn):
-        registry.register(
+        registry.register_cause_handler(
             group=group, version=version, plural=plural,
             event=causation.UPDATE, id=id, timeout=timeout,
             fn=fn)
@@ -61,7 +61,7 @@ def delete(
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn):
-        registry.register(
+        registry.register_cause_handler(
             group=group, version=version, plural=plural,
             event=causation.DELETE, id=id, timeout=timeout,
             fn=fn)
@@ -79,10 +79,25 @@ def field(
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn):
-        registry.register(
+        registry.register_cause_handler(
             group=group, version=version, plural=plural,
             event=None, field=field, id=id, timeout=timeout,
             fn=fn)
+        return fn
+    return decorator
+
+
+def event(
+        group: str, version: str, plural: str,
+        *,
+        id: Optional[str] = None,
+        registry: Optional[registries.GlobalRegistry] = None):
+    """ ``@kopf.on.event()`` handler for the silent spies on the events. """
+    registry = registry if registry is not None else registries.get_default_registry()
+    def decorator(fn):
+        registry.register_event_handler(
+            group=group, version=version, plural=plural,
+            id=id, fn=fn)
         return fn
     return decorator
 

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -1,5 +1,5 @@
 """
-Conversion of the low-level events to the high-level causes, and handling them.
+Conversion of low-level events to high-level causes, and handling them.
 
 These functions are invoked from the queueing module `kopf.reactor.queueing`,
 which are the actual event loop of the operator process.

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -20,7 +20,6 @@ executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 async def invoke(
         fn: Callable,
         *args,
-        cause,
         **kwargs):
     """
     Invoke a single function, but safely for the main asyncio process.
@@ -37,22 +36,35 @@ async def invoke(
     """
 
     # Add aliases for the kwargs, directly linked to the body, or to the assumed defaults.
-    kwargs.update(
-        cause=cause,
-        event=cause.event,
-        body=cause.body,
-        diff=cause.diff,
-        old=cause.old,
-        new=cause.new,
-        patch=cause.patch,
-        logger=cause.logger,
-        spec=cause.body.setdefault('spec', {}),
-        meta=cause.body.setdefault('metadata', {}),
-        status=cause.body.setdefault('status', {}),
-        uid=cause.body.get('metadata', {}).get('uid'),
-        name=cause.body.get('metadata', {}).get('name'),
-        namespace=cause.body.get('metadata', {}).get('namespace'),
-    )
+    if 'event' in kwargs:
+        event = kwargs.get('event')
+        kwargs.update(
+            type=event['type'],
+            body=event['object'],
+            spec=event['object'].setdefault('spec', {}),
+            meta=event['object'].setdefault('metadata', {}),
+            status=event['object'].setdefault('status', {}),
+            uid=event['object'].get('metadata', {}).get('uid'),
+            name=event['object'].get('metadata', {}).get('name'),
+            namespace=event['object'].get('metadata', {}).get('namespace'),
+        )
+    if 'cause' in kwargs:
+        cause = kwargs.get('cause')
+        kwargs.update(
+            event=cause.event,
+            body=cause.body,
+            diff=cause.diff,
+            old=cause.old,
+            new=cause.new,
+            patch=cause.patch,
+            logger=cause.logger,
+            spec=cause.body.setdefault('spec', {}),
+            meta=cause.body.setdefault('metadata', {}),
+            status=cause.body.setdefault('status', {}),
+            uid=cause.body.get('metadata', {}).get('uid'),
+            name=cause.body.get('metadata', {}).get('name'),
+            namespace=cause.body.get('metadata', {}).get('namespace'),
+        )
 
     if is_async_fn(fn):
         result = await fn(*args, **kwargs)

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -138,7 +138,7 @@ class GlobalRegistry(BaseRegistry):
 
     def register_event_handler(self, group, version, plural, fn, id=None):
         """
-        Register an additional handler function for the low-level events.
+        Register an additional handler function for low-level events.
         """
         resource = Resource(group, version, plural)
         registry = self._event_handlers.setdefault(resource, SimpleRegistry())

--- a/kopf/structs/status.py
+++ b/kopf/structs/status.py
@@ -49,6 +49,8 @@ is not intended: otherwise, multiple distinct causes will clutter the status
 and collide with each other (especially critical for multiple updates).
 """
 
+import collections.abc
+import copy
 import datetime
 
 
@@ -144,9 +146,18 @@ def store_success(*, body, patch, handler, result=None):
         'retries': retry + 1,
         'message': None,
     })
-    if result is not None:
+    store_result(patch=patch, handler=handler, result=result)
+
+
+def store_result(*, patch, handler, result=None):
+    if result is None:
+        pass
+    elif isinstance(result, collections.abc.Mapping):
         # TODO: merge recursively (patch-merge), do not overwrite the keys if they are present.
         patch.setdefault('status', {}).setdefault(handler.id, {}).update(result)
+    else:
+        # TODO? Fail if already present?
+        patch.setdefault('status', {})[handler.id] = copy.deepcopy(result)
 
 
 def purge_progress(*, body, patch):

--- a/tests/cli/test_preloading.py
+++ b/tests/cli/test_preloading.py
@@ -16,7 +16,7 @@ def test_one_file(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._handlers[resource]._handlers
+    handlers = registry._cause_handlers[resource]._handlers
     assert len(handlers) == 1
     assert handlers[0].id == 'create_fn'
 
@@ -28,7 +28,7 @@ def test_two_files(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._handlers[resource]._handlers
+    handlers = registry._cause_handlers[resource]._handlers
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'
@@ -41,7 +41,7 @@ def test_one_module(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._handlers[resource]._handlers
+    handlers = registry._cause_handlers[resource]._handlers
     assert len(handlers) == 1
     assert handlers[0].id == 'create_fn'
 
@@ -53,7 +53,7 @@ def test_two_modules(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._handlers[resource]._handlers
+    handlers = registry._cause_handlers[resource]._handlers
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'
@@ -66,7 +66,7 @@ def test_mixed_sources(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._handlers[resource]._handlers
+    handlers = registry._cause_handlers[resource]._handlers
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -86,9 +86,11 @@ def registry(clear_default_registry):
 
 @dataclasses.dataclass(frozen=True, eq=False, order=False)
 class HandlersContainer:
+    event_mock: Mock
     create_mock: Mock
     update_mock: Mock
     delete_mock: Mock
+    event_fn: Callable
     create_fn: Callable
     update_fn: Callable
     delete_fn: Callable
@@ -96,9 +98,14 @@ class HandlersContainer:
 
 @pytest.fixture()
 def handlers(clear_default_registry):
+    event_mock = Mock(return_value=None)
     create_mock = Mock(return_value=None)
     update_mock = Mock(return_value=None)
     delete_mock = Mock(return_value=None)
+
+    @kopf.on.event('zalando.org', 'v1', 'kopfexamples', id='event_fn')
+    async def event_fn(**kwargs):
+        return event_mock(**kwargs)
 
     @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn', timeout=600)
     async def create_fn(**kwargs):
@@ -113,9 +120,11 @@ def handlers(clear_default_registry):
         return delete_mock(**kwargs)
 
     return HandlersContainer(
+        event_mock=event_mock,
         create_mock=create_mock,
         update_mock=update_mock,
         delete_mock=delete_mock,
+        event_fn=event_fn,
         create_fn=create_fn,
         update_fn=update_fn,
         delete_fn=delete_fn,
@@ -124,9 +133,14 @@ def handlers(clear_default_registry):
 
 @pytest.fixture()
 def extrahandlers(clear_default_registry, handlers):
+    event_mock = Mock(return_value=None)
     create_mock = Mock(return_value=None)
     update_mock = Mock(return_value=None)
     delete_mock = Mock(return_value=None)
+
+    @kopf.on.event('zalando.org', 'v1', 'kopfexamples', id='event_fn2')
+    async def event_fn2(**kwargs):
+        return event_mock(**kwargs)
 
     @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn2')
     async def create_fn2(**kwargs):
@@ -141,9 +155,11 @@ def extrahandlers(clear_default_registry, handlers):
         return delete_mock(**kwargs)
 
     return HandlersContainer(
+        event_mock=event_mock,
         create_mock=create_mock,
         update_mock=update_mock,
         delete_mock=delete_mock,
+        event_fn=event_fn2,
         create_fn=create_fn2,
         update_fn=update_fn2,
         delete_fn=delete_fn2,

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -55,7 +55,7 @@ async def test_new(registry, handlers, resource, cause_mock,
         "First appearance",
         "Adding the finalizer",
         "Patching with",
-    ], strict=True)
+    ])
 
 
 async def test_create(registry, handlers, resource, cause_mock,
@@ -94,7 +94,7 @@ async def test_create(registry, handlers, resource, cause_mock,
         "Handler 'create_fn' succeeded",
         "All handlers succeeded",
         "Patching with",
-    ], strict=True)
+    ])
 
 
 async def test_update(registry, handlers, resource, cause_mock,
@@ -133,7 +133,7 @@ async def test_update(registry, handlers, resource, cause_mock,
         "Handler 'update_fn' succeeded",
         "All handlers succeeded",
         "Patching with",
-    ], strict=True)
+    ])
 
 
 async def test_delete(registry, handlers, resource, cause_mock,
@@ -170,7 +170,7 @@ async def test_delete(registry, handlers, resource, cause_mock,
         "All handlers succeeded",
         "Removing the finalizer",
         "Patching with",
-    ], strict=True)
+    ])
 
 
 #
@@ -200,7 +200,7 @@ async def test_gone(registry, handlers, resource, cause_mock,
 
     assert_logs([
         "Deleted, really deleted",
-    ], strict=True)
+    ])
 
 
 async def test_free(registry, handlers, resource, cause_mock,
@@ -226,7 +226,7 @@ async def test_free(registry, handlers, resource, cause_mock,
 
     assert_logs([
         "Deletion event, but we are done with it",
-    ], strict=True)
+    ])
 
 
 async def test_noop(registry, handlers, resource, cause_mock,
@@ -252,4 +252,4 @@ async def test_noop(registry, handlers, resource, cause_mock,
 
     assert_logs([
         "Something has changed, but we are not interested",
-    ], strict=True)
+    ])

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -1,0 +1,67 @@
+import asyncio
+import logging
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import CREATE, UPDATE, DELETE, NEW, GONE, FREE, NOOP
+from kopf.reactor.handling import custom_object_handler
+
+
+@pytest.mark.parametrize('cause_type', [NEW, CREATE, UPDATE, DELETE, NOOP, FREE, GONE])
+async def test_handlers_called_always(
+        registry, handlers, extrahandlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = cause_type
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'ev-type', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert handlers.event_mock.call_count == 1
+    assert extrahandlers.event_mock.call_count == 1
+
+    event = handlers.event_mock.call_args_list[0][1]['event']
+    assert event['type'] == 'ev-type'
+    assert event['object'] is cause_mock.body
+    assert event['type'] == 'ev-type'
+    assert event['object'] is cause_mock.body
+
+    assert_logs([
+        "Invoking handler 'event_fn'.",
+        "Handler 'event_fn' succeeded.",
+        "Invoking handler 'event_fn2'.",
+        "Handler 'event_fn2' succeeded.",
+    ])
+
+
+@pytest.mark.parametrize('cause_type', [NEW, CREATE, UPDATE, DELETE, NOOP, FREE, GONE])
+async def test_errors_are_ignored(
+        registry, handlers, extrahandlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = cause_type
+    handlers.event_mock.side_effect = Exception("oops")
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'ev-type', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert handlers.event_mock.called
+    assert extrahandlers.event_mock.called
+
+    assert_logs([
+        "Invoking handler 'event_fn'.",
+        "Handler 'event_fn' failed with an exception. Will ignore.",
+        "Invoking handler 'event_fn2'.",
+        "Handler 'event_fn2' succeeded.",
+    ])

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -15,7 +15,7 @@ def test_on_create_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].event == CREATE
@@ -32,7 +32,7 @@ def test_on_update_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].event == UPDATE
@@ -49,7 +49,7 @@ def test_on_delete_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].event == DELETE
@@ -67,7 +67,7 @@ def test_on_field_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].event is None
@@ -92,7 +92,7 @@ def test_on_create_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].event == CREATE
@@ -111,7 +111,7 @@ def test_on_update_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].event == UPDATE
@@ -130,7 +130,7 @@ def test_on_delete_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].event == DELETE
@@ -150,7 +150,7 @@ def test_on_field_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].event is None
@@ -169,7 +169,7 @@ def test_subhandler_declaratively(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
 
@@ -184,6 +184,6 @@ def test_subhandler_imperatively(mocker):
         pass
     kopf.register(fn)
 
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn

--- a/tests/registries/test_global_registry.py
+++ b/tests/registries/test_global_registry.py
@@ -10,8 +10,8 @@ def some_fn():
 
 def test_resources():
     registry = GlobalRegistry()
-    registry.register('group1', 'version1', 'plural1', some_fn)
-    registry.register('group2', 'version2', 'plural2', some_fn)
+    registry.register_cause_handler('group1', 'version1', 'plural1', some_fn)
+    registry.register_cause_handler('group2', 'version2', 'plural2', some_fn)
 
     resources = registry.resources
 

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -24,7 +24,7 @@ def register_fn(registry, resource):
     if isinstance(registry, SimpleRegistry):
         return registry.register
     if isinstance(registry, GlobalRegistry):
-        return functools.partial(registry.register, resource.group, resource.version, resource.plural)
+        return functools.partial(registry.register_cause_handler, resource.group, resource.version, resource.plural)
     raise Exception(f"Unsupported registry type: {registry}")
 
 
@@ -58,19 +58,19 @@ def cause_any_diff(resource, request):
 
 def test_catchall_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, event=None, field=None)
-    handlers = registry.get_handlers(cause_any_diff)
+    handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, event=None, field='some-field')
-    handlers = registry.get_handlers(cause_with_diff)
+    handlers = registry.get_cause_handlers(cause_with_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, event=None, field='some-field')
-    handlers = registry.get_handlers(cause_no_diff)
+    handlers = registry.get_cause_handlers(cause_no_diff)
     assert not handlers
 
 #
@@ -80,31 +80,31 @@ def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_
 
 def test_relevant_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, event='some-event')
-    handlers = registry.get_handlers(cause_any_diff)
+    handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, event='some-event', field='some-field')
-    handlers = registry.get_handlers(cause_with_diff)
+    handlers = registry.get_cause_handlers(cause_with_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, event='some-event', field='some-field')
-    handlers = registry.get_handlers(cause_no_diff)
+    handlers = registry.get_cause_handlers(cause_no_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_without_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, event='another-event')
-    handlers = registry.get_handlers(cause_any_diff)
+    handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, event='another-event', field='another-field')
-    handlers = registry.get_handlers(cause_any_diff)
+    handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 #
@@ -119,7 +119,7 @@ def test_order_persisted_a(cause_with_diff, registry, register_fn):
     register_fn(some_fn, event=None, field='filtered-out-field')
     register_fn(some_fn, event=None, field='some-field')
 
-    handlers = registry.get_handlers(cause_with_diff)
+    handlers = registry.get_cause_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
     assert len(handlers) == 3
@@ -138,7 +138,7 @@ def test_order_persisted_b(cause_with_diff, registry, register_fn):
     register_fn(some_fn, event='some-event')
     register_fn(some_fn, event=None)
 
-    handlers = registry.get_handlers(cause_with_diff)
+    handlers = registry.get_cause_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
     assert len(handlers) == 3

--- a/tests/registries/test_id_detection.py
+++ b/tests/registries/test_id_detection.py
@@ -76,7 +76,7 @@ def test_with_no_hints(mocker):
 
     registry = SimpleRegistry()
     registry.register(some_fn)
-    handlers = registry.get_handlers(mocker.MagicMock())
+    handlers = registry.get_cause_handlers(mocker.MagicMock())
 
     assert get_fn_id.called
 
@@ -90,7 +90,7 @@ def test_with_prefix(mocker):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn)
-    handlers = registry.get_handlers(mocker.MagicMock())
+    handlers = registry.get_cause_handlers(mocker.MagicMock())
 
     assert get_fn_id.called
 
@@ -105,7 +105,7 @@ def test_with_suffix(mocker, field):
 
     registry = SimpleRegistry()
     registry.register(some_fn, field=field)
-    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -120,7 +120,7 @@ def test_with_prefix_and_suffix(mocker, field):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn, field=field)
-    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -135,7 +135,7 @@ def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn, id='explicit-id', field=field)
-    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
 
     assert not get_fn_id.called
 

--- a/tests/registries/test_registering.py
+++ b/tests/registries/test_registering.py
@@ -12,7 +12,7 @@ def test_simple_registry_via_iter(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
     registry = SimpleRegistry()
-    iterator = registry.iter_handlers(cause)
+    iterator = registry.iter_cause_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -27,7 +27,7 @@ def test_simple_registry_via_list(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
     registry = SimpleRegistry()
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -40,7 +40,7 @@ def test_simple_registry_with_minimal_signature(mocker):
 
     registry = SimpleRegistry()
     registry.register(some_fn)
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn
@@ -50,7 +50,7 @@ def test_global_registry_via_iter(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    iterator = registry.iter_handlers(cause)
+    iterator = registry.iter_cause_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -65,7 +65,7 @@ def test_global_registry_via_list(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    handlers = registry.get_handlers(cause)
+    handlers = registry.get_cause_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -77,8 +77,8 @@ def test_global_registry_with_minimal_signature(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    registry.register(resource.group, resource.version, resource.plural, some_fn)
-    handlers = registry.get_handlers(cause)
+    registry.register_cause_handler(resource.group, resource.version, resource.plural, some_fn)
+    handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -18,6 +18,7 @@ from kopf.structs.status import (
     set_retry_time,
     store_failure,
     store_success,
+    store_result,
     purge_progress,
 )
 
@@ -318,6 +319,21 @@ def test_store_success(handler, expected, body, result):
     store_success(body=body, patch=patch, handler=handler, result=result)
     assert patch == expected
     assert body == origbody  # not modified
+
+
+
+@pytest.mark.parametrize('result, expected', [
+    (None,
+     {}),
+    ({'field': 'value'},
+     {'status': {'some-id': {'field': 'value'}}}),
+    ('string',
+     {'status': {'some-id': 'string'}}),
+])
+def test_store_result(handler, expected, result):
+    patch = {}
+    store_result(patch=patch, handler=handler, result=result)
+    assert patch == expected
 
 
 @pytest.mark.parametrize('body', [


### PR DESCRIPTION
> Issue: closes #30

Add the simplistic event-handlers for spying on the low-level events of other resources,
not belonging to the operator (and not storing any status fields or finalizers or so).

The syntax is:

```python
import kopf

@kopf.on.event('zalando.org', 'v1', 'kopfexamples')
def event_fn(event, **kwargs):
    pass
```

The difference from the regular handlers is documented in the `docs/handlers.rst` (see the changed files). Briefly:

* No state storage on the objects.
* No annotations or finalizers added to the objects.
* No k8s-events posted for the activity (only the stdout/stderr logs).

Altogether, this means "silent" — the objects do not know they are being watched & handled (i.e. spied).

Checklist:

* [ ] Tests.
* [ ] Documentation.
