### PR TITLE
Add the new-style events (of v1 core API) to the RBAC docs

### DIFF
--- a/docs/deployment-rbac.yaml
+++ b/docs/deployment-rbac.yaml
@@ -37,6 +37,9 @@ rules:
   - apiGroups: [events.k8s.io]
     resources: [events]
     verbs: [create]
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [create]
 
   # Application: watching & handling for the custom resource we declare.
   - apiGroups: [zalando.org]


### PR DESCRIPTION
> Issue : #76, follow up for #81

In #81, new events API was used, but the documentation was not updated with the proper RBAC file. 

It did not affect the behaviour of the framework or of operators, but can cause confusion with the new users.