### PR TITLE
Suppress errors in event posting, and prevent them when possible

### DIFF
--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -1,4 +1,8 @@
 import pytest
+from kubernetes.client import V1Event as V1Event
+from kubernetes.client import V1EventSource as V1EventSource
+from kubernetes.client import V1ObjectMeta as V1ObjectMeta
+from kubernetes.client import V1beta1Event as V1beta1Event
 from kubernetes.client.rest import ApiException  # to avoid mocking it
 
 
@@ -8,4 +12,8 @@ from kubernetes.client.rest import ApiException  # to avoid mocking it
 def client_mock(mocker):
     client_mock = mocker.patch('kubernetes.client')
     client_mock.rest.ApiException = ApiException  # to be raises and caught
+    client_mock.V1Event = V1Event
+    client_mock.V1beta1Event = V1beta1Event
+    client_mock.V1EventSource = V1EventSource
+    client_mock.V1ObjectMeta = V1ObjectMeta
     return client_mock

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -1,18 +1,9 @@
 from asynctest import call, ANY
-from kubernetes.client import V1Event as V1Event_orig
-from kubernetes.client import V1EventSource as V1EventSource_orig
-from kubernetes.client import V1ObjectMeta as V1ObjectMeta_orig
-from kubernetes.client import V1beta1Event as V1beta1Event_orig
 
 from kopf.k8s.events import post_event
 
 
 def test_posting(client_mock):
-    client_mock.V1Event = V1Event_orig
-    client_mock.V1beta1Event = V1beta1Event_orig
-    client_mock.V1EventSource = V1EventSource_orig
-    client_mock.V1ObjectMeta = V1ObjectMeta_orig
-
     result = object()
     apicls_mock = client_mock.CoreV1Api
     apicls_mock.return_value.create_namespaced_event.return_value = result
@@ -32,7 +23,7 @@ def test_posting(client_mock):
         body=ANY,
     )]
 
-    event: V1Event_orig = postfn_mock.call_args_list[0][1]['body']
+    event = postfn_mock.call_args_list[0][1]['body']
     assert event.type == 'type'
     assert event.reason == 'reason'
     assert event.message == 'message'
@@ -44,10 +35,7 @@ def test_posting(client_mock):
     assert event.involved_object['uid'] == 'uid'
 
 
-def test_type_is_v1_not_v1beta1(client_mock, resource):
-    client_mock.V1Event = V1Event_orig
-    client_mock.V1beta1Event = V1beta1Event_orig
-
+def test_type_is_v1_not_v1beta1(client_mock):
     apicls_mock = client_mock.CoreV1Api
     postfn_mock = apicls_mock.return_value.create_namespaced_event
 
@@ -59,5 +47,5 @@ def test_type_is_v1_not_v1beta1(client_mock, resource):
     post_event(obj=obj, type='type', reason='reason', message='message')
 
     event = postfn_mock.call_args_list[0][1]['body']
-    assert isinstance(event, V1Event_orig)
-    assert not isinstance(event, V1beta1Event_orig)
+    assert isinstance(event, client_mock.V1Event)
+    assert not isinstance(event, client_mock.V1beta1Event)


### PR DESCRIPTION
> Issue : #87 

Handle the case when Kopf fails to post a Kubernetes event (for logging), and by doing so interrupts the handling cycle. The events are auxiliary by their nature, not mandatory. Their errors should not break the framework's or operator's behaviour. Yet they must be noticed (e.g. in logs).

With this PR, the event posting is changed:

* If any API error happens during posting an event, a warning is logged, but the operator continues to handle the resources. The event info and the error are both put to the logs for later investigation.
* The messages are cut to 1024 characters, keeping the starting and ending parts, and putting an infix in the middle. At least something will be posted, which is better than nothing at all.

By occasion also move the shared parts to conftest, as now we have more than 1 test for events.