### PR TITLE
Log to k8s events

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -22,9 +22,6 @@ from kopf.config import (
     EventsConfig,
     WorkersConfig,
 )
-from kopf.engines.logging import (
-    ObjectLogger,
-)
 from kopf.engines.posting import (
     event,
     info,

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -20,7 +20,10 @@ from kopf.config import (
     LOGLEVEL_ERROR,
     LOGLEVEL_CRITICAL,
     EventsConfig,
-    WorkersConfig
+    WorkersConfig,
+)
+from kopf.engines.logging import (
+    ObjectLogger,
 )
 from kopf.engines.posting import (
     event,

--- a/kopf/config.py
+++ b/kopf/config.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import concurrent.futures
 import logging
@@ -6,6 +5,8 @@ from typing import Optional
 
 import kubernetes
 import kubernetes.client.rest
+
+from kopf.engines import logging as logging_engine
 
 format = '[%(asctime)s] %(name)-20.20s [%(levelname)-8.8s] %(message)s'
 
@@ -25,7 +26,7 @@ def configure(debug=None, verbose=None, quiet=None):
 
     logger = logging.getLogger()
     handler = logging.StreamHandler()
-    formatter = logging.Formatter(format)
+    formatter = logging_engine.ObjectPrefixingFormatter(format)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(log_level)
@@ -86,7 +87,6 @@ class WorkersConfig:
     @staticmethod
     def get_syn_executor() -> concurrent.futures.ThreadPoolExecutor:
         if not WorkersConfig.threadpool_executor:
-            logging.debug('Setting up syn executor')
             WorkersConfig.threadpool_executor = concurrent.futures.ThreadPoolExecutor(
                 max_workers=WorkersConfig.synchronous_tasks_threadpool_limit
             )

--- a/kopf/engines/logging.py
+++ b/kopf/engines/logging.py
@@ -1,0 +1,137 @@
+"""
+A connection between object logger and background k8s-event poster.
+
+Everything logged to the object logger (except for debug information)
+is also posted as the k8s-event -- in the background: `kopf.engines.posting`.
+
+This eliminates the need to log & post the same messages, which complicates
+the operators' code, and can lead to information loss or mismatch
+(e.g. when logging call is added, but posting is forgotten).
+"""
+import copy
+import logging
+
+from kopf.engines import posting
+
+
+class ObjectPrefixingFormatter(logging.Formatter):
+    """ An utility to prefix the per-object log messages. """
+
+    def format(self, record):
+        if hasattr(record, 'k8s_ref'):
+            ref = record.k8s_ref
+            prefix = f"[{ref['namespace']}/{ref['name']}]"
+            record = copy.copy(record)  # shallow
+            record.msg = f"{prefix} {record.msg}"
+        return super().format(record)
+
+
+class K8sPoster(logging.Handler):
+    """
+    A handler to post all log messages as K8s events.
+    """
+
+    def __init__(self, level=logging.NOTSET, queue=None):
+        super().__init__(level=level)
+        self.queue = queue
+
+    def createLock(self):
+        # Save some time on unneeded locks. Events are posted in the background.
+        # We only put events to the queue, which is already lock-protected.
+        self.lock = None
+
+    def filter(self, record):
+        # Only those which have a k8s object referred (see: `ObjectLogger`).
+        # Otherwise, we have nothing to post, and nothing to do.
+        has_ref = hasattr(record, 'k8s_ref')
+        skipped = hasattr(record, 'k8s_skip') and record.k8s_skip
+        return has_ref and not skipped and super().filter(record)
+
+    def emit(self, record):
+        type = (
+            "Debug" if record.levelno <= logging.DEBUG else
+            "Normal" if record.levelno <= logging.INFO else
+            "Warning" if record.levelno <= logging.WARNING else
+            "Error" if record.levelno <= logging.ERROR else
+            "Fatal" if record.levelno <= logging.FATAL else
+            logging.getLevelName(record.levelno).capitalize())
+        reason = 'Logging'
+        message = self.format(record)
+        self.queue.put_nowait(posting.K8sEvent(
+            ref=record.k8s_ref,
+            type=type,
+            reason=reason,
+            message=message))
+
+
+class ObjectLogger(logging.LoggerAdapter):
+    """
+    A logger/adapter to carry the object identifiers for formatting.
+
+    The identifiers are then used both for formatting the per-object messages
+    in `ObjectPrefixingFormatter`, and when posting the per-object k8s-events.
+
+    Constructed in event handling of each individual object.
+
+    The internal structure is made the same as an object reference in K8s API,
+    but can change over time to anything needed for our internal purposes.
+    However, the as little information should be carried as possible,
+    and the information should be protected against the object modification
+    (e.g. in case of background posting via the queue; see `K8sPoster`).
+    """
+
+    def __init__(self, *, body, event_level=logging.INFO, event_queue=None):
+        super().__init__(self._make_logger(event_level, event_queue), dict(
+            k8s_skip=False,
+            k8s_ref=dict(
+                apiVersion=body.get('apiVersion'),
+                kind=body.get('kind'),
+                name=body.get('metadata', {}).get('name'),
+                uid=body.get('metadata', {}).get('uid'),
+                namespace=body.get('metadata', {}).get('namespace'),
+            ),
+        ))
+        self.queue = event_queue  # for kopf.event()&co explicit posting
+
+    def __del__(self):
+        # When an object logger is garbage-collected, purge its handlers & posting queues.
+        # Note: Depending on the garbage collection setup, this can never happen or be delayed.
+        # In this case, the object logger stays ready to log, i.e. keeps its handler+queue.
+        # TODO: also remove the dynamic logger itself, to avoid memory leaks.
+        for handler in list(self.logger.handlers):
+            if isinstance(handler, K8sPoster):
+                self.logger.removeHandler(handler)
+                handler.close()
+
+    def _make_logger(self, event_level, event_queue):
+        """
+        Get-or-create a logger for this event queue, and setup the k8s poster.
+
+        If only one global queue is used, it will be one logger.
+
+        If multiple queues are used, each queue uses its own logger
+        with its own handler. This is currently needed for tests
+        (every test provides and later asserts its own k8s-event queue).
+
+        In the future, or now via user tweaks, the framework can create
+        separate k8s-event-queues per resource kind, per individual objects,
+        or on another grouping basis. They should not duplicate each other
+        by posting the same log-message to k8s more than once.
+        For this purpose, separate `logging.Logger` instances are used:
+        strictly one per an `ObjectLogger` instance, dynamically created.
+        """
+        logger = logging.getLogger(f'kopf.objects.{id(event_queue)}')
+        if not logger.handlers:
+            logger.addHandler(K8sPoster(level=event_level, queue=event_queue))
+        return logger
+
+    def process(self, msg, kwargs):
+        # Native logging overwrites the message's extra with the adapter's extra.
+        # We merge them, so that both message's & adapter's extras are available.
+        kwargs["extra"] = dict(self.extra, **kwargs.get('extra', {}))
+        return msg, kwargs
+
+    def log(self, level, msg, *args, local=False, **kwargs):
+        if local:
+            kwargs['extra'] = dict(kwargs.pop('extra', {}), k8s_skip=True)
+        super().log(level, msg, *args, **kwargs)

--- a/kopf/engines/logging.py
+++ b/kopf/engines/logging.py
@@ -79,7 +79,7 @@ class ObjectLogger(logging.LoggerAdapter):
 
     The internal structure is made the same as an object reference in K8s API,
     but can change over time to anything needed for our internal purposes.
-    However, the as little information should be carried as possible,
+    However, as little information should be carried as possible,
     and the information should be protected against the object modification
     (e.g. in case of background posting via the queue; see `K8sPoster`).
     """

--- a/kopf/engines/posting.py
+++ b/kopf/engines/posting.py
@@ -6,6 +6,13 @@ and can be used directly from the handlers to add arbitrary custom events.
 
 The actual k8s-event posting runs in the background,
 and posts the k8s-events as soon as they are queued.
+
+The k8s-events are queued in two ways:
+
+* Explicit calls to `kopf.event`, `kopf.info`, `kopf.warn`, `kopf.exception`.
+* Logging messages made on the object logger (above INFO level by default).
+
+This also includes all logging messages posted by the framework itself.
 """
 import asyncio
 import sys

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -17,11 +17,11 @@ and therefore do not trigger the user-defined handlers.
 import asyncio
 import collections
 import datetime
-import logging
 from contextvars import ContextVar
-from typing import Optional, Callable, Iterable, Union, Collection
+from typing import Optional, Callable, Iterable, Collection
 
 from kopf.clients import patching
+from kopf.engines import logging as logging_engine
 from kopf.engines import posting
 from kopf.reactor import causation
 from kopf.reactor import invocation
@@ -37,12 +37,6 @@ WAITING_KEEPALIVE_INTERVAL = 10 * 60
 
 DEFAULT_RETRY_DELAY = 1 * 60
 """ The default delay duration for the regular exception in retry-mode. """
-
-
-class ObjectLogger(logging.LoggerAdapter):
-    """ An utility to prefix the per-object log messages. """
-    def process(self, msg, kwargs):
-        return f"[{self.extra['namespace']}/{self.extra['name']}] {msg}", kwargs
 
 
 class HandlerFatalError(Exception):
@@ -95,10 +89,7 @@ async def custom_object_handler(
     patch = {}
 
     # Each object has its own prefixed logger, to distinguish parallel handling.
-    logger = ObjectLogger(logging.getLogger(__name__), extra=dict(
-        namespace=body.get('metadata', {}).get('namespace', 'default'),
-        name=body.get('metadata', {}).get('name', body.get('metadata', {}).get('uid', None)),
-    ))
+    logger = logging_engine.ObjectLogger(body=body, event_queue=event_queue)
     posting.event_queue_var.set(event_queue)  # till the end of this object's task.
 
     # If the global freeze is set for the processing (i.e. other operator overrides), do nothing.
@@ -129,14 +120,14 @@ async def custom_object_handler(
 
     # Sleep strictly after patching, never before -- to keep the status proper.
     if delay:
-        logger.info(f"Sleeping for {delay} seconds for the delayed handlers.")
+        logger.debug(f"Sleeping for {delay} seconds for the delayed handlers.")
         await asyncio.sleep(delay)
 
 
 async def handle_event(
         registry: registries.BaseRegistry,
         resource: registries.Resource,
-        logger: Union[logging.LoggerAdapter, logging.Logger],
+        logger: logging_engine.ObjectLogger,
         patch: dict,
         event: dict,
 ):
@@ -146,6 +137,9 @@ async def handle_event(
     This is a lightweight version of the cause handling, but for the raw events,
     without any progress persistence. Multi-step calls are also not supported.
     If the handler fails, it fails and is never retried.
+
+    Note: K8s-event posting is skipped for `kopf.on.event` handlers,
+    as they should be silent. Still, the messages are logged normally.
     """
     handlers = registry.get_event_handlers(resource=resource, event=event)
     for handler in handlers:
@@ -163,10 +157,10 @@ async def handle_event(
             )
 
         except Exception:
-            logger.exception(f"Handler {handler.id!r} failed with an exception. Will ignore.")
+            logger.exception(f"Handler {handler.id!r} failed with an exception. Will ignore.", local=True)
 
         else:
-            logger.info(f"Handler {handler.id!r} succeeded.")
+            logger.info(f"Handler {handler.id!r} succeeded.", local=True)
             status.store_result(patch=patch, handler=handler, result=result)
 
 
@@ -207,7 +201,6 @@ async def handle_cause(
                 done = False
             else:
                 logger.info(f"All handlers succeeded for {title}.")
-                posting.info(cause.body, reason='Success', message=f"All handlers succeeded for {title}.")
                 done = True
         else:
             skip = True
@@ -378,21 +371,19 @@ async def _execute(
 
         # Unfinished children cause the regular retry, but with less logging and event reporting.
         except HandlerChildrenRetry as e:
-            logger.info(f"Handler {handler.id!r} has unfinished sub-handlers. Will retry soon.")
+            logger.debug(f"Handler {handler.id!r} has unfinished sub-handlers. Will retry soon.")
             status.set_retry_time(body=cause.body, patch=cause.patch, handler=handler, delay=e.delay)
             handlers_left.append(handler)
 
         # Definitely retriable error, no matter what is the error-reaction mode.
         except HandlerRetryError as e:
             logger.exception(f"Handler {handler.id!r} failed with a retry exception. Will retry.")
-            posting.exception(cause.body, message=f"Handler {handler.id!r} failed. Will retry.")
             status.set_retry_time(body=cause.body, patch=cause.patch, handler=handler, delay=e.delay)
             handlers_left.append(handler)
 
         # Definitely fatal error, no matter what is the error-reaction mode.
         except HandlerFatalError as e:
             logger.exception(f"Handler {handler.id!r} failed with a fatal exception. Will stop.")
-            posting.exception(cause.body, message=f"Handler {handler.id!r} failed. Will stop.")
             status.store_failure(body=cause.body, patch=cause.patch, handler=handler, exc=e)
             # TODO: report the handling failure somehow (beside logs/events). persistent status?
 
@@ -400,19 +391,16 @@ async def _execute(
         except Exception as e:
             if retry_on_errors:
                 logger.exception(f"Handler {handler.id!r} failed with an exception. Will retry.")
-                posting.exception(cause.body, message=f"Handler {handler.id!r} failed. Will retry.")
                 status.set_retry_time(body=cause.body, patch=cause.patch, handler=handler, delay=DEFAULT_RETRY_DELAY)
                 handlers_left.append(handler)
             else:
                 logger.exception(f"Handler {handler.id!r} failed with an exception. Will stop.")
-                posting.exception(cause.body, message=f"Handler {handler.id!r} failed. Will stop.")
                 status.store_failure(body=cause.body, patch=cause.patch, handler=handler, exc=e)
                 # TODO: report the handling failure somehow (beside logs/events). persistent status?
 
         # No errors means the handler should be excluded from future runs in this reaction cycle.
         else:
             logger.info(f"Handler {handler.id!r} succeeded.")
-            posting.info(cause.body, reason='Success', message=f"Handler {handler.id!r} succeeded.")
             status.store_success(body=cause.body, patch=cause.patch, handler=handler, result=result)
 
     # Provoke the retry of the handling cycle if there were any unfinished handlers,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import asyncio
+import io
+import logging
 import re
 import time
 
@@ -6,6 +8,8 @@ import asynctest
 import pytest
 import pytest_mock
 
+from kopf.config import configure
+from kopf.engines.logging import ObjectPrefixingFormatter
 from kopf.reactor.registries import Resource
 
 
@@ -87,6 +91,30 @@ class Timer(object):
 #
 # Helpers for the logging checks.
 #
+
+
+@pytest.fixture()
+def logstream(caplog):
+    """ Prefixing is done at the final output. We have to intercept it. """
+
+    logger = logging.getLogger()
+    handlers = list(logger.handlers)
+
+    configure(verbose=True)
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    formatter = ObjectPrefixingFormatter('prefix %(message)s')
+    handler.setFormatter(formatter)
+
+    logger.addHandler(handler)
+    try:
+        with caplog.at_level(logging.DEBUG):
+            yield stream
+    finally:
+        logger.removeHandler(handler)
+        logger.handlers[:] = handlers  # undo `configure()`
+
 
 @pytest.fixture()
 def assert_logs(caplog):

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -1,17 +1,39 @@
 import asyncio
+import io
 import logging
 
 import pytest
 
 import kopf
+from kopf.engines.logging import ObjectPrefixingFormatter
 from kopf.reactor.causation import ALL_CAUSES, HANDLER_CAUSES
 from kopf.reactor.handling import custom_object_handler
 
 
+@pytest.fixture()
+def logstream(caplog):
+    """ Prefixing is done at the final output. We have to intercept it. """
+
+    kopf.configure(verbose=True)
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    formatter = ObjectPrefixingFormatter('prefix %(message)s')
+    handler.setFormatter(formatter)
+
+    logger = logging.getLogger()
+    logger.addHandler(handler)
+    try:
+        with caplog.at_level(logging.DEBUG):
+            yield stream
+    finally:
+        logger.removeHandler(handler)
+        logger.handlers[:] = []  # undo `kopf.configure()`
+
+
 @pytest.mark.parametrize('cause_type', ALL_CAUSES)
 async def test_all_logs_are_prefixed(registry, resource, handlers,
-                                     caplog, cause_type, cause_mock):
-    caplog.set_level(logging.DEBUG)
+                                     logstream, cause_type, cause_mock):
     cause_mock.event = cause_type
 
     await custom_object_handler(
@@ -22,8 +44,10 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
         freeze=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
-    assert caplog.messages  # no messages means that we cannot test it
-    assert all(message.startswith('[ns1/name1] ') for message in caplog.messages)
+
+    lines = logstream.getvalue().splitlines()
+    assert lines  # no messages means that we cannot test it
+    assert all(line.startswith('prefix [ns1/name1] ') for line in lines)
 
 
 @pytest.mark.parametrize('diff', [

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -1,34 +1,11 @@
 import asyncio
-import io
 import logging
 
 import pytest
 
 import kopf
-from kopf.engines.logging import ObjectPrefixingFormatter
 from kopf.reactor.causation import ALL_CAUSES, HANDLER_CAUSES
 from kopf.reactor.handling import custom_object_handler
-
-
-@pytest.fixture()
-def logstream(caplog):
-    """ Prefixing is done at the final output. We have to intercept it. """
-
-    kopf.configure(verbose=True)
-
-    stream = io.StringIO()
-    handler = logging.StreamHandler(stream)
-    formatter = ObjectPrefixingFormatter('prefix %(message)s')
-    handler.setFormatter(formatter)
-
-    logger = logging.getLogger()
-    logger.addHandler(handler)
-    try:
-        with caplog.at_level(logging.DEBUG):
-            yield stream
-    finally:
-        logger.removeHandler(handler)
-        logger.handlers[:] = []  # undo `kopf.configure()`
 
 
 @pytest.mark.parametrize('cause_type', ALL_CAUSES)

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -38,5 +38,5 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
     assert not asyncio_sleep.called
 
     assert_logs([
-        r"\[ns1/name1\] Ignoring the events due to freeze.",
+        r"Ignoring the events due to freeze.",
     ])

--- a/tests/posting/test_log2k8s.py
+++ b/tests/posting/test_log2k8s.py
@@ -1,40 +1,13 @@
 import asyncio
-import io
-import logging
 
 import pytest
 
-import kopf
 from kopf.engines.logging import ObjectLogger
-from kopf.engines.logging import ObjectPrefixingFormatter
 
 OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
         'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}}
 REF1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
         'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}
-
-
-@pytest.fixture()
-def logstream(caplog):
-    """ Prefixing is done at the final output. We have to intercept it. """
-
-    logger = logging.getLogger()
-    handlers = list(logger.handlers)
-
-    kopf.configure(verbose=True)
-
-    stream = io.StringIO()
-    handler = logging.StreamHandler(stream)
-    formatter = ObjectPrefixingFormatter('prefix %(message)s')
-    handler.setFormatter(formatter)
-
-    logger.addHandler(handler)
-    try:
-        with caplog.at_level(logging.DEBUG):
-            yield stream
-    finally:
-        logger.removeHandler(handler)
-        logger.handlers[:] = handlers  # undo `kopf.configure()`
 
 
 @pytest.mark.parametrize('logfn, event_type', [

--- a/tests/posting/test_log2k8s.py
+++ b/tests/posting/test_log2k8s.py
@@ -1,0 +1,88 @@
+import asyncio
+import io
+import logging
+
+import pytest
+
+import kopf
+from kopf.engines.logging import ObjectLogger
+from kopf.engines.logging import ObjectPrefixingFormatter
+
+OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
+        'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}}
+REF1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
+        'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}
+
+
+@pytest.fixture()
+def logstream(caplog):
+    """ Prefixing is done at the final output. We have to intercept it. """
+
+    logger = logging.getLogger()
+    handlers = list(logger.handlers)
+
+    kopf.configure(verbose=True)
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    formatter = ObjectPrefixingFormatter('prefix %(message)s')
+    handler.setFormatter(formatter)
+
+    logger.addHandler(handler)
+    try:
+        with caplog.at_level(logging.DEBUG):
+            yield stream
+    finally:
+        logger.removeHandler(handler)
+        logger.handlers[:] = handlers  # undo `kopf.configure()`
+
+
+@pytest.mark.parametrize('logfn, event_type', [
+    ['info', "Normal"],
+    ['warning', "Warning"],
+    ['error', "Error"],
+    ['critical', "Fatal"],
+])
+def test_posting_normal_levels(caplog, logstream, logfn, event_type):
+    queue = asyncio.Queue()
+    logger = ObjectLogger(body=OBJ1, event_queue=queue)
+
+    getattr(logger, logfn)("hello %s", "world")
+
+    assert queue.qsize() == 1
+    event1 = queue.get_nowait()
+    assert event1.ref == REF1
+    assert event1.type == event_type
+    assert event1.reason == "Logging"
+    assert event1.message == "hello world"
+    assert caplog.messages == ["hello world"]
+
+
+@pytest.mark.parametrize('logfn', [
+    'debug',
+])
+def test_skipping_debug_level(caplog, logstream, logfn):
+    queue = asyncio.Queue()
+    logger = ObjectLogger(body=OBJ1, event_queue=queue)
+
+    getattr(logger, logfn)("hello %s", "world")
+
+    assert queue.empty()
+    assert caplog.messages == ["hello world"]
+
+
+@pytest.mark.parametrize('logfn', [
+    'debug',
+    'info',
+    'warning',
+    'error',
+    'critical',
+])
+def test_skipping_when_local_with_all_level(caplog, logstream, logfn):
+    queue = asyncio.Queue()
+    logger = ObjectLogger(body=OBJ1, event_queue=queue)
+
+    getattr(logger, logfn)("hello %s", "world", local=True)
+
+    assert queue.empty()
+    assert caplog.messages == ["hello world"]

--- a/tests/posting/test_selfdestruction.py
+++ b/tests/posting/test_selfdestruction.py
@@ -1,0 +1,27 @@
+import asyncio
+import gc
+import logging
+import weakref
+
+from kopf.engines.logging import ObjectLogger
+
+OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
+        'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}}
+
+
+def test_garbage_collection_of_log_handlers():
+
+    event_queue = asyncio.Queue()
+    native_logger = logging.getLogger(f'kopf.objects.{id(event_queue)}')
+    assert len(native_logger.handlers) == 0
+
+    object_logger = ObjectLogger(body=OBJ1, event_queue=event_queue)
+    assert object_logger.logger is native_logger
+    assert len(native_logger.handlers) == 1
+
+    object_logger_ref = weakref.ref(object_logger)
+    del object_logger
+    gc.collect()  # triggers ObjectLogger.__del__()
+
+    assert object_logger_ref() is None  # garbage-collected indeed.
+    assert len(native_logger.handlers) == 0


### PR DESCRIPTION
> Issue : #136 

_As a logical continuation of #125:_

## Description

Kopf is not a K8s API client library. Therefore, it should not provide any means of talking to the K8s API. The operators developers should use the K8s API client libraries of their choice. This also applies to K8s-event posting.

However, Kopf provides few routines for k8s-event posting: `kopf.event()`, `kopf.info()`, `kopf.warn()`, `kopf.exception()`. This is highly useful for logging not only to the logs (stdout/stderr), but also to K8s itself.

To deal with this dilemma, this PR changes the way how Kopf deals with this specific field — logging to k8s events:

Instead of providing the methods to explicitly post everything in addition to regular logging (thus duplicating the messages and code), everything logged to the per-object logger is now posted to K8s events transparently.

Was:

```python
@kopf.on.create('zalando.org', 'v1', 'kopfexamples')
def create_fn(logger, **kwargs):
    child = _create_child()
    kopf.info("Created a child: %s".format(child.id))
    logger.info("Created a child: %s", child.id)
```

Now:

```python
@kopf.on.create('zalando.org', 'v1', 'kopfexamples')
def create_fn(logger, **kwargs):
    child = _create_child()
    logger.info("Created a child: %s", child.id)
```

In the latter case, an k8s-event will be created too.

Only the log messages with level INFO+ will be posted. The DEBUG messages will **not** be posted (but will be logged as usually).

Only the messages logged to the per-object logger are posted. The rest of the `logging` machinery is **not** affected.

The existing k8s-event-posting routines remain in place. They continue to post the events as usually, attached to the specified object (their first positional argument).

All of the internal Kopf-originated events are now also posted that way — via the per-object logger (some were lowered to the DEBUG level to reduce noise).


## Types of Changes

- New feature (non-breaking change which adds functionality)
- Refactor/improvements

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
