### PR TITLE
Turn of coverage by default; turn on for CI only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - tools/kubernetes-client.sh
 
 script:
-  - pytest -v
+  - pytest -v --cov=kopf --cov-branch
   - coveralls
   - codecov --flags unit
   - pytest -v --only-e2e  # NB: after the coverage uploads!

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts =
-    --cov=kopf/
-    --cov-branch


### PR DESCRIPTION
Disable coverage measurements by default. Enable explicitly for CI.

> Issue : #99 

## Description

In #72, coverage has been enabled by default for all runs. While this fine for CI runs, it was conflicting with the test runs in IDEs: coverage uses the same `set_trace()` calls as the PyCharm debugger.

In general, unless explicitly enabled, coverage is not needed in the IDEs, or even in the CLI runs.

Hence, disable it by default, and enable it for CI runs only.

## Types of Changes

- Configuration change
- Refactor/improvements
