### PR TITLE
Add file's dir to sys.path

### DIFF
--- a/kopf/utilities/loaders.py
+++ b/kopf/utilities/loaders.py
@@ -14,9 +14,11 @@ Currently, two loading modes are supported, both are equivalent to Python CLI:
 Multiple files/modules can be specified. They will be loaded in the order.
 """
 
+import sys
 import importlib
 import importlib.util
 import os.path
+
 
 
 def preload(paths, modules):
@@ -25,6 +27,8 @@ def preload(paths, modules):
     """
 
     for path in paths:
+        print(path  )
+        sys.path.append(os.path.abspath(os.path.join(path, os.pardir)))
         name, _ = os.path.splitext(os.path.basename(path))
         spec = importlib.util.spec_from_file_location(name, path)
         module = importlib.util.module_from_spec(spec)

--- a/kopf/utilities/loaders.py
+++ b/kopf/utilities/loaders.py
@@ -14,11 +14,10 @@ Currently, two loading modes are supported, both are equivalent to Python CLI:
 Multiple files/modules can be specified. They will be loaded in the order.
 """
 
-import sys
 import importlib
 import importlib.util
 import os.path
-
+import sys
 
 
 def preload(paths, modules):
@@ -27,7 +26,7 @@ def preload(paths, modules):
     """
 
     for path in paths:
-        sys.path.append(os.path.abspath(os.path.curdir))
+        sys.path.insert(0, os.path.abspath(os.path.dirname(path)))
         name, _ = os.path.splitext(os.path.basename(path))
         spec = importlib.util.spec_from_file_location(name, path)
         module = importlib.util.module_from_spec(spec)

--- a/kopf/utilities/loaders.py
+++ b/kopf/utilities/loaders.py
@@ -27,8 +27,7 @@ def preload(paths, modules):
     """
 
     for path in paths:
-        print(path  )
-        sys.path.append(os.path.abspath(os.path.join(path, os.pardir)))
+        sys.path.append(os.path.abspath(os.path.curdir))
         name, _ = os.path.splitext(os.path.basename(path))
         spec = importlib.util.spec_from_file_location(name, path)
         module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
# One-line summary
Add current dir to sys.path prior to imports

> Issue : closes #92 
> Origin: closes #93 (suggestions added and conflicts resolved; original author: @trondhindenes)

## Description
Fixes the bug where modules weren't importable from current path since `current dir` was missing from `sys.path` (where modules are resolved from)

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

