### PR TITLE
Restrict kubernetes client library to version 9.x.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
         'click',
         'iso8601',
         'aiojobs',
-        'kubernetes',
+        'kubernetes<10.0.0',  # see: https://github.com/kubernetes-client/python/issues/866
     ],
 )


### PR DESCRIPTION
> Issue : #134

## Description

Restrict `kubernetes` client library to `<10.0.0`, as 10.0.0 is broken (both for Kopf and for an isolated example).

A hotfix version [kopf==0.17.post1](https://github.com/zalando-incubator/kopf/releases/tag/0.17.post1) was released to hot-fix this issue for regular use of Kopf via `pip install kopf` (0.17 is the latest released version to the moment).

But this same restriction must be in the master branch before the next version is released (i.e. for 0.18).

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
