### PR TITLE
Skip handling & logging when there are no handlers

### DIFF
--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -37,6 +37,12 @@ NOOP = 'noop'
 FREE = 'free'
 GONE = 'gone'
 
+# These sets are checked in few places, so we keep them centralised:
+# the user-facing causes (for handlers), and internally facing (so as handled).
+HANDLER_CAUSES = (CREATE, UPDATE, DELETE)
+REACTOR_CAUSES = (NEW, NOOP, FREE, GONE)
+ALL_CAUSES = HANDLER_CAUSES + REACTOR_CAUSES
+
 # The human-readable names of these causes. Will be capitalised when needed.
 TITLES = {
     CREATE: 'creation',

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -182,7 +182,7 @@ async def handle_cause(
     done = None
 
     # Regular causes invoke the handlers.
-    if cause.event in [causation.CREATE, causation.UPDATE, causation.DELETE]:
+    if cause.event in causation.HANDLER_CAUSES:
         title = causation.TITLES.get(cause.event, repr(cause.event))
         logger.debug(f"{title.capitalize()} event: %r", body)
         try:

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -39,9 +39,7 @@ def test_all_examples_are_runnable(mocker, with_crd, with_peering, exampledir):
     # This just shows us that the operator is doing something, it is alive.
     assert '[default/kopf-example-1] First appearance:' in runner.stdout
     assert '[default/kopf-example-1] Creation event:' in runner.stdout
-    assert '[default/kopf-example-1] All handlers succeeded for creation' in runner.stdout
     assert '[default/kopf-example-1] Deletion event:' in runner.stdout
-    assert '[default/kopf-example-1] All handlers succeeded for deletion' in runner.stdout
     assert '[default/kopf-example-1] Deleted, really deleted' in runner.stdout
     if not e2e_tracebacks:
         assert 'Traceback (most recent call last):' not in runner.stdout

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -4,13 +4,13 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import CREATE, UPDATE, DELETE, NEW, GONE, FREE, NOOP
+from kopf.reactor.causation import ALL_CAUSES, CREATE, UPDATE, DELETE, NEW, GONE, FREE, NOOP
 from kopf.reactor.handling import custom_object_handler
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 
 
-@pytest.mark.parametrize('cause_type', [NEW, CREATE, UPDATE, DELETE, NOOP, FREE, GONE])
+@pytest.mark.parametrize('cause_type', ALL_CAUSES)
 async def test_all_logs_are_prefixed(registry, resource, caplog, cause_type, cause_mock):
     caplog.set_level(logging.DEBUG)
     cause_mock.event = cause_type

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -5,13 +5,13 @@ import freezegun
 import pytest
 
 import kopf
-from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE
 from kopf.reactor.handling import HandlerRetryError
 from kopf.reactor.handling import WAITING_KEEPALIVE_INTERVAL
 from kopf.reactor.handling import custom_object_handler
 
 
-@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
 @pytest.mark.parametrize('now, ts, delay', [
     ['2020-01-01T00:00:00', '2020-01-01T00:04:56.789000', 4 * 60 + 56.789],
 ], ids=['fast'])
@@ -52,7 +52,7 @@ async def test_delayed_handlers_progress(
     ])
 
 
-@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
 @pytest.mark.parametrize('now, ts, delay', [
     ['2020-01-01T00:00:00', '2020-01-01T00:04:56.789000', 4 * 60 + 56.789],
     ['2020-01-01T00:00:00', '2099-12-31T23:59:59.000000', WAITING_KEEPALIVE_INTERVAL],

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -4,13 +4,13 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE
 from kopf.reactor.handling import HandlerFatalError, HandlerRetryError
 from kopf.reactor.handling import custom_object_handler
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
-@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
 async def test_fatal_error_stops_handler(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
@@ -48,7 +48,7 @@ async def test_fatal_error_stops_handler(
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
-@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
 async def test_retry_error_delays_handler(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
@@ -87,7 +87,7 @@ async def test_retry_error_delays_handler(
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
-@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
 async def test_arbitrary_error_delays_handler(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -4,11 +4,11 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import CREATE, UPDATE, DELETE, NEW, GONE, FREE, NOOP
+from kopf.reactor.causation import ALL_CAUSES
 from kopf.reactor.handling import custom_object_handler
 
 
-@pytest.mark.parametrize('cause_type', [NEW, CREATE, UPDATE, DELETE, NOOP, FREE, GONE])
+@pytest.mark.parametrize('cause_type', ALL_CAUSES)
 async def test_handlers_called_always(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
@@ -40,7 +40,7 @@ async def test_handlers_called_always(
     ])
 
 
-@pytest.mark.parametrize('cause_type', [NEW, CREATE, UPDATE, DELETE, NOOP, FREE, GONE])
+@pytest.mark.parametrize('cause_type', ALL_CAUSES)
 async def test_errors_are_ignored(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -3,11 +3,11 @@ import asyncio
 import pytest
 
 import kopf
-from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE
 from kopf.reactor.handling import custom_object_handler
 
 
-@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
 async def test_1st_step_stores_progress_by_patching(
         registry, handlers, extrahandlers,
         resource, cause_mock, cause_type, k8s_mocked):
@@ -44,7 +44,7 @@ async def test_1st_step_stores_progress_by_patching(
     assert 'started' in patch['status']['kopf']['progress'][name2]
 
 
-@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
 async def test_2nd_step_finishes_the_handlers(
         registry, handlers, extrahandlers,
         resource, cause_mock, cause_type, k8s_mocked):

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -1,0 +1,51 @@
+import asyncio
+import logging
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import HANDLER_CAUSES
+from kopf.reactor.handling import custom_object_handler
+from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
+
+
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+async def test_skipped_with_no_handlers(
+        registry, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = cause_type
+
+    assert not registry.has_cause_handlers(resource=resource)  # prerequisite
+    registry.register_cause_handler(
+        group=resource.group,
+        version=resource.version,
+        plural=resource.plural,
+        event='a-non-existent-cause-type',
+        fn=lambda **_: None,
+    )
+    assert registry.has_cause_handlers(resource=resource)  # prerequisite
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+
+    assert not k8s_mocked.asyncio_sleep.called
+    assert k8s_mocked.patch_obj.called
+
+    # The patch must contain ONLY the last-seen update, and nothing else.
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert set(patch.keys()) == {'metadata'}
+    assert set(patch['metadata'].keys()) == {'annotations'}
+    assert set(patch['metadata']['annotations'].keys()) == {LAST_SEEN_ANNOTATION}
+
+    assert_logs([
+        ".* event:",
+        "Patching with:",
+    ], prohibited=[
+        "All handlers succeeded",
+    ])

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -5,13 +5,13 @@ import freezegun
 import pytest
 
 import kopf
-from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.causation import HANDLER_CAUSES
 from kopf.reactor.handling import custom_object_handler
 
 
 # The timeout is hard-coded in conftest.py:handlers().
 # The extrahandlers are needed to prevent the cycle ending and status purging.
-@pytest.mark.parametrize('cause_type', [CREATE, UPDATE, DELETE])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
 @pytest.mark.parametrize('now, ts', [
     ['2099-12-31T23:59:59', '2020-01-01T00:00:00'],
 ], ids=['slow'])


### PR DESCRIPTION
> Issue : #60

## Description

Currently, if there are no handlers, the handling attempt is anyway done, and the messages are logged that all handlers (zero out of zero) have succeeded.

With this PR, Kopf does not even attempt doing the handling cycle, if there are no handlers for the current event/cause. This also eliminates the unnecessary logging for fake handling cycles.

## Notes

This PR is part of a chain leading to the resuming handlers on operator restarts: #103 -> #104 -> #105.

## Refactoring

For simplicity in the future, a little refactoring is also performed: all causes are grouped into the internal and user-facing causes.

Also, the handling stack is now one call shorter (the all-purpose `execute()` is bypassed):

* Now:`custom_object_handler→handle_cause→_execute→call_handler`
* Was: `custom_object_handler→handle_cause→execute→_execute→call_handler`


## Types of Changes

- Refactor/improvements
