### PR TITLE
Fix the stop-flag setting: no arguments are expected

### DIFF
--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -229,8 +229,8 @@ def create_tasks(
 
     # On Ctrl+C or pod termination, cancel all tasks gracefully.
     if threading.current_thread() is threading.main_thread():
-        loop.add_signal_handler(signal.SIGINT, should_stop.set, tasks)
-        loop.add_signal_handler(signal.SIGTERM, should_stop.set, tasks)
+        loop.add_signal_handler(signal.SIGINT, should_stop.set)
+        loop.add_signal_handler(signal.SIGTERM, should_stop.set)
     else:
         logger.warning("OS signals are ignored: running not in the main thread.")
 


### PR DESCRIPTION
> Issue: #142, introduced in #147 

## Description

Sadly so, in #147, an error sneaked into the code: 

`Event.set()` does not accept any arguments, but they are passed into a callback. The callback was originally implemented as a separate async-function, which took a list of tasks and cancelled all of them. Then, the callback was replaced to a flag-setting. But the argument with a list of tasks went unnoticed.

This only affects the operators on its termination stage (Ctrl+C or pod deletion/restarting), and does not affect the behaviour itself.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
