### PR TITLE
Move and split the modules (no code/logic changes)

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -44,16 +44,16 @@ from kopf.reactor.lifecycles import (
     get_default_lifecycle,
     set_default_lifecycle,
 )
-from kopf.reactor.queueing import (
-    run,
-    create_tasks,
-)
 from kopf.reactor.registries import (
     BaseRegistry,
     SimpleRegistry,
     GlobalRegistry,
     get_default_registry,
     set_default_registry,
+)
+from kopf.reactor.running import (
+    run,
+    create_tasks,
 )
 from kopf.structs.hierarchies import (
     adopt,

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -6,7 +6,7 @@ import click
 from kopf import config
 from kopf.clients import auth
 from kopf.engines import peering
-from kopf.reactor import queueing
+from kopf.reactor import running
 from kopf.utilities import loaders
 
 
@@ -54,7 +54,7 @@ def run(paths, modules, peering_name, priority, standalone, namespace):
         paths=paths,
         modules=modules,
     )
-    return queueing.run(
+    return running.run(
         standalone=standalone,
         namespace=namespace,
         priority=priority,

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -59,29 +59,3 @@ def list_objs(*, resource, namespace=None):
     namespace = namespace if issubclass(cls, pykube.objects.NamespacedAPIObject) else None
     lst = cls.objects(api, namespace=pykube.all if namespace is None else namespace)
     return lst.response
-
-
-def watch_objs(*, resource, namespace=None, timeout=None, since=None):
-    """
-    Watch the objects of specific resource type.
-
-    The cluster-scoped call is used in two cases:
-
-    * The resource itself is cluster-scoped, and namespacing makes not sense.
-    * The operator serves all namespaces for the namespaced custom resource.
-
-    Otherwise, the namespace-scoped call is used:
-
-    * The resource is namespace-scoped AND operator is namespaced-restricted.
-    """
-
-    params = {}
-    if timeout is not None:
-        params['timeoutSeconds'] = timeout
-
-    api = auth.get_pykube_api(timeout=None)
-    cls = classes._make_cls(resource=resource)
-    namespace = namespace if issubclass(cls, pykube.objects.NamespacedAPIObject) else None
-    lst = cls.objects(api, namespace=pykube.all if namespace is None else namespace)
-    src = lst.watch(since=since, params=params)
-    return iter({'type': event.type, 'object': event.object.obj} for event in src)

--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -83,9 +83,6 @@ async def streaming_watch(
         yield {'type': None, 'object': item}
 
     # Then, watch the resources starting from the list's resource version.
-    kwargs = {}
-    kwargs.update(dict(resource_version=resource_version) if resource_version else {})
-    kwargs.update(dict(timeout_seconds=config.WatchersConfig.default_stream_timeout) if config.WatchersConfig.default_stream_timeout else {})
     loop = asyncio.get_event_loop()
     stream = fetching.watch_objs(resource=resource, namespace=namespace,
                                  timeout=config.WatchersConfig.default_stream_timeout,

--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -75,9 +75,8 @@ async def infinite_watch(
     """
     Stream the watch-events infinitely.
 
-    This routine is extracted only due to difficulty of testing
-    of the infinite loops. It is made as simple as possible,
-    and is assumed to work without testing.
+    This routine is extracted because it is difficult to test infinite loops.
+    It is made as simple as possible, and is assumed to work without testing.
 
     This routine never ends gracefully. If a watcher's stream fails,
     a new one is recreated, and the stream continues.
@@ -136,7 +135,7 @@ async def streaming_watch(
 
 def watch_objs(*, resource, namespace=None, timeout=None, since=None):
     """
-    Watch the objects of specific resource type.
+    Watch objects of a specific resource type.
 
     The cluster-scoped call is used in two cases:
 

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -24,22 +24,14 @@ is done in the `kopf.reactor.handling` routines.
 """
 
 import asyncio
-import contextvars
-import functools
 import logging
-import signal
-import threading
 import time
-from typing import Optional, Callable, Tuple, Union, MutableMapping, NewType
+from typing import Callable, Tuple, Union, MutableMapping, NewType
 
 import aiojobs
 
 from kopf import config
 from kopf.clients import watching
-from kopf.engines import peering
-from kopf.engines import posting
-from kopf.reactor import handling
-from kopf.reactor import lifecycles
 from kopf.reactor import registries
 
 logger = logging.getLogger(__name__)
@@ -158,160 +150,6 @@ async def worker(
             del queues[key]
         except KeyError:
             pass
-
-
-def create_tasks(
-        loop: asyncio.AbstractEventLoop,
-        lifecycle: Optional[Callable] = None,
-        registry: Optional[registries.BaseRegistry] = None,
-        standalone: bool = False,
-        priority: int = 0,
-        peering_name: str = peering.PEERING_DEFAULT_NAME,
-        namespace: Optional[str] = None,
-):
-    """
-    Create all the tasks needed to run the operator, but do not spawn/start them.
-    The tasks are properly inter-connected depending on the runtime specification.
-    They can be injected into any event loop as needed.
-    """
-
-    # The freezer and the registry are scoped to this whole task-set, to sync them all.
-    lifecycle = lifecycle if lifecycle is not None else lifecycles.get_default_lifecycle()
-    registry = registry if registry is not None else registries.get_default_registry()
-    event_queue = asyncio.Queue(loop=loop)
-    freeze_flag = asyncio.Event(loop=loop)
-    should_stop = asyncio.Event(loop=loop)
-    tasks = []
-
-    # A top-level task for external stopping by setting a stop-flag. Once set,
-    # this task will exit, and thus all other top-level tasks will be cancelled.
-    tasks.extend([
-        loop.create_task(_stop_flag_checker(should_stop)),
-    ])
-
-    # K8s-event posting. Events are queued in-memory and posted in the background.
-    # NB: currently, it is a global task, but can be made per-resource or per-object.
-    tasks.extend([
-        loop.create_task(posting.poster(
-            event_queue=event_queue)),
-    ])
-
-    # Monitor the peers, unless explicitly disabled.
-    ourselves: Optional[peering.Peer] = peering.Peer.detect(
-        id=peering.detect_own_id(), priority=priority,
-        standalone=standalone, namespace=namespace, name=peering_name,
-    )
-    if ourselves:
-        tasks.extend([
-            loop.create_task(peering.peers_keepalive(
-                ourselves=ourselves)),
-            loop.create_task(watcher(
-                namespace=namespace,
-                resource=ourselves.resource,
-                handler=functools.partial(peering.peers_handler,
-                                          ourselves=ourselves,
-                                          freeze=freeze_flag))),  # freeze is set/cleared
-        ])
-
-    # Resource event handling, only once for every known resource (de-duplicated).
-    for resource in registry.resources:
-        tasks.extend([
-            loop.create_task(watcher(
-                namespace=namespace,
-                resource=resource,
-                handler=functools.partial(handling.custom_object_handler,
-                                          lifecycle=lifecycle,
-                                          registry=registry,
-                                          resource=resource,
-                                          event_queue=event_queue,
-                                          freeze=freeze_flag))),  # freeze is only checked
-        ])
-
-    # On Ctrl+C or pod termination, cancel all tasks gracefully.
-    if threading.current_thread() is threading.main_thread():
-        loop.add_signal_handler(signal.SIGINT, should_stop.set)
-        loop.add_signal_handler(signal.SIGTERM, should_stop.set)
-    else:
-        logger.warning("OS signals are ignored: running not in the main thread.")
-
-    return tasks
-
-
-def run(
-        loop: Optional[asyncio.AbstractEventLoop] = None,
-        lifecycle: Optional[Callable] = None,
-        registry: Optional[registries.BaseRegistry] = None,
-        standalone: bool = False,
-        priority: int = 0,
-        peering_name: str = peering.PEERING_DEFAULT_NAME,
-        namespace: Optional[str] = None,
-):
-    """
-    Serve the events for all the registered resources and handlers.
-
-    This process typically never ends, unless an unhandled error happens
-    in one of the consumers/producers.
-    """
-    loop = loop if loop is not None else asyncio.get_event_loop()
-    tasks = create_tasks(
-        loop=loop,
-        lifecycle=lifecycle,
-        registry=registry,
-        standalone=standalone,
-        namespace=namespace,
-        priority=priority,
-        peering_name=peering_name,
-    )
-
-    # Run the infinite tasks until one of them fails/exits (they never exit normally).
-    # Give some time for the remaining tasks to handle the cancellations (e.g. via try-finally).
-    done1, pending1 = _wait_gracefully(loop, tasks, return_when=asyncio.FIRST_COMPLETED)
-    done2, pending2 = _wait_cancelled(loop, pending1)
-    done3, pending3 = _wait_gracefully(loop, asyncio.all_tasks(loop), timeout=1.0)
-    done4, pending4 = _wait_cancelled(loop, pending3)
-
-    # Check the results of the non-cancelled tasks, and re-raise of there were any exceptions.
-    # The cancelled tasks are not re-raised, as it is a normal flow.
-    _reraise(loop, list(done1) + list(done2) + list(done3) + list(done4))
-
-
-def _wait_gracefully(loop, tasks, *, timeout=None, return_when=asyncio.ALL_COMPLETED):
-    if not tasks:
-        return [], []
-    try:
-        done, pending = loop.run_until_complete(asyncio.wait(tasks, return_when=return_when, timeout=timeout))
-    except asyncio.CancelledError:
-        # ``asyncio.wait()`` is cancelled, but the tasks can be running.
-        done, pending = [], tasks
-    return done, pending
-
-
-def _wait_cancelled(loop, tasks, *, timeout=None):
-    for task in tasks:
-        task.cancel()
-    if tasks:
-        done, pending = loop.run_until_complete(asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED, timeout=timeout))
-        assert not pending
-        return done, pending
-    else:
-        return [], []
-
-
-def _reraise(loop, tasks):
-    for task in tasks:
-        try:
-            task.result()  # can raise the regular (non-cancellation) exceptions.
-        except asyncio.CancelledError:
-            pass
-
-
-async def _stop_flag_checker(should_stop):
-    try:
-        await should_stop.wait()
-    except asyncio.CancelledError:
-        pass  # operator is stopping for any other reason
-    else:
-        logger.debug("Stop-flag is raised. Operator is stopping.")
 
 
 async def _wait_for_depletion(*, scheduler, queues):

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -1,0 +1,169 @@
+import asyncio
+import functools
+import logging
+import signal
+import threading
+from typing import Optional, Callable
+
+from kopf.engines import peering
+from kopf.engines import posting
+from kopf.reactor import handling
+from kopf.reactor import lifecycles
+from kopf.reactor import queueing
+from kopf.reactor import registries
+
+logger = logging.getLogger(__name__)
+
+
+def run(
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        lifecycle: Optional[Callable] = None,
+        registry: Optional[registries.BaseRegistry] = None,
+        standalone: bool = False,
+        priority: int = 0,
+        peering_name: str = peering.PEERING_DEFAULT_NAME,
+        namespace: Optional[str] = None,
+):
+    """
+    Serve the events for all the registered resources and handlers.
+
+    This process typically never ends, unless an unhandled error happens
+    in one of the consumers/producers.
+    """
+    loop = loop if loop is not None else asyncio.get_event_loop()
+    tasks = create_tasks(
+        loop=loop,
+        lifecycle=lifecycle,
+        registry=registry,
+        standalone=standalone,
+        namespace=namespace,
+        priority=priority,
+        peering_name=peering_name,
+    )
+
+    # Run the infinite tasks until one of them fails/exits (they never exit normally).
+    # Give some time for the remaining tasks to handle the cancellations (e.g. via try-finally).
+    done1, pending1 = _wait_gracefully(loop, tasks, return_when=asyncio.FIRST_COMPLETED)
+    done2, pending2 = _wait_cancelled(loop, pending1)
+    done3, pending3 = _wait_gracefully(loop, asyncio.all_tasks(loop), timeout=1.0)
+    done4, pending4 = _wait_cancelled(loop, pending3)
+
+    # Check the results of the non-cancelled tasks, and re-raise of there were any exceptions.
+    # The cancelled tasks are not re-raised, as it is a normal flow.
+    _reraise(loop, list(done1) + list(done2) + list(done3) + list(done4))
+
+
+def create_tasks(
+        loop: asyncio.AbstractEventLoop,
+        lifecycle: Optional[Callable] = None,
+        registry: Optional[registries.BaseRegistry] = None,
+        standalone: bool = False,
+        priority: int = 0,
+        peering_name: str = peering.PEERING_DEFAULT_NAME,
+        namespace: Optional[str] = None,
+):
+    """
+    Create all the tasks needed to run the operator, but do not spawn/start them.
+    The tasks are properly inter-connected depending on the runtime specification.
+    They can be injected into any event loop as needed.
+    """
+
+    # The freezer and the registry are scoped to this whole task-set, to sync them all.
+    lifecycle = lifecycle if lifecycle is not None else lifecycles.get_default_lifecycle()
+    registry = registry if registry is not None else registries.get_default_registry()
+    event_queue = asyncio.Queue(loop=loop)
+    freeze_flag = asyncio.Event(loop=loop)
+    should_stop = asyncio.Event(loop=loop)
+    tasks = []
+
+    # A top-level task for external stopping by setting a stop-flag. Once set,
+    # this task will exit, and thus all other top-level tasks will be cancelled.
+    tasks.extend([
+        loop.create_task(_stop_flag_checker(should_stop)),
+    ])
+
+    # K8s-event posting. Events are queued in-memory and posted in the background.
+    # NB: currently, it is a global task, but can be made per-resource or per-object.
+    tasks.extend([
+        loop.create_task(posting.poster(
+            event_queue=event_queue)),
+    ])
+
+    # Monitor the peers, unless explicitly disabled.
+    ourselves: Optional[peering.Peer] = peering.Peer.detect(
+        id=peering.detect_own_id(), priority=priority,
+        standalone=standalone, namespace=namespace, name=peering_name,
+    )
+    if ourselves:
+        tasks.extend([
+            loop.create_task(peering.peers_keepalive(
+                ourselves=ourselves)),
+            loop.create_task(queueing.watcher(
+                namespace=namespace,
+                resource=ourselves.resource,
+                handler=functools.partial(peering.peers_handler,
+                                          ourselves=ourselves,
+                                          freeze=freeze_flag))),  # freeze is set/cleared
+        ])
+
+    # Resource event handling, only once for every known resource (de-duplicated).
+    for resource in registry.resources:
+        tasks.extend([
+            loop.create_task(queueing.watcher(
+                namespace=namespace,
+                resource=resource,
+                handler=functools.partial(handling.custom_object_handler,
+                                          lifecycle=lifecycle,
+                                          registry=registry,
+                                          resource=resource,
+                                          event_queue=event_queue,
+                                          freeze=freeze_flag))),  # freeze is only checked
+        ])
+
+    # On Ctrl+C or pod termination, cancel all tasks gracefully.
+    if threading.current_thread() is threading.main_thread():
+        loop.add_signal_handler(signal.SIGINT, should_stop.set)
+        loop.add_signal_handler(signal.SIGTERM, should_stop.set)
+    else:
+        logger.warning("OS signals are ignored: running not in the main thread.")
+
+    return tasks
+
+
+def _wait_gracefully(loop, tasks, *, timeout=None, return_when=asyncio.ALL_COMPLETED):
+    if not tasks:
+        return [], []
+    try:
+        done, pending = loop.run_until_complete(asyncio.wait(tasks, return_when=return_when, timeout=timeout))
+    except asyncio.CancelledError:
+        # ``asyncio.wait()`` is cancelled, but the tasks can be running.
+        done, pending = [], tasks
+    return done, pending
+
+
+def _wait_cancelled(loop, tasks, *, timeout=None):
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        done, pending = loop.run_until_complete(asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED, timeout=timeout))
+        assert not pending
+        return done, pending
+    else:
+        return [], []
+
+
+def _reraise(loop, tasks):
+    for task in tasks:
+        try:
+            task.result()  # can raise the regular (non-cancellation) exceptions.
+        except asyncio.CancelledError:
+            pass
+
+
+async def _stop_flag_checker(should_stop):
+    try:
+        await should_stop.wait()
+    except asyncio.CancelledError:
+        pass  # operator is stopping for any other reason
+    else:
+        logger.debug("Stop-flag is raised. Operator is stopping.")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -98,4 +98,4 @@ def preload(mocker):
 
 @pytest.fixture()
 def real_run(mocker):
-    return mocker.patch('kopf.reactor.queueing.run')
+    return mocker.patch('kopf.reactor.running.run')

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -26,7 +26,7 @@ def test_help_in_subcommand(invoke, mocker):
     verify_pykube = mocker.patch('kopf.clients.auth.verify_pykube')
     verify_client = mocker.patch('kopf.clients.auth.verify_client')
     preload = mocker.patch('kopf.utilities.loaders.preload')
-    real_run = mocker.patch('kopf.reactor.queueing.run')
+    real_run = mocker.patch('kopf.reactor.running.run')
 
     result = invoke(['run', '--help'])
 


### PR DESCRIPTION
_A preparation for switch to aiohttp and full-async._

> Issue : #142 

## Description

In order to make the coming PRs easier to read with their diffs, this is a preparatory PR with no behaviour changes, no code modified, but only with the code moved across the modules.

As the code grows, some modules need to be split:

* `kopf.reactor.queueing` is split into:
  * `kopf.reactor.running` for asyncio task management (starting and orchestration).
  * `kopf.reactor.queueing` for watch-event queueing and multiplexing only.

Other functions have to be moved for cohesion to their related functions:

* `watch_objs` moved from `kopf.clients.fetching` to `kopf.clients.watching` (with the intention of reimplementing the watching & streaming).

_The behaviour is NOT changed in any way._

## Types of Changes

- Refactor/improvements
