### PR TITLE
Gracefully terminate an operator on SIGINT/SIGTERM

### DIFF
--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -89,7 +89,7 @@ async def watcher(
 
     finally:
         # Forcedly terminate all the fire-and-forget per-object jobs, of they are still running.
-        await scheduler.close()
+        await asyncio.shield(scheduler.close())
 
 
 async def worker(


### PR DESCRIPTION
_Part of an effort to make Kopf-based operators more stable and resilient._

> Issue: #142, partially replaces #143.

## Description

First of all, react to SIGINT/SIGTERM at all. Previously, the process was terminated on the OS level, but not via the intended reaction.

Second, when exiting for any reason — e.g. SIGINT/SIGTERM, or explicit cancellation, or any exception — do this as gracefully as possible. For this, first cancel the core ever-running tasks of the framework; give them some time to finish; then cancel all running tasks & sub-tasks if left; give it some time again; and only then actually exit.

Third, add a check for all tests on whether any pending tasks are left unattended (i.e. scheduled but not executed) — which is especially important for the e2e tests.

**There are no behaviour changes except of a better termination.**


## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
