### PR TITLE
Test for finalizers

### DIFF
--- a/kopf/structs/finalizers.py
+++ b/kopf/structs/finalizers.py
@@ -8,7 +8,8 @@ to "release" the object (e.g. cleanups; delete-handlers in our case).
 
 # A string marker to be put on the list of the finalizers to block
 # the object from being deleted without the permission of the framework.
-FINALIZER = 'KopfFinalizerMarker'
+FINALIZER = 'kopf.zalando.org/KopfFinalizerMarker'
+LEGACY_FINALIZER = 'KopfFinalizerMarker'
 
 
 def is_deleted(body):
@@ -16,7 +17,8 @@ def is_deleted(body):
 
 
 def has_finalizers(body):
-    return FINALIZER in body.get('metadata', {}).get('finalizers', [])
+    finalizers = body.get('metadata', {}).get('finalizers', [])
+    return FINALIZER in finalizers or LEGACY_FINALIZER in finalizers
 
 
 def append_finalizers(*, body, patch):
@@ -30,4 +32,7 @@ def remove_finalizers(*, body, patch):
     if has_finalizers(body=body):
         finalizers = body.get('metadata', {}).get('finalizers', [])
         patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))
-        patch['metadata']['finalizers'].remove(FINALIZER)
+        if LEGACY_FINALIZER in patch['metadata']['finalizers']:
+            patch['metadata']['finalizers'].remove(LEGACY_FINALIZER)
+        if FINALIZER in patch['metadata']['finalizers']:
+            patch['metadata']['finalizers'].remove(FINALIZER)

--- a/kopf/structs/finalizers.py
+++ b/kopf/structs/finalizers.py
@@ -16,7 +16,7 @@ def is_deleted(body):
 
 
 def has_finalizers(body):
-    return 'finalizers' in body['metadata'] and FINALIZER in body['metadata']['finalizers']
+    return FINALIZER in body.get('metadata', {}).get('finalizers', [])
 
 
 def append_finalizers(*, body, patch):

--- a/tests/test_finalizers.py
+++ b/tests/test_finalizers.py
@@ -1,0 +1,71 @@
+import pytest
+
+from kopf.structs.finalizers import FINALIZER
+from kopf.structs.finalizers import append_finalizers, remove_finalizers
+from kopf.structs.finalizers import is_deleted, has_finalizers
+
+
+@pytest.mark.parametrize('expected, body', [
+    pytest.param(True, {'metadata': {'deletionTimestamp': '2020-12-31T23:59:59'}}, id='time'),
+    pytest.param(False, {'metadata': {'deletionTimestamp': None}}, id='none'),
+    pytest.param(False, {'metadata': {}}, id='no-field'),
+    pytest.param(False, {}, id='no-metadata'),
+])
+def test_is_deleted(expected, body):
+    result = is_deleted(body=body)
+    assert result == expected
+
+
+@pytest.mark.parametrize('expected, body', [
+    pytest.param(False, {}, id='no-metadata'),
+    pytest.param(False, {'metadata': {}}, id='no-finalizers'),
+    pytest.param(False, {'metadata': {'finalizers': []}}, id='empty'),
+    pytest.param(False, {'metadata': {'finalizers': ['other']}}, id='others'),
+    pytest.param(True, {'metadata': {'finalizers': [FINALIZER]}}, id='ours'),
+    pytest.param(True, {'metadata': {'finalizers': ['other', FINALIZER]}}, id='mixed'),
+])
+def test_has_finalizers(expected, body):
+    result = has_finalizers(body=body)
+    assert result == expected
+
+
+def test_append_finalizers_to_others():
+    body = {'metadata': {'finalizers': ['other1', 'other2']}}
+    patch = {}
+    append_finalizers(body=body, patch=patch)
+    assert patch == {'metadata': {'finalizers': ['other1', 'other2', FINALIZER]}}
+
+
+def test_append_finalizers_to_empty():
+    body = {}
+    patch = {}
+    append_finalizers(body=body, patch=patch)
+    assert patch == {'metadata': {'finalizers': [FINALIZER]}}
+
+
+def test_append_finalizers_when_present():
+    body = {'metadata': {'finalizers': ['other1', FINALIZER, 'other2']}}
+    patch = {}
+    append_finalizers(body=body, patch=patch)
+    assert patch == {}
+
+
+def test_remove_finalizers_keeps_others():
+    body = {'metadata': {'finalizers': ['other1', FINALIZER, 'other2']}}
+    patch = {}
+    remove_finalizers(body=body, patch=patch)
+    assert patch == {'metadata': {'finalizers': ['other1', 'other2']}}
+
+
+def test_remove_finalizers_when_absetn():
+    body = {'metadata': {'finalizers': ['other1', 'other2']}}
+    patch = {}
+    remove_finalizers(body=body, patch=patch)
+    assert patch == {}
+
+
+def test_remove_finalizers_when_empty():
+    body = {}
+    patch = {}
+    remove_finalizers(body=body, patch=patch)
+    assert patch == {}


### PR DESCRIPTION
> Issue : #13 

Add tests for the finalizers: appending, removing, checking.

Also change the finalizer to a FQDN string — as once I hit the issue that the finalizer cannot be an arbitrary string (e.g. when assigning it to a pod in Minikube; but it works with custom resources though).

But keep the legacy finalizer (just a string, not FQDN) if it is assigned to the existing resource — for checking and for removing.
