### PR TITLE
Optional finalizers

### DIFF
--- a/docs/continuity.rst
+++ b/docs/continuity.rst
@@ -51,8 +51,8 @@ This corresponds to the Kubernetes's concept of eventual consistency
 and level triggering (as opposed to edge triggering).
 
 .. warning::
-    If the operator is down, the objects cannot be deleted,
-    as they contain the Kopf's finalizers in ``metadata.finalizers``,
+    If the operator is down, the objects may not be deleted,
+    as they may contain the Kopf's finalizers in ``metadata.finalizers``,
     and Kubernetes blocks the deletion until all finalizers are removed.
     If the operator is not running, the finalizers will never be removed.
-    See: :ref:`finalizers-blocking-deletion` for a work-around.
+    See: :ref:`finalizers-blocking-deletion` for a work-around. 

--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -147,6 +147,16 @@ The following 3 core cause-handlers are available::
     def my_handler(spec, **_):
         pass
 
+.. note::
+    Kopf's finalizers will be added to the object when there are delete
+    handlers specified. Finalizers block Kubernetes from fully deleting
+    objects, and Kubernetes will only actually delete objects when all
+    finalizers are removed, i.e. only if the Kopf operator is running to
+    remove them (check: :ref:`finalizers-blocking-deletion` for a work-around).
+    If a delete handler is added but finalizers are not required to block the
+    actual deletion, i.e. the handler is optional, the optional argument
+    `optional=True` can be passed to the delete cause decorator.
+
 An additional handler can be used for cases when the operator restarts
 and detects an object that existed before, but was not changed/deleted
 during downtime (which would trigger the update-/delete-handlers)::

--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -155,7 +155,7 @@ The following 3 core cause-handlers are available::
     remove them (check: :ref:`finalizers-blocking-deletion` for a work-around).
     If a delete handler is added but finalizers are not required to block the
     actual deletion, i.e. the handler is optional, the optional argument
-    `optional=True` can be passed to the delete cause decorator.
+    ``optional=True`` can be passed to the delete cause decorator.
 
 An additional handler can be used for cases when the operator restarts
 and detects an object that existed before, but was not changed/deleted

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -75,14 +75,14 @@ def delete(
         id: Optional[str] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.GlobalRegistry] = None,
-        mandatory: bool = True):
+        optional: Optional[bool] = None):
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn):
         registry.register_cause_handler(
             group=group, version=version, plural=plural,
             event=causation.DELETE, id=id, timeout=timeout,
-            fn=fn, requires_finalizer=mandatory)
+            fn=fn, requires_finalizer=bool(not optional))
         return fn
     return decorator
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -74,14 +74,15 @@ def delete(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.GlobalRegistry] = None):
+        registry: Optional[registries.GlobalRegistry] = None,
+        mandatory=True):
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn):
         registry.register_cause_handler(
             group=group, version=version, plural=plural,
             event=causation.DELETE, id=id, timeout=timeout,
-            fn=fn)
+            fn=fn, requires_finalizer=mandatory)
         return fn
     return decorator
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -75,7 +75,7 @@ def delete(
         id: Optional[str] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.GlobalRegistry] = None,
-        mandatory=True):
+        mandatory: bool = True):
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn):

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -73,6 +73,7 @@ class Cause(NamedTuple):
 
 def detect_cause(
         event: Mapping,
+        requires_finalizer=True,
         **kwargs
 ) -> Cause:
     """
@@ -111,7 +112,8 @@ def detect_cause(
 
     # For a fresh new object, first block it from accidental deletions without our permission.
     # The actual handler will be called on the next call.
-    if not finalizers.has_finalizers(body):
+    # Only return this cause if the resource requires finalizers to be added.
+    if not initial and requires_finalizer and not finalizers.has_finalizers(body):
         return Cause(
             event=NEW,
             body=body,

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -73,7 +73,7 @@ class Cause(NamedTuple):
 
 def detect_cause(
         event: Mapping,
-        requires_finalizer=True,
+        requires_finalizer: bool = True,
         **kwargs
 ) -> Cause:
     """

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -29,7 +29,6 @@ from kopf.structs import lastseen
 
 # Constants for event types, to prevent a direct usage of strings, and typos.
 # They are not exposed by the framework, but are used internally. See also: `kopf.on`.
-NEW = 'new'
 CREATE = 'create'
 UPDATE = 'update'
 DELETE = 'delete'
@@ -37,11 +36,13 @@ RESUME = 'resume'
 NOOP = 'noop'
 FREE = 'free'
 GONE = 'gone'
+ACQUIRE = 'acquire'
+RELEASE = 'release'
 
 # These sets are checked in few places, so we keep them centralised:
 # the user-facing causes (for handlers), and internally facing (so as handled).
 HANDLER_CAUSES = (CREATE, UPDATE, DELETE, RESUME)
-REACTOR_CAUSES = (NEW, NOOP, FREE, GONE)
+REACTOR_CAUSES = (NOOP, FREE, GONE, ACQUIRE, RELEASE)
 ALL_CAUSES = HANDLER_CAUSES + REACTOR_CAUSES
 
 # The human-readable names of these causes. Will be capitalised when needed.
@@ -113,9 +114,20 @@ def detect_cause(
     # For a fresh new object, first block it from accidental deletions without our permission.
     # The actual handler will be called on the next call.
     # Only return this cause if the resource requires finalizers to be added.
-    if not initial and requires_finalizer and not finalizers.has_finalizers(body):
+    if requires_finalizer and not finalizers.has_finalizers(body):
         return Cause(
-            event=NEW,
+            event=ACQUIRE,
+            body=body,
+            initial=initial,
+            **kwargs)
+
+    # Check whether or not the resource has finalizers, but doesn't require them. If this is
+    # the case, then a resource may not be able to be deleted completely as finalizers may
+    # not be removed by the operator under normal operation. We remove the finalizers first,
+    # and any handler that should be called will be done on the next call.
+    if not requires_finalizer and finalizers.has_finalizers(body):
+        return Cause(
+            event=RELEASE,
             body=body,
             initial=initial,
             **kwargs)

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -83,7 +83,7 @@ class SimpleRegistry(BaseRegistry):
     def __init__(self, prefix=None):
         super().__init__()
         self.prefix = prefix
-        self.requires_finalizer = False
+        self._requires_finalizer = False
         self._handlers = []  # [Handler, ...]
 
     def __bool__(self):
@@ -110,7 +110,7 @@ class SimpleRegistry(BaseRegistry):
         self.append(handler)
 
         if requires_finalizer:
-            self.requires_finalizer = True
+            self._requires_finalizer = True
 
         return fn  # to be usable as a decorator too.
 
@@ -129,6 +129,9 @@ class SimpleRegistry(BaseRegistry):
     def iter_event_handlers(self, resource, event):
         for handler in self._handlers:
             yield handler
+
+    def requires_finalizer(self, resource):
+        return self._requires_finalizer
 
 
 def get_callable_id(c):
@@ -218,7 +221,7 @@ class GlobalRegistry(BaseRegistry):
         resource_registry = self._cause_handlers.get(resource, None)
         if resource_registry is None:
             return False
-        return resource_registry.requires_finalizer
+        return resource_registry.requires_finalizer(resource)
 
 
 _default_registry = GlobalRegistry()

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -88,6 +88,19 @@ mismatching_lastseen = pytest.mark.parametrize('annotations', [
     pytest.param({'annotations': {LAST_SEEN_ANNOTATION: ALT_JSON}}, id='mismatching-last-seen'),
 ])
 
+all_requires_finalizer = pytest.mark.parametrize('requires_finalizer', [
+    pytest.param(True, id='requires-finalizer'),
+    pytest.param(False, id='doesnt-require-finalizer'),
+])
+
+requires_finalizer = pytest.mark.parametrize('requires_finalizer', [
+    pytest.param(True, id='requires-finalizer'),
+])
+
+doesnt_require_finalizer = pytest.mark.parametrize('requires_finalizer', [
+    pytest.param(False, id='doesnt-require-finalizer'),
+])
+
 
 @pytest.fixture
 def content():
@@ -117,95 +130,115 @@ def check_kwargs(cause, kwargs):
 # The tests.
 #
 
+@all_requires_finalizer
 @all_finalizers
 @all_deletions
 @deleted_events
-def test_for_gone(kwargs, event, finalizers, deletion_ts):
+def test_for_gone(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, **kwargs)
+    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
     assert cause.event == GONE
     check_kwargs(cause, kwargs)
 
 
+@all_requires_finalizer
 @no_finalizers
 @real_deletions
 @regular_events
-def test_for_free(kwargs, event, finalizers, deletion_ts):
+def test_for_free(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, **kwargs)
+    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
     assert cause.event == FREE
     check_kwargs(cause, kwargs)
 
 
+@all_requires_finalizer
 @our_finalizers
 @real_deletions
 @regular_events
-def test_for_delete(kwargs, event, finalizers, deletion_ts):
+def test_for_delete(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, **kwargs)
+    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
     assert cause.event == DELETE
     check_kwargs(cause, kwargs)
 
 
+@requires_finalizer
 @no_finalizers
 @no_deletions
 @regular_events
-def test_for_new(kwargs, event, finalizers, deletion_ts):
+def test_for_new(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, **kwargs)
+    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
     assert cause.event == NEW
     check_kwargs(cause, kwargs)
 
 
+@requires_finalizer
 @absent_lastseen
 @our_finalizers
 @no_deletions
 @regular_events
-def test_for_create(kwargs, event, finalizers, deletion_ts, annotations, content):
+def test_for_create(kwargs, event, finalizers, deletion_ts, annotations, content, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object'].update(content)
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_cause(event=event, **kwargs)
+    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
     assert cause.event == CREATE
     check_kwargs(cause, kwargs)
 
 
+@doesnt_require_finalizer
+@no_finalizers
+@no_deletions
+@regular_events
+def test_for_create_skip_new(kwargs, event, finalizers, deletion_ts, requires_finalizer):
+    event = {'type': event, 'object': {'metadata': {}}}
+    event['object']['metadata'].update(finalizers)
+    event['object']['metadata'].update(deletion_ts)
+    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    assert cause.event == CREATE
+    check_kwargs(cause, kwargs)
+
+
+@requires_finalizer
 @matching_lastseen
 @our_finalizers
 @no_deletions
 @regular_events
-def test_for_no_op(kwargs, event, finalizers, deletion_ts, annotations, content):
+def test_for_no_op(kwargs, event, finalizers, deletion_ts, annotations, content, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object'].update(content)
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_cause(event=event, **kwargs)
+    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
     assert cause.event == NOOP
     check_kwargs(cause, kwargs)
 
 
+@requires_finalizer
 @mismatching_lastseen
 @our_finalizers
 @no_deletions
 @regular_events
-def test_for_update(kwargs, event, finalizers, deletion_ts, annotations, content):
+def test_for_update(kwargs, event, finalizers, deletion_ts, annotations, content, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object'].update(content)
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_cause(event=event, **kwargs)
+    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
     assert cause.event == UPDATE
     check_kwargs(cause, kwargs)
 

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -18,12 +18,12 @@ def test_all_examples_are_runnable(mocker, with_crd, with_peering, exampledir):
     m = re.search(r'^E2E_TRACEBACKS\s*=\s*(\w+)$', example_py.read_text(), re.M)
     e2e_tracebacks = eval(m.group(1)) if m else None
     # check whether there are mandatory deletion handlers or not
-    m = re.search(r'@kopf\.on\.delete\((\s|.*)?(mandatory=(\w+))?\)', example_py.read_text(), re.M)
+    m = re.search(r'@kopf\.on\.delete\((\s|.*)?(optional=(\w+))?\)', example_py.read_text(), re.M)
     requires_finalizer = False
     if m:
         requires_finalizer = True
         if m.group(2):
-            requires_finalizer = eval(m.group(3))
+            requires_finalizer = not eval(m.group(3))
 
     # To prevent lengthy sleeps on the simulated retries.
     mocker.patch('kopf.reactor.handling.DEFAULT_RETRY_DELAY', 1)

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -17,6 +17,13 @@ def test_all_examples_are_runnable(mocker, with_crd, with_peering, exampledir):
     e2e_delete_time = eval(m.group(1)) if m else None
     m = re.search(r'^E2E_TRACEBACKS\s*=\s*(\w+)$', example_py.read_text(), re.M)
     e2e_tracebacks = eval(m.group(1)) if m else None
+    # check whether there are mandatory deletion handlers or not
+    m = re.search(r'@kopf\.on\.delete\((\s|.*)?(mandatory=(\w+))?\)', example_py.read_text(), re.M)
+    requires_finalizer = False
+    if m:
+        requires_finalizer = True
+        if m.group(2):
+            requires_finalizer = eval(m.group(3))
 
     # To prevent lengthy sleeps on the simulated retries.
     mocker.patch('kopf.reactor.handling.DEFAULT_RETRY_DELAY', 1)
@@ -37,9 +44,11 @@ def test_all_examples_are_runnable(mocker, with_crd, with_peering, exampledir):
 
     # There are usually more than these messages, but we only check for the certain ones.
     # This just shows us that the operator is doing something, it is alive.
-    assert '[default/kopf-example-1] First appearance:' in runner.stdout
+    if requires_finalizer:
+        assert '[default/kopf-example-1] First appearance:' in runner.stdout
     assert '[default/kopf-example-1] Creation event:' in runner.stdout
-    assert '[default/kopf-example-1] Deletion event:' in runner.stdout
+    if requires_finalizer:
+        assert '[default/kopf-example-1] Deletion event:' in runner.stdout
     assert '[default/kopf-example-1] Deleted, really deleted' in runner.stdout
     if not e2e_tracebacks:
         assert 'Traceback (most recent call last):' not in runner.stdout

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -45,7 +45,7 @@ def test_all_examples_are_runnable(mocker, with_crd, with_peering, exampledir):
     # There are usually more than these messages, but we only check for the certain ones.
     # This just shows us that the operator is doing something, it is alive.
     if requires_finalizer:
-        assert '[default/kopf-example-1] First appearance:' in runner.stdout
+        assert '[default/kopf-example-1] Adding the finalizer' in runner.stdout
     assert '[default/kopf-example-1] Creation event:' in runner.stdout
     if requires_finalizer:
         assert '[default/kopf-example-1] Deletion event:' in runner.stdout

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -198,6 +198,9 @@ def cause_mock(mocker, resource):
         body = copy.deepcopy(mock.body) if mock.body is not None else original_body
         diff = copy.deepcopy(mock.diff) if mock.diff is not None else original_diff
 
+        # Remove requires_finalizer from kwargs as it shouldn't be passed to the Cause object
+        kwargs.pop('requires_finalizer', None)
+
         # Pass through kwargs: resource, logger, patch, diff, old, new.
         # I.e. everything except what we mock: event & body.
         cause = Cause(

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -9,6 +9,7 @@ from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE, RESUM
 from kopf.reactor.handling import HandlerRetryError
 from kopf.reactor.handling import WAITING_KEEPALIVE_INTERVAL
 from kopf.reactor.handling import custom_object_handler
+from kopf.structs.finalizers import FINALIZER
 
 
 @pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
@@ -73,6 +74,8 @@ async def test_delayed_handlers_sleep(
             'resume_fn': {'delayed': ts},
         }}}
     })
+    # make sure the finalizer is added since there are mandatory deletion handlers
+    cause_mock.body.setdefault('metadata', {})['finalizers'] = [FINALIZER]
 
     with freezegun.freeze_time(now):
         await custom_object_handler(

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -126,17 +126,17 @@ def test_on_update_with_all_kwargs(mocker):
     assert registry.requires_finalizer(resource=resource) is False
 
 
-@pytest.mark.parametrize('mandatory', [
-    pytest.param(True, id='mandatory'),
-    pytest.param(False, id='not-mandatory'),
+@pytest.mark.parametrize('optional', [
+    pytest.param(True, id='optional'),
+    pytest.param(False, id='mandatory'),
 ])
-def test_on_delete_with_all_kwargs(mocker, mandatory):
+def test_on_delete_with_all_kwargs(mocker, optional):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
     cause = mocker.MagicMock(resource=resource, event=DELETE)
 
     @kopf.on.delete('group', 'version', 'plural',
-                    id='id', timeout=123, registry=registry, mandatory=mandatory)
+                    id='id', timeout=123, registry=registry, optional=optional)
     def fn(**_):
         pass
 
@@ -147,7 +147,7 @@ def test_on_delete_with_all_kwargs(mocker, mandatory):
     assert handlers[0].field is None
     assert handlers[0].id == 'id'
     assert handlers[0].timeout == 123
-    assert registry.requires_finalizer(resource=resource) is mandatory
+    assert registry.requires_finalizer(resource=resource) is not optional
 
 
 def test_on_field_with_all_kwargs(mocker):


### PR DESCRIPTION
> Issue : #24

## Description
Adding finalizers to resources means that resources cannot be deleted if the operator is not running. This PR makes sure that finalizers are added only when strictly necessary, i.e. when there are mandatory deletion handlers. If there are no deletion handlers registered, then no finalizers will be added, same if a deletion handler is marked as optional.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Documentation / non-code

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Add documentation

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
