### PR TITLE
Purge status & metadata from the last-handled state

### DIFF
--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -152,3 +152,16 @@ def detect_cause(
         body=body,
         initial=initial,
         **kwargs)
+
+
+def enrich_cause(
+        cause: Cause,
+        **kwargs
+) -> Cause:
+    """
+    Produce a new derived cause with some fields modified ().
+
+    Usually, those are the old/new/diff fields, and used when a field-handler
+    is invoked (the old/new/diff refer to the field's values only).
+    """
+    return cause._replace(**kwargs)

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -454,7 +454,7 @@ async def _call_handler(
     old = cause.old if handler.field is None else dicts.resolve(cause.old, handler.field, None)
     new = cause.new if handler.field is None else dicts.resolve(cause.new, handler.field, None)
     diff = cause.diff if handler.field is None else diffs.reduce(cause.diff, handler.field)
-    cause = cause._replace(old=old, new=new, diff=diff)
+    cause = causation.enrich_cause(cause=cause, old=old, new=new, diff=diff)
 
     # Store the context of the current resource-object-event-handler, to be used in `@kopf.on.this`,
     # and maybe other places, and consumed in the recursive `execute()` calls for the children.

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -113,7 +113,8 @@ async def custom_object_handler(
     # Object patch accumulator. Populated by the methods. Applied in the end of the handler.
     # Detect the cause and handle it (or at least log this happened).
     if registry.has_cause_handlers(resource=resource):
-        old, new, diff = lastseen.get_state_diffs(body=body)
+        extra_fields = registry.get_extra_fields(resource=resource)
+        old, new, diff = lastseen.get_state_diffs(body=body, extra_fields=extra_fields)
         cause = causation.detect_cause(event=event, resource=resource,
                                        logger=logger, patch=patch,
                                        old=old, new=new, diff=diff)
@@ -217,7 +218,8 @@ async def handle_cause(
 
     # Regular causes also do some implicit post-handling when all handlers are done.
     if done or skip:
-        lastseen.refresh_state(body=body, patch=patch)
+        extra_fields = registry.get_extra_fields(resource=cause.resource)
+        lastseen.refresh_state(body=body, patch=patch, extra_fields=extra_fields)
         if done:
             status.purge_progress(body=body, patch=patch)
         if cause.event == causation.DELETE:

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -113,7 +113,10 @@ async def custom_object_handler(
     # Object patch accumulator. Populated by the methods. Applied in the end of the handler.
     # Detect the cause and handle it (or at least log this happened).
     if registry.has_cause_handlers(resource=resource):
-        cause = causation.detect_cause(event=event, resource=resource, logger=logger, patch=patch)
+        old, new, diff = lastseen.get_state_diffs(body=body)
+        cause = causation.detect_cause(event=event, resource=resource,
+                                       logger=logger, patch=patch,
+                                       old=old, new=new, diff=diff)
         delay = await handle_cause(lifecycle=lifecycle, registry=registry, cause=cause)
 
     # Provoke a dummy change to trigger the reactor after sleep.

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -190,7 +190,7 @@ async def handle_cause(
 
         title = causation.TITLES.get(cause.event, repr(cause.event))
         logger.debug(f"{title.capitalize()} event: %r", body)
-        if cause.diff is not None:
+        if cause.diff is not None and cause.old is not None and cause.new is not None:
             logger.debug(f"{title.capitalize()} diff: %r", cause.diff)
 
         handlers = registry.get_cause_handlers(cause=cause)

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -52,6 +52,13 @@ class BaseRegistry(metaclass=abc.ABCMeta):
     def iter_event_handlers(self, resource, event):
         pass
 
+    def get_extra_fields(self, resource):
+        return set(self.iter_extra_fields(resource=resource))
+
+    @abc.abstractmethod
+    def iter_extra_fields(self, resource):
+        pass
+
     @staticmethod
     def _deduplicated(handlers):
         """
@@ -134,6 +141,11 @@ class SimpleRegistry(BaseRegistry):
         for handler in self._handlers:
             yield handler
 
+    def iter_extra_fields(self, resource):
+        for handler in self._handlers:
+            if handler.field:
+                yield handler.field
+
 
 def get_callable_id(c):
     """ Get an reasonably good id of any commonly used callable. """
@@ -213,6 +225,11 @@ class GlobalRegistry(BaseRegistry):
         resource_registry = self._event_handlers.get(resource, None)
         if resource_registry is not None:
             yield from resource_registry.iter_event_handlers(resource=resource, event=event)
+
+    def iter_extra_fields(self, resource):
+        resource_registry = self._cause_handlers.get(resource, None)
+        if resource_registry is not None:
+            yield from resource_registry.iter_extra_fields(resource=resource)
 
 
 _default_registry = GlobalRegistry()

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -15,6 +15,13 @@ def parse_field(
 ) -> FieldPath:
     """
     Convert any field into a tuple of nested sub-fields.
+
+    Supported notations:
+
+    * ``None`` (for root of a dict).
+    * ``"field.subfield"``
+    * ``("field", "subfield")``
+    * ``["field", "subfield"]``
     """
     if field is None:
         return tuple()

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -2,7 +2,7 @@
 Some basic dicts and field-in-a-dict manipulation helpers.
 """
 import collections.abc
-from typing import Any, Union, Mapping, Tuple, List, Text, Iterable, Optional
+from typing import Any, Union, MutableMapping, Mapping, Tuple, List, Text, Iterable, Optional
 
 FieldPath = Tuple[str, ...]
 FieldSpec = Union[None, Text, FieldPath, List[str]]
@@ -52,6 +52,42 @@ def resolve(
             raise
         else:
             return default
+
+
+def ensure(
+        d: MutableMapping,
+        field: FieldSpec,
+        value: Any,
+):
+    """
+    Force-set a nested sub-field in a dict.
+    """
+    result = d
+    path = parse_field(field)
+    if not path:
+        raise ValueError("Setting a root of a dict is impossible. Provide the specific fields.")
+    for key in path[:-1]:
+        try:
+            result = result[key]
+        except KeyError:
+            result = result.setdefault(key, {})
+    result[path[-1]] = value
+
+
+def cherrypick(
+        src: Mapping,
+        dst: MutableMapping,
+        fields: Optional[Iterable[FieldSpec]],
+):
+    """
+    Copy all specified fields between dicts (from src to dst).
+    """
+    fields = fields if fields is not None else []
+    for field in fields:
+        try:
+            ensure(dst, field, resolve(src, field))
+        except KeyError:
+            pass  # absent in the source, nothing to merge
 
 
 def walk(

--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -37,6 +37,10 @@ def get_state(body, extra_fields=None):
     orig = copy.deepcopy(body)
     body = copy.deepcopy(body)
 
+    # Purge the whole stenzas with system info (extra-fields are restored below).
+    if 'status' in body:
+        del body['status']
+
     # Remove the system fields, keeping the potentially useful, user-oriented fields/data.
     if LAST_SEEN_ANNOTATION in body.get('metadata', {}).get('annotations', {}):
         del body['metadata']['annotations'][LAST_SEEN_ANNOTATION]
@@ -56,8 +60,6 @@ def get_state(body, extra_fields=None):
         del body['metadata']['resourceVersion']
     if 'generation' in body.get('metadata', {}):
         del body['metadata']['generation']
-    if 'kopf' in body.get('status', {}):
-        del body['status']['kopf']
 
     # Restore all explicitly whitelisted extra-fields from the original body.
     dicts.cherrypick(src=orig, dst=body, fields=extra_fields)

--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -41,6 +41,12 @@ def get_state(body, extra_fields=None):
     orig = copy.deepcopy(body)
     body = copy.deepcopy(body)
 
+    # The top-level identifying fields never change, so there is not need to track them.
+    if 'apiVersion' in body:
+        del body['apiVersion']
+    if 'kind' in body:
+        del body['kind']
+
     # Purge the whole stenzas with system info (extra-fields are restored below).
     if 'metadata' in body:
         del body['metadata']

--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -67,13 +67,6 @@ def has_state(body):
     return LAST_SEEN_ANNOTATION in annotations
 
 
-def is_state_changed(body):
-    # TODO: make it more efficient, so that the dicts are not rebuilt locally every time.
-    old = retreive_state(body)
-    new = get_state(body)
-    return old != new
-
-
 def get_state_diffs(body):
     old = retreive_state(body)
     new = get_state(body)

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -205,14 +205,6 @@ def test_for_update(kwargs, event, finalizers, deletion_ts, annotations, content
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_cause(event=event, **kwargs)
+    cause = detect_cause(event=event, diff=True, **kwargs)
     assert cause.event == UPDATE
     check_kwargs(cause, kwargs)
-
-    # Diffs are tested elsewhere, but quickly check the absence of meta-fields.
-    assert cause.diff
-    assert len(cause.diff) == 1
-    assert cause.diff[0][0] == 'change'
-    assert cause.diff[0][1] == ('spec', 'field')
-    assert cause.diff[0][2] == 'other'
-    assert cause.diff[0][3] == 'value'

--- a/tests/diffs-n-dicts/test_cherrypicking.py
+++ b/tests/diffs-n-dicts/test_cherrypicking.py
@@ -1,0 +1,66 @@
+import pytest
+
+from kopf.structs.dicts import cherrypick
+
+
+def test_overrides_existing_keys():
+    src = {'ignored-key': 'src-val', 'tested-key': 'src-val'}
+    dst = {'ignored-key': 'dst-val', 'tested-key': 'dst-val'}
+    cherrypick(src=src, dst=dst, fields=['tested-key'])
+    assert dst == {'ignored-key': 'dst-val', 'tested-key': 'src-val'}
+
+
+def test_adds_absent_dst_keys():
+    src = {'ignored-key': 'src-val', 'tested-key': 'src-val'}
+    dst = {'ignored-key': 'dst-val'}
+    cherrypick(src=src, dst=dst, fields=['tested-key'])
+    assert dst == {'ignored-key': 'dst-val', 'tested-key': 'src-val'}
+
+
+def test_skips_absent_src_keys():
+    src = {'ignored-key': 'src-val'}
+    dst = {'ignored-key': 'dst-val', 'tested-key': 'dst-val'}
+    cherrypick(src=src, dst=dst, fields=['tested-key'])
+    assert dst == {'ignored-key': 'dst-val', 'tested-key': 'dst-val'}
+
+
+def test_overrides_existing_subkeys():
+    src = {'sub': {'ignored-key': 'src-val', 'tested-key': 'src-val'}}
+    dst = {'sub': {'ignored-key': 'dst-val', 'tested-key': 'dst-val'}}
+    cherrypick(src=src, dst=dst, fields=['sub.tested-key'])
+    assert dst == {'sub': {'ignored-key': 'dst-val', 'tested-key': 'src-val'}}
+
+
+def test_adds_absent_dst_subkeys():
+    src = {'sub': {'ignored-key': 'src-val', 'tested-key': 'src-val'}}
+    dst = {'sub': {'ignored-key': 'dst-val'}}
+    cherrypick(src=src, dst=dst, fields=['sub.tested-key'])
+    assert dst == {'sub': {'ignored-key': 'dst-val', 'tested-key': 'src-val'}}
+
+
+def test_skips_absent_src_subkeys():
+    src = {'sub': {'ignored-key': 'src-val'}}
+    dst = {'sub': {'ignored-key': 'dst-val', 'tested-key': 'dst-val'}}
+    cherrypick(src=src, dst=dst, fields=['sub.tested-key'])
+    assert dst == {'sub': {'ignored-key': 'dst-val', 'tested-key': 'dst-val'}}
+
+
+def test_ensures_dst_subdicts():
+    src = {'sub': {'ignored-key': 'src-val', 'tested-key': 'src-val'}}
+    dst = {}
+    cherrypick(src=src, dst=dst, fields=['sub.tested-key'])
+    assert dst == {'sub': {'tested-key': 'src-val'}}
+
+
+def test_fails_on_nonmapping_src_key():
+    src = {'sub': 'scalar-value'}
+    dst = {'sub': {'ignored-key': 'src-val', 'tested-key': 'src-val'}}
+    with pytest.raises(TypeError):
+        cherrypick(src=src, dst=dst, fields=['sub.tested-key'])
+
+
+def test_fails_on_nonmapping_dst_key():
+    src = {'sub': {'ignored-key': 'src-val', 'tested-key': 'src-val'}}
+    dst = {'sub': 'scalar-value'}
+    with pytest.raises(TypeError):
+        cherrypick(src=src, dst=dst, fields=['sub.tested-key'])

--- a/tests/diffs-n-dicts/test_ensuring.py
+++ b/tests/diffs-n-dicts/test_ensuring.py
@@ -1,0 +1,40 @@
+import pytest
+
+from kopf.structs.dicts import ensure
+
+
+def test_existing_key():
+    d = {'abc': {'def': {'hij': 'val'}}}
+    ensure(d, ['abc', 'def', 'hij'], 'new')
+    assert d == {'abc': {'def': {'hij': 'new'}}}
+
+
+def test_unexisting_key_in_existing_dict():
+    d = {'abc': {'def': {}}}
+    ensure(d, ['abc', 'def', 'hij'], 'new')
+    assert d == {'abc': {'def': {'hij': 'new'}}}
+
+
+def test_unexisting_key_in_unexisting_dict():
+    d = {}
+    ensure(d, ['abc', 'def', 'hij'], 'new')
+    assert d == {'abc': {'def': {'hij': 'new'}}}
+
+
+def test_toplevel_key():
+    d = {'key': 'val'}
+    ensure(d, ['key'], 'new')
+    assert d == {'key': 'new'}
+
+
+def test_nonmapping_key():
+    d = {'key': 'val'}
+    with pytest.raises(TypeError):
+        ensure(d, ['key', 'sub'], 'new')
+
+
+def test_empty_path():
+    d = {}
+    with pytest.raises(ValueError) as e:
+        ensure(d, [], 'new')
+    assert "Setting a root of a dict is impossible" in str(e.value)

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -193,10 +193,14 @@ def cause_mock(mocker, resource):
         original_event = kwargs.pop('event', None)
         original_body = kwargs.pop('body', None)
         original_diff = kwargs.pop('diff', None)
+        original_new = kwargs.pop('new', None)
+        original_old = kwargs.pop('old', None)
         event = mock.event if mock.event is not None else original_event
         initial = bool(event == RESUME)
         body = copy.deepcopy(mock.body) if mock.body is not None else original_body
         diff = copy.deepcopy(mock.diff) if mock.diff is not None else original_diff
+        new = copy.deepcopy(mock.new) if mock.new is not None else original_new
+        old = copy.deepcopy(mock.old) if mock.old is not None else original_old
 
         # Pass through kwargs: resource, logger, patch, diff, old, new.
         # I.e. everything except what we mock: event & body.
@@ -205,6 +209,8 @@ def cause_mock(mocker, resource):
             initial=initial,
             body=body,
             diff=diff,
+            new=new,
+            old=old,
             **kwargs)
 
         # Needed for the k8s-event creation, as they are attached to objects.
@@ -220,8 +226,10 @@ def cause_mock(mocker, resource):
     mocker.patch('kopf.reactor.causation.detect_cause', new=new_detect_fn)
 
     # The mock object stores some values later used by the factory substitute.
-    mock = mocker.Mock(spec_set=['event', 'body', 'diff'])
+    mock = mocker.Mock(spec_set=['event', 'body', 'diff', 'new', 'old'])
     mock.event = None
     mock.body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
     mock.diff = None
+    mock.new = None
+    mock.old = None
     return mock

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -37,6 +37,8 @@ async def test_diffs_logged_if_present(registry, resource, handlers, cause_type,
     caplog.set_level(logging.DEBUG)
     cause_mock.event = cause_type
     cause_mock.diff = diff
+    cause_mock.new = object()  # checked for `not None`
+    cause_mock.old = object()  # checked for `not None`
 
     await custom_object_handler(
         lifecycle=kopf.lifecycles.all_at_once,

--- a/tests/test_lastseen.py
+++ b/tests/test_lastseen.py
@@ -153,7 +153,7 @@ def test_state_is_not_changed_with_system_noise():
     assert result == False
 
 
-# This is to ensure it is callable with proper signsture.
+# This is to ensure it is callable with proper signature.
 # For actual tests of diffing, see `/tests/diffs/`.
 def test_state_diff():
     data = {'spec': {'depth': {'field': 'x'}}}

--- a/tests/test_lastseen.py
+++ b/tests/test_lastseen.py
@@ -23,6 +23,12 @@ def test_has_state(expected, body):
     assert result == expected
 
 
+def test_get_state_removes_resource_references():
+    body = {'apiVersion': 'group/version', 'kind': 'Kind'}
+    state = get_state(body=body)
+    assert state == {}
+
+
 @pytest.mark.parametrize('field', [
     'uid',
     'name',

--- a/tests/test_lastseen.py
+++ b/tests/test_lastseen.py
@@ -72,15 +72,15 @@ def test_get_state_removes_annotations_and_keeps_others(annotation):
     assert state == {'metadata': {'annotations': {'other': 'y'}}}
 
 
-def test_get_state_removes_kopf_status_and_cleans_parents():
-    body = {'status': {'kopf': {'progress': 'x', 'anything': 'y'}}}
+def test_get_state_removes_status_and_cleans_parents():
+    body = {'status': {'kopf': {'progress': 'x', 'anything': 'y'}, 'other': 'z'}}
     state = get_state(body=body)
     assert state == {}
 
 
-def test_get_state_removes_kopf_status_and_keeps_others():
+def test_get_state_removes_status_but_keeps_extra_fields():
     body = {'status': {'kopf': {'progress': 'x', 'anything': 'y'}, 'other': 'z'}}
-    state = get_state(body=body)
+    state = get_state(body=body, extra_fields=['status.other'])
     assert state == {'status': {'other': 'z'}}
 
 
@@ -144,7 +144,9 @@ def test_state_changed_ignored_with_system_fields():
                          'deletionTimestamp': 'x',
                          'uid': 'uid',
                          },
-            'status': {'kopf': {'progress': 'x', 'anything': 'y'}},
+            'status': {'kopf': {'progress': 'x', 'anything': 'y'},
+                       'other': 'x'
+                       },
             'spec': {'depth': {'field': 'x'}}}
     old, new, diff = get_state_diffs(body=body)
     assert not diff
@@ -158,7 +160,7 @@ def test_state_diff():
     body = {'metadata': {'annotations': {LAST_SEEN_ANNOTATION: encoded}},
             'status': {'x': 'y'},
             'spec': {'depth': {'field': 'y'}}}
-    old, new, diff = get_state_diffs(body=body)
+    old, new, diff = get_state_diffs(body=body, extra_fields=['status.x'])
     assert old == {'spec': {'depth': {'field': 'x'}}}
     assert new == {'spec': {'depth': {'field': 'y'}}, 'status': {'x': 'y'}}
     assert len(diff) == 2  # spec.depth.field & status.x, but the order is not known.


### PR DESCRIPTION
> Issue : closes #129, prepares #119, regression of #64, closes #130 (supersedes it).

## Description

Kopf remembers the last-handled state in the annotations. It is then used to detect if the object was handled previous and should be handled now, and also whether it is a CREATE or UPDATE cause (affects the selected handlers).

**`.status`:** Currently, the `.status` stenza is fully included in the last-handle state, except for Kopf's own structures (`.status.kopf`). According to the K8s conventions, status should be generally ignored when triggering the events, as all other controllers and operators can store any arbitrary information there. See also #119.

**`.metadata`:** Similarly for `.metadata` — new fields appear over time. For example, now it is `.metadata.deletionGracePeriodSeconds` that was added and sneaked into diffs, and caused the `@kopf.on.update` handlers. Kopf cannot follow all new fields in all Kubernetes versions. Instead, it will (since this PR) ignore all of metadata except for labels and annotations (except for surely useless annotations, like Kopf's own ones and kubectl's one). See also #64. 

**`.apiVersion/.kind`:** All resource kind references, including its name and namespace, are also excluded from the last-handled state. They are immutable, so it makes no sense to trace them.

**`.spec`:** All other stenzas like `.spec`, so as all other top-level fields (as in some resources) are treated as useful data even if not listed explicitly. They get to the last-handled state normally, always.

This PR does the following:

* Removes all of the system information (i.e. status & metadata & apiVersion & kind) from the remembered last-handled state.
* Re-adds labels & annotations.
* Re-adds the fields explicitly tracked in the field-handlers. Example:

```python
@kopf.on.field('zalando.org', 'v1', 'kopfexamples', field='status.expected-field')
def expected_field_changed(old, new, diff, **kwargs):
     print(diff)
```

In this example, the status sub-field will be taken into the last-handled state dumps because it is explicitly mentioned. All other status fields will be ignored.

## Side-effects

The old & new states, so as the diff structure will be provided to the creation and deletion handlers. Not much use of them there, so it will probably affect nothing. Previously, the old/new/diff kwargs were passed with `None`.

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
