### PR TITLE
Log diffs when present

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -184,8 +184,12 @@ async def handle_cause(
 
     # Regular causes invoke the handlers.
     if cause.event in causation.HANDLER_CAUSES:
+
         title = causation.TITLES.get(cause.event, repr(cause.event))
         logger.debug(f"{title.capitalize()} event: %r", body)
+        if cause.diff is not None:
+            logger.debug(f"{title.capitalize()} diff: %r", cause.diff)
+
         handlers = registry.get_cause_handlers(cause=cause)
         if handlers:
             try:

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -176,14 +176,17 @@ def cause_mock(mocker, resource):
         # Avoid collision of our mocked values with the passed kwargs.
         original_event = kwargs.pop('event', None)
         original_body = kwargs.pop('body', None)
+        original_diff = kwargs.pop('diff', None)
         event = mock.event if mock.event is not None else original_event
         body = copy.deepcopy(mock.body) if mock.body is not None else original_body
+        diff = copy.deepcopy(mock.diff) if mock.diff is not None else original_diff
 
         # Pass through kwargs: resource, logger, patch, diff, old, new.
         # I.e. everything except what we mock: event & body.
         cause = Cause(
             event=event,
             body=body,
+            diff=diff,
             **kwargs)
 
         # Needed for the k8s-event creation, as they are attached to objects.
@@ -199,7 +202,8 @@ def cause_mock(mocker, resource):
     mocker.patch('kopf.reactor.causation.detect_cause', new=new_detect_fn)
 
     # The mock object stores some values later used by the factory substitute.
-    mock = mocker.Mock(spec_set=['event', 'body'])
+    mock = mocker.Mock(spec_set=['event', 'body', 'diff'])
     mock.event = None
     mock.body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    mock.diff = None
     return mock

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -1,28 +1,11 @@
 import asyncio
 import logging
 
-import pytest
-
 import kopf
-from kopf.reactor.causation import ALL_CAUSES, CREATE, UPDATE, DELETE, NEW, GONE, FREE, NOOP
+from kopf.reactor.causation import CREATE, UPDATE, DELETE, NEW, GONE, FREE, NOOP
 from kopf.reactor.handling import custom_object_handler
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
-
-
-@pytest.mark.parametrize('cause_type', ALL_CAUSES)
-async def test_all_logs_are_prefixed(registry, resource, caplog, cause_type, cause_mock):
-    caplog.set_level(logging.DEBUG)
-    cause_mock.event = cause_type
-
-    await custom_object_handler(
-        lifecycle=kopf.lifecycles.all_at_once,
-        registry=registry,
-        resource=resource,
-        event={'type': 'irrelevant', 'object': cause_mock.body},
-        freeze=asyncio.Event(),
-    )
-    assert all(message.startswith('[ns1/name1] ') for message in caplog.messages)
 
 
 async def test_new(registry, handlers, resource, cause_mock,

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -9,7 +9,8 @@ from kopf.reactor.handling import custom_object_handler
 
 
 @pytest.mark.parametrize('cause_type', ALL_CAUSES)
-async def test_all_logs_are_prefixed(registry, resource, caplog, cause_type, cause_mock):
+async def test_all_logs_are_prefixed(registry, resource, handlers,
+                                     caplog, cause_type, cause_mock):
     caplog.set_level(logging.DEBUG)
     cause_mock.event = cause_type
 
@@ -20,4 +21,5 @@ async def test_all_logs_are_prefixed(registry, resource, caplog, cause_type, cau
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
     )
+    assert caplog.messages  # no messages means that we cannot test it
     assert all(message.startswith('[ns1/name1] ') for message in caplog.messages)

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -1,0 +1,23 @@
+import asyncio
+import logging
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import ALL_CAUSES
+from kopf.reactor.handling import custom_object_handler
+
+
+@pytest.mark.parametrize('cause_type', ALL_CAUSES)
+async def test_all_logs_are_prefixed(registry, resource, caplog, cause_type, cause_mock):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = cause_type
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+    assert all(message.startswith('[ns1/name1] ') for message in caplog.messages)

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import ALL_CAUSES
+from kopf.reactor.causation import ALL_CAUSES, HANDLER_CAUSES
 from kopf.reactor.handling import custom_object_handler
 
 
@@ -23,3 +23,49 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
     )
     assert caplog.messages  # no messages means that we cannot test it
     assert all(message.startswith('[ns1/name1] ') for message in caplog.messages)
+
+
+@pytest.mark.parametrize('diff', [
+    pytest.param((('op', ('field',), 'old', 'new'),), id='realistic-diff'),
+    pytest.param((), id='empty-tuple-diff'),
+    pytest.param([], id='empty-list-diff'),
+])
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+async def test_diffs_logged_if_present(registry, resource, handlers, cause_type, cause_mock,
+                                       caplog, assert_logs, diff):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = cause_type
+    cause_mock.diff = diff
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+    assert_logs([
+        " event: ",
+        " diff: "
+    ])
+
+
+@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+async def test_diffs_not_logged_if_absent(registry, resource, handlers, cause_type, cause_mock,
+                                          caplog, assert_logs):
+    caplog.set_level(logging.DEBUG)
+    cause_mock.event = cause_type
+    cause_mock.diff = None  # same as the default, but for clarity
+
+    await custom_object_handler(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+    )
+    assert_logs([
+        " event: ",
+    ], prohibited=[
+        " diff: "
+    ])


### PR DESCRIPTION
> Issue : caused by #13 + #82

## Description

Log diffs during the handling cycles if there are detected diffs — usually on the `@kopf.on.update` handlers.

Since the recent unification of handling routines (#82), the logs were changed to the event dumps, and the update-diffs dumps were removed. 

Now, they can be seen (e.g. for debugging), in addition to the event dumps.


## Types of Changes

- Refactor/improvements
