### PR TITLE
RBAC for automatic legacy peering detection

### DIFF
--- a/docs/deployment-rbac.yaml
+++ b/docs/deployment-rbac.yaml
@@ -15,6 +15,9 @@ rules:
   - apiGroups: [zalando.org]
     resources: [clusterkopfpeerings]
     verbs: [list, watch, patch, get]
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [list, get]
 
   # Application: read-only access for watching cluster-wide.
   - apiGroups: [zalando.org]

--- a/kopf/k8s/fetching.py
+++ b/kopf/k8s/fetching.py
@@ -12,7 +12,7 @@ def read_crd(*, resource, default=_UNSET_):
         rsp = api.read_custom_resource_definition(name=name)
         return rsp
     except kubernetes.client.rest.ApiException as e:
-        if e.status == 404 and default is not _UNSET_:
+        if e.status in [404, 403] and default is not _UNSET_:
             return default
         raise
 

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -47,12 +47,13 @@ def test_when_successful_namespaced(client_mock, resource):
 
 
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
-def test_raises_api_error(client_mock, resource, namespace):
-    error = kubernetes.client.rest.ApiException(status=666)
+@pytest.mark.parametrize('status', [400, 401, 403, 500, 666])
+def test_raises_api_error(client_mock, resource, namespace, status):
+    error = kubernetes.client.rest.ApiException(status=status)
     apicls_mock = client_mock.CustomObjectsApi
     apicls_mock.return_value.list_cluster_custom_object.side_effect = error
     apicls_mock.return_value.list_namespaced_custom_object.side_effect = error
 
     with pytest.raises(kubernetes.client.rest.ApiException) as e:
         list_objs(resource=resource, namespace=namespace)
-    assert e.value.status == 666
+    assert e.value.status == status

--- a/tests/k8s/test_make_list_fn.py
+++ b/tests/k8s/test_make_list_fn.py
@@ -63,8 +63,9 @@ def test_when_present_namespaced(client_mock, resource):
 
 
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
-def test_raises_api_error(client_mock, resource, namespace):
-    error = kubernetes.client.rest.ApiException(status=666)
+@pytest.mark.parametrize('status', [400, 401, 403, 404, 500, 666])
+def test_raises_api_error(client_mock, resource, namespace, status):
+    error = kubernetes.client.rest.ApiException(status=status)
     apicls_mock = client_mock.CustomObjectsApi
     apicls_mock.return_value.list_cluster_custom_object.side_effect = error
     apicls_mock.return_value.list_namespaced_custom_object.side_effect = error
@@ -72,7 +73,7 @@ def test_raises_api_error(client_mock, resource, namespace):
     fn = make_list_fn(resource=resource, namespace=namespace)
     with pytest.raises(kubernetes.client.rest.ApiException) as e:
         fn(opt1='val1', opt2=123)
-    assert e.value.status == 666
+    assert e.value.status == status
 
 
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])

--- a/tests/k8s/test_read_crd.py
+++ b/tests/k8s/test_read_crd.py
@@ -22,7 +22,7 @@ def test_when_present(client_mock, resource):
     ]
 
 
-@pytest.mark.parametrize('status', [404])
+@pytest.mark.parametrize('status', [403, 404])
 def test_when_absent_with_no_default(client_mock, resource, status):
     error = kubernetes.client.rest.ApiException(status=status)
     apicls_mock = client_mock.ApiextensionsV1beta1Api
@@ -34,7 +34,7 @@ def test_when_absent_with_no_default(client_mock, resource, status):
 
 
 @pytest.mark.parametrize('default', [None, object()], ids=['none', 'object'])
-@pytest.mark.parametrize('status', [404])
+@pytest.mark.parametrize('status', [403, 404])
 def test_when_absent_with_default(client_mock, resource, default, status):
     error = kubernetes.client.rest.ApiException(status=status)
     apicls_mock = client_mock.ApiextensionsV1beta1Api
@@ -44,7 +44,7 @@ def test_when_absent_with_default(client_mock, resource, default, status):
     assert crd is default
 
 
-@pytest.mark.parametrize('status', [400, 401, 403, 500, 666])
+@pytest.mark.parametrize('status', [400, 401, 500, 666])
 def test_raises_api_error_despite_default(client_mock, resource, status):
     error = kubernetes.client.rest.ApiException(status=status)
     apicls_mock = client_mock.ApiextensionsV1beta1Api

--- a/tests/k8s/test_read_obj.py
+++ b/tests/k8s/test_read_obj.py
@@ -49,21 +49,23 @@ def test_when_present_namespaced(client_mock, resource):
 
 
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
-def test_when_absent_with_no_default(client_mock, resource, namespace):
-    error = kubernetes.client.rest.ApiException(status=404)
+@pytest.mark.parametrize('status', [404])
+def test_when_absent_with_no_default(client_mock, resource, namespace, status):
+    error = kubernetes.client.rest.ApiException(status=status)
     apicls_mock = client_mock.CustomObjectsApi
     apicls_mock.return_value.get_cluster_custom_object.side_effect = error
     apicls_mock.return_value.get_namespaced_custom_object.side_effect = error
 
     with pytest.raises(kubernetes.client.rest.ApiException) as e:
         read_obj(resource=resource, namespace=namespace, name='name1')
-    assert e.value.status == 404
+    assert e.value.status == status
 
 
 @pytest.mark.parametrize('default', [None, object()], ids=['none', 'object'])
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
-def test_when_absent_with_default(client_mock, resource, namespace, default):
-    error = kubernetes.client.rest.ApiException(status=404)
+@pytest.mark.parametrize('status', [404])
+def test_when_absent_with_default(client_mock, resource, namespace, default, status):
+    error = kubernetes.client.rest.ApiException(status=status)
     apicls_mock = client_mock.CustomObjectsApi
     apicls_mock.return_value.get_cluster_custom_object.side_effect = error
     apicls_mock.return_value.get_namespaced_custom_object.side_effect = error
@@ -73,12 +75,13 @@ def test_when_absent_with_default(client_mock, resource, namespace, default):
 
 
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
-def test_raises_api_error_despite_default(client_mock, resource, namespace):
-    error = kubernetes.client.rest.ApiException(status=666)
+@pytest.mark.parametrize('status', [400, 401, 403, 500, 666])
+def test_raises_api_error_despite_default(client_mock, resource, namespace, status):
+    error = kubernetes.client.rest.ApiException(status=status)
     apicls_mock = client_mock.CustomObjectsApi
     apicls_mock.return_value.get_cluster_custom_object.side_effect = error
     apicls_mock.return_value.get_namespaced_custom_object.side_effect = error
 
     with pytest.raises(kubernetes.client.rest.ApiException) as e:
         read_obj(resource=resource, namespace=namespace, name='name1', default=object())
-    assert e.value.status == 666
+    assert e.value.status == status


### PR DESCRIPTION
> Issue : #12, #13, originally mentioned in #49 comments

Add the missing RBAC permissions for legacy CRD scanning in the documentation (deployment patterns, RBAC section).

Since CRD scanning is a cluster-scoped operation, and cluster-scoped RBAC is not always possible, make so that the "403 permission denied" response for CRDs is treated as the absence of CRD. It is currently only used for legacy peering CRD, and nothing else.

As part of that, in tests, also check for other typical statuses for all get/list API operations — via parametrization.

_PS: The feature was introduced in the automatic peering/standalone mode discovery (#33 #38)._
