### PR TITLE
WIP: Only run coveralls and codecov when testing from the zalando repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,12 @@ before_script:
 
 script:
   - pytest -v
-  - coveralls
-  - codecov --flags unit
+  - if [[ -n "${TRAVIS_PULL_REQUEST_SLUG}" && "${TRAVIS_PULL_REQUEST_SLUG}" == "${TRAVIS_REPO_SLUG}" ]]; then
+      coveralls;
+    fi
+  - if [[ -n "${TRAVIS_PULL_REQUEST_SLUG}" && "${TRAVIS_PULL_REQUEST_SLUG}" == "${TRAVIS_REPO_SLUG}" ]]; then
+      codecov --flags unit;
+    fi
   - pytest -v --only-e2e  # NB: after the coverage uploads!
 
 deploy:


### PR DESCRIPTION
Do not run coveralls or codecov commands when running from a kopf fork.

> Issue : #138 

## Description
Whenever Travis is testing a PR/branch from a fork of kopf, the coveralls command fails. I don't think that these commands (coveralls and codecov) are really necessary to be run in these situations.

- Build failing due to coveralls - [https://travis-ci.org/dlmiddlecote/kopf/jobs/558501593](https://travis-ci.org/dlmiddlecote/kopf/jobs/558501593)
- Change example - [https://travis-ci.org/dlmiddlecote/kopf/jobs/558531431](https://travis-ci.org/dlmiddlecote/kopf/jobs/558531431)

## Types of Changes
- Documentation / non-code

## Tasks
_List of tasks you will do to complete the PR_
- [ ] Need to verify the logic, need this open PR to be able to do that.

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Is the thinking behind this change ok?
