### PR TITLE
Freeze all operators with same priority and warn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ junit.xml
 # Documentation
 docs/_build
 docs/packages
+
+# VirtualEnv
+env
+
+# VSCode
+.vscode

--- a/docs/peering.rst
+++ b/docs/peering.rst
@@ -14,7 +14,8 @@ notices that other operators start with a higher priority, it freezes
 its operation until those operators stop working.
 
 This is done to prevent collisions of multiple operators handling
-the same objects.
+the same objects. If two operators runs with the same priority  all operators 
+issue a warning and freeze, so that the cluster becomes not served anymore.
 
 To set the operator's priority, use :option:`--priority`:
 

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -40,12 +40,8 @@ from typing import Iterable, Mapping, Optional, Union
 
 import iso8601
 
-<<<<<<< HEAD:kopf/engines/peering.py
 from kopf.clients import fetching
 from kopf.clients import patching
-=======
-from kopf.k8s import fetching, patching
->>>>>>> All operators with the same priority issue a warning and freeze, so that the cluster becomes not served anymore:kopf/reactor/peering.py
 from kopf.reactor import registries
 logger = logging.getLogger(__name__)
 

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -257,9 +257,12 @@ async def peers_keepalive(
             await asyncio.sleep(max(1, int(ourselves.lifetime.total_seconds() - 10)))
     finally:
         try:
-            await ourselves.disappear()
-        except:
+            await asyncio.shield(ourselves.disappear())
+        except asyncio.CancelledError:
+            # It is the cancellation of `keepalive()`, not of the shielded `disappear()`.
             pass
+        except Exception:
+            logger.exception(f"Couldn't remove self from the peering. Ignoring.")
 
 
 def detect_own_id() -> str:

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -235,15 +235,13 @@ async def peers_handler(
             logger.info(f"Freezing operations in favour of {prio_peers}.")
             freeze.set()
     
-    else:
-        if same_peers:
-            logger.warning(f"Possibly conflicting operators with the same priority: {same_peers}.")
-            logger.warning(f"Freezed all Operators: {peers}")
-            freeze.set()
-        else:
-            if freeze.is_set():
-                logger.info(f"Resuming operations after the freeze. Conflicting operators with the same priority are gone")
-                freeze.clear()
+    elif same_peers:
+        logger.warning(f"Possibly conflicting operators with the same priority: {same_peers}.")
+        logger.warning(f"Freezed all Operators: {peers}")
+        freeze.set()
+    elif freeze.is_set():
+        logger.info(f"Resuming operations after the freeze. Conflicting operators with the same priority are gone")
+        freeze.clear()
 
 
 async def peers_keepalive(

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -36,14 +36,17 @@ import logging
 import os
 import random
 import socket
-from typing import Optional, Mapping, Iterable, Union
+from typing import Iterable, Mapping, Optional, Union
 
 import iso8601
 
+<<<<<<< HEAD:kopf/engines/peering.py
 from kopf.clients import fetching
 from kopf.clients import patching
+=======
+from kopf.k8s import fetching, patching
+>>>>>>> All operators with the same priority issue a warning and freeze, so that the cluster becomes not served anymore:kopf/reactor/peering.py
 from kopf.reactor import registries
-
 logger = logging.getLogger(__name__)
 
 # The CRD info on the special sync-object.
@@ -231,12 +234,16 @@ async def peers_handler(
         if not freeze.is_set():
             logger.info(f"Freezing operations in favour of {prio_peers}.")
             freeze.set()
+    
     else:
         if same_peers:
             logger.warning(f"Possibly conflicting operators with the same priority: {same_peers}.")
-        if freeze.is_set():
-            logger.info(f"Resuming operations after the freeze.")
-            freeze.clear()
+            logger.warning(f"Freezed all Operators: {peers}")
+            freeze.set()
+        else:
+            if freeze.is_set():
+                logger.info(f"Resuming operations after the freeze. Conflicting operators with the same priority are gone")
+                freeze.clear()
 
 
 async def peers_keepalive(


### PR DESCRIPTION
# One-line summary

> Issue : #51

## Description

When two operators runs with the same priority, both will handle the same request. This PR adds the possibility to freeze all events with the same priority, as mentioned in #51 and print a warning error.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Manual Tests
- [x] Documentation