### PR TITLE
Add "resuming" handlers for resources (as co-handlers)

### DIFF
--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -147,6 +147,31 @@ The following 3 core cause-handlers are available::
     def my_handler(spec, **_):
         pass
 
+An additional handler can be used for cases when the operator restarts
+and detects an object that existed before, but was not changed/deleted
+during downtime (which would trigger the update-/delete-handlers)::
+
+    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples')
+    def my_handler(spec, **_):
+        pass
+
+This handler can be used to start threads or asyncio tasks or to update
+a global state to keep it consistent with the actual state of the cluster.
+With the resuming handler in addition to creation/update/deletion handlers,
+no object will be left unattended even if it does not change over time.
+
+.. note::
+    Kopf does its best to call the resuming handler only once per object
+    for every running process of Kopf.
+
+    But due to the nature of Kubernetes watching, which needs the full reset
+    from time to time, there is no guarantee that the handler will not be called
+    few times over lifetime of a single operator process.
+
+    It is the developer's responsibility to ensure that the threads/tasks
+    or other state are maintained properly for multiple resuming calls.
+
+
 
 Field handlers
 ==============

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -18,6 +18,23 @@ from kopf.reactor import handling
 from kopf.reactor import registries
 
 
+def resume(
+        group: str, version: str, plural: str,
+        *,
+        id: Optional[str] = None,
+        timeout: Optional[float] = None,
+        registry: Optional[registries.GlobalRegistry] = None):
+    """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
+    registry = registry if registry is not None else registries.get_default_registry()
+    def decorator(fn):
+        registry.register_cause_handler(
+            group=group, version=version, plural=plural,
+            event=None, initial=True, id=id, timeout=timeout,
+            fn=fn)
+        return fn
+    return decorator
+
+
 def create(
         group: str, version: str, plural: str,
         *,

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -61,6 +61,7 @@ class Cause(NamedTuple):
     logger: Union[logging.Logger, logging.LoggerAdapter]
     resource: registries.Resource
     event: Text
+    initial: bool
     body: MutableMapping
     patch: MutableMapping
     diff: Optional[diffs.Diff] = None
@@ -81,12 +82,14 @@ def detect_cause(
     and other side-effects.
     """
     body = event['object']
+    initial = event['type'] is None  # special value simulated by us in kopf.reactor.watching.
 
     # The object was really deleted from the cluster. But we do not care anymore.
     if event['type'] == 'DELETED':
         return Cause(
             event=GONE,
             body=body,
+            initial=initial,
             **kwargs)
 
     # The finalizer has been just removed. We are fully done.
@@ -94,12 +97,14 @@ def detect_cause(
         return Cause(
             event=FREE,
             body=body,
+            initial=initial,
             **kwargs)
 
     if finalizers.is_deleted(body):
         return Cause(
             event=DELETE,
             body=body,
+            initial=initial,
             **kwargs)
 
     # For a fresh new object, first block it from accidental deletions without our permission.
@@ -108,6 +113,7 @@ def detect_cause(
         return Cause(
             event=NEW,
             body=body,
+            initial=initial,
             **kwargs)
 
     # For an object seen for the first time (i.e. just-created), call the creation handlers,
@@ -116,6 +122,7 @@ def detect_cause(
         return Cause(
             event=CREATE,
             body=body,
+            initial=initial,
             **kwargs)
 
     # The previous step triggers one more patch operation without actual changes. Ignore it.
@@ -124,6 +131,7 @@ def detect_cause(
         return Cause(
             event=NOOP,
             body=body,
+            initial=initial,
             **kwargs)
 
     # And what is left, is the update operation on one of the useful fields of the existing object.
@@ -131,6 +139,7 @@ def detect_cause(
     return Cause(
         event=UPDATE,
         body=body,
+        initial=initial,
         diff=diff,
         old=old,
         new=new,

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -59,7 +59,7 @@ class BaseRegistry(metaclass=abc.ABCMeta):
             @kopf.on.resume(...)
             def fn(**kwargs): pass
 
-        In normal case, the function will be called either on resource creation,
+        In normal cases, the function will be called either on resource creation
         or on operator restart for the pre-existing (already handled) resources.
         When a resource is created during the operator downtime, it is
         both creation and resuming at the same time: the object is new (not yet
@@ -115,7 +115,7 @@ class SimpleRegistry(BaseRegistry):
         for handler in self._handlers:
             if handler.event is None or handler.event == cause.event:
                 if handler.initial and not cause.initial:
-                    pass  # ignore initial handlers in the non-initial causes.
+                    pass  # ignore initial handlers in non-initial causes.
                 elif handler.field:
                     if any(field[:len(handler.field)] == handler.field for field in fields):
                         yield handler

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -114,7 +114,9 @@ class SimpleRegistry(BaseRegistry):
         fields = {field for _, field, _, _ in cause.diff or []}
         for handler in self._handlers:
             if handler.event is None or handler.event == cause.event:
-                if handler.field:
+                if handler.initial and not cause.initial:
+                    pass  # ignore initial handlers in the non-initial causes.
+                elif handler.field:
                     if any(field[:len(handler.field)] == handler.field for field in fields):
                         yield handler
                 else:

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -12,6 +12,7 @@ def test_all_args(mocker):
     logger = mocker.Mock()
     resource = mocker.Mock()
     event = mocker.Mock()
+    initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
     diff = mocker.Mock()
@@ -21,6 +22,7 @@ def test_all_args(mocker):
         resource=resource,
         logger=logger,
         event=event,
+        initial=initial,
         body=body,
         patch=patch,
         diff=diff,
@@ -30,6 +32,7 @@ def test_all_args(mocker):
     assert cause.resource is resource
     assert cause.logger is logger
     assert cause.event is event
+    assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
     assert cause.diff is diff
@@ -41,18 +44,21 @@ def test_required_args(mocker):
     logger = mocker.Mock()
     resource = mocker.Mock()
     event = mocker.Mock()
+    initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
     cause = Cause(
         resource=resource,
         logger=logger,
         event=event,
+        initial=initial,
         body=body,
         patch=patch,
     )
     assert cause.resource is resource
     assert cause.logger is logger
     assert cause.event is event
+    assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
     assert cause.diff is None

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -13,16 +13,19 @@ def test_all_args(mocker):
     id = mocker.Mock()
     event = mocker.Mock()
     field = mocker.Mock()
-    timeout  = mocker.Mock()
+    timeout = mocker.Mock()
+    initial = mocker.Mock()
     handler = Handler(
         fn=fn,
         id=id,
         event=event,
         field=field,
         timeout=timeout,
+        initial=initial,
     )
     assert handler.fn is fn
     assert handler.id is id
     assert handler.event is event
     assert handler.field is field
     assert handler.timeout is timeout
+    assert handler.initial is initial

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -183,6 +183,7 @@ def cause_mock(mocker, resource):
         # I.e. everything except what we mock: event & body.
         cause = Cause(
             event=event,
+            initial=None,
             body=body,
             **kwargs)
 

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -42,7 +42,7 @@ import pytest
 from kubernetes.client.rest import ApiException  # to avoid mocking it
 
 import kopf
-from kopf.reactor.causation import Cause
+from kopf.reactor.causation import Cause, RESUME
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
@@ -90,10 +90,12 @@ class HandlersContainer:
     create_mock: Mock
     update_mock: Mock
     delete_mock: Mock
+    resume_mock: Mock
     event_fn: Callable
     create_fn: Callable
     update_fn: Callable
     delete_fn: Callable
+    resume_fn: Callable
 
 
 @pytest.fixture()
@@ -102,6 +104,7 @@ def handlers(clear_default_registry):
     create_mock = Mock(return_value=None)
     update_mock = Mock(return_value=None)
     delete_mock = Mock(return_value=None)
+    resume_mock = Mock(return_value=None)
 
     @kopf.on.event('zalando.org', 'v1', 'kopfexamples', id='event_fn')
     async def event_fn(**kwargs):
@@ -119,15 +122,21 @@ def handlers(clear_default_registry):
     async def delete_fn(**kwargs):
         return delete_mock(**kwargs)
 
+    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn', timeout=600)
+    async def resume_fn(**kwargs):
+        return resume_mock(**kwargs)
+
     return HandlersContainer(
         event_mock=event_mock,
         create_mock=create_mock,
         update_mock=update_mock,
         delete_mock=delete_mock,
+        resume_mock=resume_mock,
         event_fn=event_fn,
         create_fn=create_fn,
         update_fn=update_fn,
         delete_fn=delete_fn,
+        resume_fn=resume_fn,
     )
 
 
@@ -137,6 +146,7 @@ def extrahandlers(clear_default_registry, handlers):
     create_mock = Mock(return_value=None)
     update_mock = Mock(return_value=None)
     delete_mock = Mock(return_value=None)
+    resume_mock = Mock(return_value=None)
 
     @kopf.on.event('zalando.org', 'v1', 'kopfexamples', id='event_fn2')
     async def event_fn2(**kwargs):
@@ -154,15 +164,21 @@ def extrahandlers(clear_default_registry, handlers):
     async def delete_fn2(**kwargs):
         return delete_mock(**kwargs)
 
+    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn2')
+    async def resume_fn2(**kwargs):
+        return resume_mock(**kwargs)
+
     return HandlersContainer(
         event_mock=event_mock,
         create_mock=create_mock,
         update_mock=update_mock,
         delete_mock=delete_mock,
+        resume_mock=resume_mock,
         event_fn=event_fn2,
         create_fn=create_fn2,
         update_fn=update_fn2,
         delete_fn=delete_fn2,
+        resume_fn=resume_fn2,
     )
 
 
@@ -177,13 +193,14 @@ def cause_mock(mocker, resource):
         original_event = kwargs.pop('event', None)
         original_body = kwargs.pop('body', None)
         event = mock.event if mock.event is not None else original_event
+        initial = bool(event == RESUME)
         body = copy.deepcopy(mock.body) if mock.body is not None else original_body
 
         # Pass through kwargs: resource, logger, patch, diff, old, new.
         # I.e. everything except what we mock: event & body.
         cause = Cause(
             event=event,
-            initial=None,
+            initial=initial,
             body=body,
             **kwargs)
 

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE
+from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE, RESUME
 from kopf.reactor.handling import HandlerFatalError, HandlerRetryError
 from kopf.reactor.handling import custom_object_handler
 
@@ -21,6 +21,7 @@ async def test_fatal_error_stops_handler(
     handlers.create_mock.side_effect = HandlerFatalError("oops")
     handlers.update_mock.side_effect = HandlerFatalError("oops")
     handlers.delete_mock.side_effect = HandlerFatalError("oops")
+    handlers.resume_mock.side_effect = HandlerFatalError("oops")
 
     await custom_object_handler(
         lifecycle=kopf.lifecycles.one_by_one,
@@ -33,6 +34,7 @@ async def test_fatal_error_stops_handler(
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
     assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+    assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
     assert not k8s_mocked.asyncio_sleep.called
     assert k8s_mocked.patch_obj.called
@@ -59,6 +61,7 @@ async def test_retry_error_delays_handler(
     handlers.create_mock.side_effect = HandlerRetryError("oops")
     handlers.update_mock.side_effect = HandlerRetryError("oops")
     handlers.delete_mock.side_effect = HandlerRetryError("oops")
+    handlers.resume_mock.side_effect = HandlerRetryError("oops")
 
     await custom_object_handler(
         lifecycle=kopf.lifecycles.one_by_one,
@@ -71,6 +74,7 @@ async def test_retry_error_delays_handler(
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
     assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+    assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
     assert not k8s_mocked.asyncio_sleep.called
     assert k8s_mocked.patch_obj.called
@@ -98,6 +102,7 @@ async def test_arbitrary_error_delays_handler(
     handlers.create_mock.side_effect = Exception("oops")
     handlers.update_mock.side_effect = Exception("oops")
     handlers.delete_mock.side_effect = Exception("oops")
+    handlers.resume_mock.side_effect = Exception("oops")
 
     await custom_object_handler(
         lifecycle=kopf.lifecycles.one_by_one,
@@ -110,6 +115,7 @@ async def test_arbitrary_error_delays_handler(
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
     assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+    assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
     assert not k8s_mocked.asyncio_sleep.called
     assert k8s_mocked.patch_obj.called

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 import kopf
-from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE
+from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE, RESUME
 from kopf.reactor.handling import custom_object_handler
 
 
@@ -27,6 +27,7 @@ async def test_1st_step_stores_progress_by_patching(
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
     assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+    assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
     assert not k8s_mocked.asyncio_sleep.called
     assert k8s_mocked.patch_obj.called
@@ -70,6 +71,7 @@ async def test_2nd_step_finishes_the_handlers(
     assert extrahandlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
     assert extrahandlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
     assert extrahandlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
+    assert extrahandlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
     assert not k8s_mocked.asyncio_sleep.called
     assert k8s_mocked.patch_obj.called

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -27,6 +27,7 @@ async def test_timed_out_handler_fails(
             'create_fn': {'started': ts},
             'update_fn': {'started': ts},
             'delete_fn': {'started': ts},
+            'resume_fn': {'started': ts},
         }}}
     })
 
@@ -42,6 +43,7 @@ async def test_timed_out_handler_fails(
     assert not handlers.create_mock.called
     assert not handlers.update_mock.called
     assert not handlers.delete_mock.called
+    assert not handlers.resume_mock.called
 
     # Progress is reset, as the handler is not going to retry.
     assert not k8s_mocked.asyncio_sleep.called

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -19,7 +19,7 @@ import pytest
 from kopf.reactor.queueing import watcher, EOS
 
 # Some overhead for the synchronous logic in async tests: it also takes time.
-CODE_OVERHEAD = 0.05  # 0.01 is too fast, 0.1 is too slow, 0.5 is good enough.
+CODE_OVERHEAD = 0.1  # 0.01 is too fast, 0.1 is too slow, 0.05 is good enough.
 
 
 @pytest.mark.parametrize('uids, cnts, events', [


### PR DESCRIPTION
> Issue : closes #60, replaces #96 

## Description

Add the handlers for "resuming" (recalling? remembering?) an object in the operator:

```python
@kopf.on.resume('zalando.org', 'v1', 'kopfexamples')
def on_resume(**kwargs): pass
```

This complements the existing handlers for creation/update/deletion cases, and is injected into the handling cycle when one of the mentioned cases is detected (and handled normally), but strictly when the operator has started/restarted, and found that the object existed beforehand.

Which implies that if the object was created during the operator downtime, both `@kopf.on.create` **AND** `@kopf.on.resume` handlers will be called. Similarly, of the object was changed during the operator downtime, both `@kopf.on.update` **AND** `@kopf.on.resume` will be called (and both will get a diff of the object).

---

_BUT: See #103 for the de-duplication of the same function if it is registered for few causes._

This "double-cause" patten becomes possible to start a background job for permanent object monitoring (the function will be called only once when the object appears: either while the operator is running and it is created, or when the operator starts and a new unhandled object is found, or when the operator starts and an existing handled object is found):

```python
@kopf.on.create('zalando.org', 'v1', 'kopfexamples')
@kopf.on.resume('zalando.org', 'v1', 'kopfexamples')
async def start_monotoring(**kwargs): pass
    loop = asyncio.get_running_loop()
    loop.create_task(a_long_running_coroutine(**kwargs))

    thread = threading.Thread(target=a_long_running_function, kwargs=kwargs)
    thread.start()
```

---

**Difference from #96:** Unlike a solution in #96, where the resuming handler is triggered when the object is neither created, nor updated, nor deleted, but noticed to exist, in this PR, the resume handler is called event if update/creation/deletion detected, as part of the relevant handling cycle (i.e. as one of the handlers on the list).

---

_**As a side-note:** I could not decide between "resume" and "recall" for proper naming. It is "resume", as it resumes some thread that was previously running in a now-dead operator. It is "recall", as it kind of "recalls" (remembers) the object: "ah, there is also such a thing with uid 123, which is not changed!". The naming can be changed before merged._


## Types of Changes

- New feature (non-breaking change which adds functionality)
- Refactor/improvements
- Documentation / non-code

## Review

- [ ] Tests
- [ ] Documentation
