### PR TITLE
Post k8s-events in the background

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -22,7 +22,7 @@ from kopf.config import (
     EventsConfig,
     WorkersConfig
 )
-from kopf.events import (
+from kopf.engines.posting import (
     event,
     info,
     warn,

--- a/kopf/engines/posting.py
+++ b/kopf/engines/posting.py
@@ -1,0 +1,88 @@
+"""
+All the functions to write the Kubernetes events for the Kubernetes objects.
+
+They are used internally in the handling routines to show the progress,
+and can be used directly from the handlers to add arbitrary custom events.
+
+The actual k8s-event posting runs in the background,
+and posts the k8s-events as soon as they are queued.
+"""
+import asyncio
+import sys
+from contextvars import ContextVar
+from typing import Mapping, Text, NamedTuple
+
+from kopf import config
+from kopf.clients import events
+from kopf.structs import dicts
+from kopf.structs import hierarchies
+
+event_queue_var: ContextVar[asyncio.Queue] = ContextVar('event_queue_var')
+
+
+class K8sEvent(NamedTuple):
+    """
+    A single k8s-event to be posted, with all ref-information preserved.
+    It can exist and be posted even after the object is garbage-collected.
+    """
+    ref: Mapping
+    type: Text
+    reason: Text
+    message: Text
+
+
+def event(objs, *, type, reason, message=''):
+    queue = event_queue_var.get()
+    for obj in dicts.walk(objs):
+        ref = hierarchies.build_object_reference(obj)
+        event = K8sEvent(ref=ref, type=type, reason=reason, message=message)
+        queue.put_nowait(event)
+
+
+def info(obj, *, reason, message=''):
+    if config.EventsConfig.events_loglevel > config.LOGLEVEL_INFO:
+        return
+    event(obj, type='Normal', reason=reason, message=message)
+
+
+def warn(obj, *, reason, message=''):
+    if config.EventsConfig.events_loglevel > config.LOGLEVEL_WARNING:
+        return
+    event(obj, type='Warning', reason=reason, message=message)
+
+
+def exception(obj, *, reason='', message='', exc=None):
+    if config.EventsConfig.events_loglevel > config.LOGLEVEL_ERROR:
+        return
+    if exc is None:
+        _, exc, _ = sys.exc_info()
+    reason = reason if reason else type(exc).__name__
+    message = f'{message} {exc}' if message else f'{exc}'
+    event(obj, type='Error', reason=reason, message=message)
+
+
+async def poster(
+        event_queue: asyncio.Queue,
+):
+    """
+    Post events in the background as they are queued.
+
+    When the events come from the logging system, they have
+    their reason, type, and other fields adjusted to meet Kubernetes's concepts.
+
+    When the events are explicitly defined via `kopf.event` and similar calls,
+    they have these special fields defined already.
+
+    In either case, we pass the queued events directly to the K8s client
+    (or a client wrapper/adapter), with no extra processing.
+
+    This task is defined in this module only because all other tasks are here,
+    so we keep all forever-running tasks together.
+    """
+    while True:
+        posted_event = await event_queue.get()
+        await events.post_event(
+            ref=posted_event.ref,
+            type=posted_event.type,
+            reason=posted_event.reason,
+            message=posted_event.message)

--- a/kopf/engines/posting.py
+++ b/kopf/engines/posting.py
@@ -57,7 +57,7 @@ def exception(obj, *, reason='', message='', exc=None):
     if exc is None:
         _, exc, _ = sys.exc_info()
     reason = reason if reason else type(exc).__name__
-    message = f'{message} {exc}' if message else f'{exc}'
+    message = f'{message} {exc}' if message and exc else f'{exc}' if exc else f'{message}'
     event(obj, type='Error', reason=reason, message=message)
 
 

--- a/kopf/events.py
+++ b/kopf/events.py
@@ -1,72 +1,20 @@
 """
-All the functions to write the Kubernetes events on the Kubernetes objects.
-
-They are used internally in the handling routine to show the progress,
-and can be used directly from the handlers to add arbitrary custom events.
-
-The events look like this:
-
-    kubectl describe -f myres.yaml
-    ...
-    TODO
-
+**THIS MODULE IS DEPRECATED AND WILL BE REMOVED.**
 """
-import asyncio
-import sys
+import warnings
 
-from kopf import config
-from kopf.clients import events
+from kopf.engines.posting import (
+    event,
+    info,
+    warn,
+    exception,
+)
 
-
-# TODO: rename it it kopf.log()? kopf.events.log()? kopf.events.warn()?
-async def event_async(obj, *, type, reason, message=''):
-    """
-    Issue an event for the object.
-    """
-    if isinstance(obj, (list, tuple)):
-        for item in obj:
-            await events.post_event(obj=item, type=type, reason=reason, message=message)
-    else:
-        await events.post_event(obj=obj, type=type, reason=reason, message=message)
+__all__ = ['event', 'info', 'warn', 'exception']
 
 
-# Shortcuts for the only two officially documented event types as of now.
-# However, any arbitrary strings can be used as an event type to the base function.
-async def info_async(obj, *, reason, message=''):
-    if config.EventsConfig.events_loglevel > config.LOGLEVEL_INFO:
-        return
-    await event_async(obj, reason=reason, message=message, type='Normal')
-
-
-async def warn_async(obj, *, reason, message=''):
-    if config.EventsConfig.events_loglevel > config.LOGLEVEL_WARNING:
-        return
-    await event_async(obj, reason=reason, message=message, type='Warning')
-
-
-async def exception_async(obj, *, reason='', message='', exc=None):
-    if config.EventsConfig.events_loglevel > config.LOGLEVEL_ERROR:
-        return
-
-    if exc is None:
-        _, exc, _ = sys.exc_info()
-    reason = reason if reason else type(exc).__name__
-    message = f'{message} {exc}' if message else f'{exc}'
-    await event_async(obj, reason=reason, message=message, type='Error')
-
-
-# Next 4 funcs are just synchronous interface for async event functions.
-def event(obj, *, type, reason, message=''):
-    asyncio.wait_for(event_async(obj, type=type, reason=reason, message=message), timeout=None)
-
-
-def info(obj, *, reason, message=''):
-    asyncio.wait_for(info_async(obj, reason=reason, message=message), timeout=None)
-
-
-def warn(obj, *, reason, message=''):
-    asyncio.wait_for(warn_async(obj, reason=reason, message=message), timeout=None)
-
-
-def exception(obj, *, reason='', message='', exc=None):
-    asyncio.wait_for(exception_async(obj, reason=reason, message=message, exc=exc), timeout=None)
+# Triggered on explicit `import kopf.events` (not imported this way normally).
+warnings.warn(
+    "`kopf.events` is deprecated; "
+    "use `kopf` directly: e.g. `kopf.event(...)`.",
+    DeprecationWarning, stacklevel=0)

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -20,6 +20,7 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
     assert caplog.messages  # no messages means that we cannot test it
     assert all(message.startswith('[ns1/name1] ') for message in caplog.messages)
@@ -43,6 +44,7 @@ async def test_diffs_logged_if_present(registry, resource, handlers, cause_type,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
     assert_logs([
         " event: ",
@@ -63,6 +65,7 @@ async def test_diffs_not_logged_if_absent(registry, resource, handlers, cause_ty
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
     assert_logs([
         " event: ",

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -34,6 +34,7 @@ async def test_delayed_handlers_progress(
             resource=resource,
             event={'type': 'irrelevant', 'object': cause_mock.body},
             freeze=asyncio.Event(),
+            event_queue=asyncio.Queue(),
         )
 
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
@@ -81,6 +82,7 @@ async def test_delayed_handlers_sleep(
             resource=resource,
             event={'type': 'irrelevant', 'object': cause_mock.body},
             freeze=asyncio.Event(),
+            event_queue=asyncio.Queue(),
         )
 
     assert not handlers.create_mock.called

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -29,6 +29,7 @@ async def test_fatal_error_stops_handler(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
 
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
@@ -69,6 +70,7 @@ async def test_retry_error_delays_handler(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
 
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
@@ -110,6 +112,7 @@ async def test_arbitrary_error_delays_handler(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
 
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -21,6 +21,7 @@ async def test_handlers_called_always(
         resource=resource,
         event={'type': 'ev-type', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
 
     assert handlers.event_mock.call_count == 1
@@ -54,6 +55,7 @@ async def test_errors_are_ignored(
         resource=resource,
         event={'type': 'ev-type', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
 
     assert handlers.event_mock.called

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -29,6 +29,7 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
         resource=resource,
         event=event,
         freeze=freeze,
+        event_queue=asyncio.Queue(),
     )
 
     assert not detect_cause.called

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -22,6 +22,7 @@ async def test_1st_step_stores_progress_by_patching(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
 
     assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
@@ -66,6 +67,7 @@ async def test_2nd_step_finishes_the_handlers(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
 
     assert extrahandlers.create_mock.call_count == (1 if cause_type == CREATE else 0)

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -32,6 +32,7 @@ async def test_skipped_with_no_handlers(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        event_queue=asyncio.Queue(),
     )
 
     assert not k8s_mocked.asyncio_sleep.called

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -38,6 +38,7 @@ async def test_timed_out_handler_fails(
             resource=resource,
             event={'type': 'irrelevant', 'object': cause_mock.body},
             freeze=asyncio.Event(),
+            event_queue=asyncio.Queue(),
         )
 
     assert not handlers.create_mock.called

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -1,0 +1,92 @@
+import asyncio
+
+import pytest
+from asynctest import call
+
+from kopf import event, info, warn, exception
+from kopf.engines.posting import poster, K8sEvent, event_queue_var
+
+OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
+        'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}}
+REF1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
+        'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}
+OBJ2 = {'apiVersion': 'group2/version2', 'kind': 'Kind2',
+        'metadata': {'uid': 'uid2', 'name': 'name2', 'namespace': 'ns2'}}
+REF2 = {'apiVersion': 'group2/version2', 'kind': 'Kind2',
+        'uid': 'uid2', 'name': 'name2', 'namespace': 'ns2'}
+
+
+async def test_poster_polls_and_posts(mocker):
+    event1 = K8sEvent(type='type1', reason='reason1', message='message1', ref=REF1)
+    event2 = K8sEvent(type='type2', reason='reason2', message='message2', ref=REF2)
+    event_queue = asyncio.Queue()
+    event_queue.put_nowait(event1)
+    event_queue.put_nowait(event2)
+
+    # A way to cancel `while True` cycle when we need it (ASAP).
+    def _cancel(*args, **kwargs):
+        if post_event.call_count >= 2:
+            raise asyncio.CancelledError()
+    post_event = mocker.patch('kopf.clients.events.post_event', side_effect=_cancel)
+
+    # A way to cancel `whole True` cycle by timing, event if routines are not called.
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(
+            poster(event_queue=event_queue), timeout=0.5)
+
+    assert post_event.call_count == 2
+    assert post_event.await_count == 2
+    assert post_event.called_with(
+        call(ref=REF1, type='type1', reason='reason1', message='message1'),
+        call(ref=REF2, type='type2', reason='reason2', message='message2'),
+    )
+
+
+def test_queueing_fails_with_no_queue(mocker):
+    # Prerequisite: the context-var should not be set by anything in advance.
+    sentinel = object()
+    assert event_queue_var.get(sentinel) is sentinel
+
+    with pytest.raises(LookupError):
+        event(OBJ1, type='type1', reason='reason1', message='message1')
+
+
+def test_via_event_function(mocker):
+    post_event = mocker.patch('kopf.clients.events.post_event')
+
+    event_queue = asyncio.Queue()
+    event_queue_var.set(event_queue)
+    event(OBJ1, type='type1', reason='reason1', message='message1')
+
+    assert not post_event.called
+    assert event_queue.qsize() == 1
+    event1 = event_queue.get_nowait()
+
+    assert isinstance(event1, K8sEvent)
+    assert event1.ref == REF1
+    assert event1.type == 'type1'
+    assert event1.reason == 'reason1'
+    assert event1.message == 'message1'
+
+
+@pytest.mark.parametrize('event_fn, event_type', [
+    pytest.param(info, "Normal", id='info'),
+    pytest.param(warn, "Warning", id='warn'),
+    pytest.param(exception, "Error", id='exception'),
+])
+def test_via_shortcut(mocker, event_fn, event_type):
+    post_event = mocker.patch('kopf.clients.events.post_event')
+
+    event_queue = asyncio.Queue()
+    event_queue_var.set(event_queue)
+    event_fn(OBJ1, reason='reason1', message='message1')
+
+    assert not post_event.called
+    assert event_queue.qsize() == 1
+    event1 = event_queue.get_nowait()
+
+    assert isinstance(event1, K8sEvent)
+    assert event1.ref == REF1
+    assert event1.type == event_type
+    assert event1.reason == 'reason1'
+    assert event1.message == 'message1'


### PR DESCRIPTION
> Issue : closes #111, prepares #117 

## Problem 

In #109, a lot of performance improvements were introduced to make all API calls asynchronous. One of them were the event-posting API calls, which are kind of logging for custom resource handling routines. However, there was a conceptual unresolvable issue:

Event-posting calls like `kopf.event()`, `kopf.info()`, so on — are synchronous functions. When called from an asynchronous coroutines (all of the Kopf internals), there is no way how the flow control can be returned to the asyncio event loop, as it requires `await`, which is a syntax error for sync-functions. The actual event-posting functions via API calls, however, must be async (explicitly or via thread executors), not sync and blocking. 

This problem is nicely described, for example, in this article — https://www.aeracode.org/2018/02/19/python-async-simplified/ — specifically, in "Async From Sync" section. Briefly, the suggested solution is `asgiref.sync.async_to_sync` from Django, which is basically a trick with multiple threads and cross-thread cross-eventloop task orchestration — an overkill for a little event-posting porblem.

One way would be splitting the event-posting functions to sync and async, and letting the developers to decide which one to use. First of all, it adds complexity and complications. Second, API calls must be duplicated: in sync & async way; if we switch to async k8s client, the sync way will be impossible again.

**Summary:** There is no easy way how "async->sync->async" call chain can be made in asyncio.

## Solution

This PR fixes the async-from-sync invocation dilemma by removing the API calls from the event-posting functions _at all_:

No async-from-sync calls — no problem.

Instead, those event-posting functions only remember the relevant object references (name, namespace, uid, etc), and put a k8s-event to a queue to be posted later. An ever-running background task posts the k8s-events to the API from the queue.

**Side-effects:** This can make some events to be slightly delayed. This is okay, with #117 in mind: the events will be not only delayed by time-windows, but also aggregated and maybe altered. Therefore, the concept of guaranteed event posting as part of the function call (and not later) should be abandoned.

## Notes

More on that, **Kopf is not a K8s API client library**, and should not generally provide any means of calling the K8s API. The operator developers should use a K8s client library of their choice to do that. 

Event posting is one of such things. Kopf only provides the tools for making some operator-related activities easier. It internally posts the events, so it has these functions, so it shares them with the operator developers.

**Look-ahead:** In the following PR _(#??? — add when created)_, this whole system will be improved even more to to use the built-in Python logging instead of explicit event posting. The operator developers should use per-object `logger` since then; though the event-posting will stay.


## Types of Changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements

**Public interfaces are unchanged.** Only the async event-posting routines are removed, but they never got into any released version (i.e. not tagged); only to the master branch 1-2 merges before.

## Review

- [ ] Tests
- [ ] Documentation
