### PR TITLE
Cleanup deprecated things and fix the docs

### DIFF
--- a/docs/deployment-depl.yaml
+++ b/docs/deployment-depl.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kopfexample-operator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       application: kopfexample-operator

--- a/docs/walkthrough/creation.rst
+++ b/docs/walkthrough/creation.rst
@@ -68,7 +68,7 @@ We will use the official Kubernetes client library:
         path = os.path.join(os.path.dirname(__file__), 'pvc.yaml')
         tmpl = open(path, 'rt').read()
         text = tmpl.format(name=name, size=size)
-        data = yaml.load(text)
+        data = yaml.safe_load(text)
 
         api = kubernetes.client.CoreV1Api()
         obj = api.create_namespaced_persistent_volume_claim(

--- a/docs/walkthrough/deletion.rst
+++ b/docs/walkthrough/deletion.rst
@@ -50,7 +50,7 @@ Let's extend the creation handler:
         path = os.path.join(os.path.dirname(__file__), 'pvc-tpl.yaml')
         tmpl = open(path, 'rt').read()
         text = tmpl.format(name=name, size=size)
-        data = yaml.load(text)
+        data = yaml.safe_load(text)
 
         kopf.adopt(data, owner=body)
 

--- a/docs/walkthrough/deletion.rst
+++ b/docs/walkthrough/deletion.rst
@@ -40,7 +40,7 @@ Let's extend the creation handler:
     import yaml
 
     @kopf.on.create('zalando.org', 'v1', 'ephemeralvolumeclaims')
-    def create_fn(meta, spec, namespace, logger, **kwargs):
+    def create_fn(meta, body, spec, namespace, logger, **kwargs):
 
         name = meta.get('name')
         size = spec.get('size')

--- a/docs/walkthrough/updates.rst
+++ b/docs/walkthrough/updates.rst
@@ -41,7 +41,7 @@ with one additional line:
         path = os.path.join(os.path.dirname(__file__), 'pvc-tpl.yaml')
         tmpl = open(path, 'rt').read()
         text = tmpl.format(size=size, name=name)
-        data = yaml.load(text)
+        data = yaml.safe_load(text)
 
         kopf.adopt(data, owner=body)
 

--- a/examples/02-children/example.py
+++ b/examples/02-children/example.py
@@ -7,7 +7,7 @@ import yaml
 def create_fn(body, spec, **kwargs):
 
     # Render the pod yaml with some spec fields used in the template.
-    doc = yaml.load(f"""
+    doc = yaml.safe_load(f"""
         apiVersion: v1
         kind: Pod
         spec:

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -15,7 +15,7 @@ and therefore do not trigger the user-defined handlers.
 """
 
 import asyncio
-import collections
+import collections.abc
 import datetime
 import logging
 from contextvars import ContextVar
@@ -275,12 +275,12 @@ async def execute(
     if len([v for v in [fns, handlers, registry] if v is not None]) > 1:
         raise TypeError("Only one of the fns, handlers, registry can be passed. Got more.")
 
-    elif fns is not None and isinstance(fns, collections.Mapping):
+    elif fns is not None and isinstance(fns, collections.abc.Mapping):
         registry = registries.SimpleRegistry(prefix=handler.id if handler else None)
         for id, fn in fns.items():
             registry.register(fn=fn, id=id)
 
-    elif fns is not None and isinstance(fns, collections.Iterable):
+    elif fns is not None and isinstance(fns, collections.abc.Iterable):
         registry = registries.SimpleRegistry(prefix=handler.id if handler else None)
         for fn in fns:
             registry.register(fn=fn)

--- a/kopf/structs/diffs.py
+++ b/kopf/structs/diffs.py
@@ -1,7 +1,7 @@
 """
 All the functions to calculate the diffs of the dicts.
 """
-import collections
+import collections.abc
 
 from typing import Any, Tuple, NewType, Generator, Sequence
 
@@ -44,7 +44,7 @@ def diff_iter(a: Any, b: Any, path: DiffPath = ()) -> Generator[DiffItem, None, 
         yield ('change', path, a, b)
     elif a == b:
         pass  # to exclude the case as soon as possible
-    elif isinstance(a, collections.Mapping):
+    elif isinstance(a, collections.abc.Mapping):
         a_keys = frozenset(a.keys())
         b_keys = frozenset(b.keys())
         for key in b_keys - a_keys:

--- a/tests/cli/test_logging.py
+++ b/tests/cli/test_logging.py
@@ -69,7 +69,7 @@ def test_no_lowlevel_dumps_in_nondebug(invoke, caplog, options, login, preload, 
     (['-d']),
     (['--debug']),
 ], ids=['d', 'debug'])
-async def test_lowlevel_dumps_in_debug_mode(invoke, caplog, options, login, preload, real_run):
+def test_lowlevel_dumps_in_debug_mode(invoke, caplog, options, login, preload, real_run):
     result = invoke(['run'] + options)
     assert result.exit_code == 0
 

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -97,5 +97,5 @@ async def test_delayed_handlers_sleep(
     assert k8s_mocked.asyncio_sleep.call_args_list[0][0][0] == delay
 
     assert_logs([
-        "Sleeping for [\d\.]+ seconds",
+        r"Sleeping for [\d\.]+ seconds",
     ])


### PR DESCRIPTION
> Issue : #13, #115, #116 

Travis & pytest show some amount of warnings on the deprecated usage of some Python-related modules/functions.

This PR fixes them.

It affects nothing except for the purity of the output — both in tests and at runtime.
