### PR TITLE
Fix the newly added test with old checks

### DIFF
--- a/examples/09-testing/test_example_09.py
+++ b/examples/09-testing/test_example_09.py
@@ -40,4 +40,3 @@ def test_resource_lifecycle(mocker):
     # There are usually more than these messages, but we only check for the certain ones.
     assert '[default/kopf-example-1] Creation event:' in runner.stdout
     assert '[default/kopf-example-1] Something was logged here.' in runner.stdout
-    assert '[default/kopf-example-1] Deletion event:' in runner.stdout


### PR DESCRIPTION
> Issue : #24

## Description

Few cross-PR bugs were introduced to the tests (and tests only):

#118 added a new test, and it was broken with the modified master. The merge, however, had no conflicts. The framework's code is not broken and functions properly, as expected. It is only one test.

#126 added a new e2e test, which expected the deletion logs, which never appeared, as they were removed in #118 (no more deletion events if there are no deletion handlers).

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
