### PR TITLE
Refactor runtime to full async/await; make officially embeddable

### DIFF
--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -105,8 +105,8 @@ in :mod:`contextvars` containers with values isolated per-loop and per-task.
 .. warning::
     It is not recommended to run Kopf in the same event-loop with other routines
     or applications: it considers all tasks in the event-loop as spawned by its
-    workers and handlers, and cancells them when it exits.
+    workers and handlers, and cancels them when it exits.
 
-    There are some basic safety measures to not cancel the tasks existed before
-    operator startup, but that cannot be applied to the tasks spawned later
-    due to asyncio implementation details.
+    There are some basic safety measures to not cancel tasks existing prior
+    to the operator's startup, but that cannot be applied to the tasks spawned
+    later due to asyncio implementation details.

--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -1,0 +1,112 @@
+=========
+Embedding
+=========
+
+Kopf is designed to be embeddable into other applications, which require
+watching over the Kubernetes resources (custom or built-in), and handling
+the changes.
+This can be used, for example, in desktop applications or web APIs/UIs
+to keep the state of the cluster and its resources in memory.
+
+
+Manual orchestration
+====================
+
+Since Kopf is fully asynchronous, the best way to run Kopf is to provide
+an event-loop specially for Kopf in a separate thread, while running
+the main application in the main thread.
+
+.. code-block:: python
+
+    import asyncio
+    import threading
+
+    import kopf
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
+    def create_fn(**_):
+        pass
+
+    def kopf_thread():
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(kopf.operator())
+
+    def main():
+        thread = threading.Thread(target_fn=kopf_thread)
+        thread.start()
+        # ...
+        thread.join()
+
+In case of :command:`kopf run`, the main application is Kopf itself,
+so its event-loop runs in the main thread.
+
+.. note::
+    When an asyncio task runs not in the main thread, it cannot set
+    the OS signal handlers, so a developer should implement the termination
+    themselves (cancellation of an operator task is enough).
+
+Alternatively, a developer can orchestrate the operator's tasks and sub-tasks
+themselves. The example above is an equivalent of the following:
+
+.. code-block:: python
+
+    def kopf_thread():
+        loop = asyncio.get_event_loop()
+        tasks = loop.run_until_complete(kopf.spawn_tasks())
+        loop.run_until_complete(kopf.run_tasks(tasks, return_when=asyncio.FIRST_COMPLETED))
+
+Or, if proper cancellation and termination is not expected, of the following:
+
+.. code-block:: python
+
+    def kopf_thread():
+        loop = asyncio.get_event_loop()
+        tasks = loop.run_until_complete(kopf.spawn_tasks())
+        loop.run_until_complete(asyncio.wait(tasks))
+
+
+Multiple operators
+==================
+
+Kopf can handle multiple resources at a time, so only one instance should be
+sufficient for most cases. However, it can be needed to run multiple isolated
+operators in the same process.
+
+It should be safe to run multiple operators in multiple isolated event-loops.
+Despite Kopf's routines use the global state, all such a global state is stored
+in :mod:`contextvars` containers with values isolated per-loop and per-task.
+
+.. code-block:: python
+
+    import asyncio
+    import threading
+
+    import kopf
+
+    registry = kopf.GlobalRegistry()
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', registry=registry)
+    def create_fn(**_):
+        pass
+
+    def kopf_thread():
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(kopf.operator(
+            registry=registry,
+        ))
+
+    def main():
+        thread = threading.Thread(target_fn=kopf_thread)
+        thread.start()
+        # ...
+        thread.join()
+
+
+.. warning::
+    It is not recommended to run Kopf in the same event-loop with other routines
+    or applications: it considers all tasks in the event-loop as spawned by its
+    workers and handlers, and cancells them when it exits.
+
+    There are some basic safety measures to not cancel the tasks existed before
+    operator startup, but that cannot be applied to the tasks spawned later
+    due to asyncio implementation details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ Kopf: Kubernetes Operators Framework
    events
    testing
    configuring
+   embedding
 
 .. toctree::
    :maxdepth: 2

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -52,8 +52,11 @@ from kopf.reactor.registries import (
     set_default_registry,
 )
 from kopf.reactor.running import (
+    spawn_tasks,
+    run_tasks,
+    operator,
     run,
-    create_tasks,
+    create_tasks,  # deprecated
 )
 from kopf.structs.hierarchies import (
     adopt,
@@ -71,7 +74,7 @@ __all__ = [
     'configure',
     'login', 'LoginError',
     'event', 'info', 'warn', 'exception',
-    'run', 'create_tasks',
+    'spawn_tasks', 'run_tasks', 'operator', 'run', 'create_tasks',
     'adopt', 'label',
     'get_default_lifecycle', 'set_default_lifecycle',
     'build_object_reference', 'build_owner_reference',

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -200,8 +200,6 @@ async def run_tasks(root_tasks, *, ignored: Collection[asyncio.Task] = frozenset
 
     # If succeeded or if cancellation is silenced, re-raise from failed tasks (if any).
     await _reraise(root_done | root_cancelled | hung_done | hung_cancelled)
-    # assert not root_left
-    # assert not hung_left
 
 
 async def _all_tasks(ignored: Collection[asyncio.Task] = frozenset()) -> Collection[asyncio.Task]:

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import signal
 import threading
-from typing import Optional, Callable
+from typing import Optional, Callable, Collection
 
 from kopf.engines import peering
 from kopf.engines import posting
@@ -25,36 +25,25 @@ def run(
         namespace: Optional[str] = None,
 ):
     """
-    Serve the events for all the registered resources and handlers.
+    Run the whole operator synchronously.
 
-    This process typically never ends, unless an unhandled error happens
-    in one of the consumers/producers.
+    This function should be used to run an operator in normal sync mode.
     """
     loop = loop if loop is not None else asyncio.get_event_loop()
-    tasks = create_tasks(
-        loop=loop,
-        lifecycle=lifecycle,
-        registry=registry,
-        standalone=standalone,
-        namespace=namespace,
-        priority=priority,
-        peering_name=peering_name,
-    )
-
-    # Run the infinite tasks until one of them fails/exits (they never exit normally).
-    # Give some time for the remaining tasks to handle the cancellations (e.g. via try-finally).
-    done1, pending1 = _wait_gracefully(loop, tasks, return_when=asyncio.FIRST_COMPLETED)
-    done2, pending2 = _wait_cancelled(loop, pending1)
-    done3, pending3 = _wait_gracefully(loop, asyncio.all_tasks(loop), timeout=1.0)
-    done4, pending4 = _wait_cancelled(loop, pending3)
-
-    # Check the results of the non-cancelled tasks, and re-raise of there were any exceptions.
-    # The cancelled tasks are not re-raised, as it is a normal flow.
-    _reraise(loop, list(done1) + list(done2) + list(done3) + list(done4))
+    try:
+        loop.run_until_complete(operator(
+            lifecycle=lifecycle,
+            registry=registry,
+            standalone=standalone,
+            namespace=namespace,
+            priority=priority,
+            peering_name=peering_name,
+        ))
+    except asyncio.CancelledError:
+        pass
 
 
-def create_tasks(
-        loop: asyncio.AbstractEventLoop,
+async def operator(
         lifecycle: Optional[Callable] = None,
         registry: Optional[registries.BaseRegistry] = None,
         standalone: bool = False,
@@ -63,10 +52,37 @@ def create_tasks(
         namespace: Optional[str] = None,
 ):
     """
-    Create all the tasks needed to run the operator, but do not spawn/start them.
-    The tasks are properly inter-connected depending on the runtime specification.
-    They can be injected into any event loop as needed.
+    Run the whole operator asynchronously.
+
+    This function should be used to run an operator in an asyncio event-loop
+    if the operator is orchestrated explicitly and manually.
     """
+    existing_tasks = await _all_tasks()
+    operator_tasks = await spawn_tasks(
+        lifecycle=lifecycle,
+        registry=registry,
+        standalone=standalone,
+        namespace=namespace,
+        priority=priority,
+        peering_name=peering_name,
+    )
+    await run_tasks(operator_tasks, ignored=existing_tasks)
+
+
+async def spawn_tasks(
+        lifecycle: Optional[Callable] = None,
+        registry: Optional[registries.BaseRegistry] = None,
+        standalone: bool = False,
+        priority: int = 0,
+        peering_name: str = peering.PEERING_DEFAULT_NAME,
+        namespace: Optional[str] = None,
+) -> Collection[asyncio.Task]:
+    """
+    Spawn all the tasks needed to run the operator.
+
+    The tasks are properly inter-connected with the synchronisation primitives.
+    """
+    loop = asyncio.get_running_loop()
 
     # The freezer and the registry are scoped to this whole task-set, to sync them all.
     lifecycle = lifecycle if lifecycle is not None else lifecycles.get_default_lifecycle()
@@ -130,29 +146,104 @@ def create_tasks(
     return tasks
 
 
-def _wait_gracefully(loop, tasks, *, timeout=None, return_when=asyncio.ALL_COMPLETED):
-    if not tasks:
-        return [], []
+async def run_tasks(root_tasks, *, ignored: Collection[asyncio.Task] = frozenset()):
+    """
+    Orchestrate the tasks and terminate them gracefully when needed.
+
+    The root tasks are expected to run forever. Their number is limited. Once
+    any of them exits, the whole operator and all other root tasks should exit.
+
+    The root tasks, in turn, can spawn multiple sub-tasks of various purposes.
+    They can be awaited, monitored, or fired-and-forgot.
+
+    The hung tasks are those that were spawned during the operator runtime,
+    and were not cancelled/exited on the root tasks termination. They are given
+    some extra time to finish, after which they are forcely terminated too.
+
+    .. note::
+        Due to implementation details, every task created after the operator's
+        startup is assumed to be a task or a sub-task of the operator.
+        In the end, all tasks are forcely cancelled. Even if those tasks were
+        created by other means. There is no way to trace who spawned what.
+        Only the tasks that existed before the operator startup are ignored
+        (for example, those that spawned the operator itself).
+    """
     try:
-        done, pending = loop.run_until_complete(asyncio.wait(tasks, return_when=return_when, timeout=timeout))
+        # Run the infinite tasks until one of them fails/exits (they never exit normally).
+        root_done, root_pending = await _wait(root_tasks, return_when=asyncio.FIRST_COMPLETED)
     except asyncio.CancelledError:
-        # ``asyncio.wait()`` is cancelled, but the tasks can be running.
-        done, pending = [], tasks
+        # If the operator is cancelled, propagate the cancellation to all the sub-tasks.
+        # There is no graceful period: cancel as soon as possible, but allow them to finish.
+        root_cancelled, root_left = await _stop(root_tasks, title="Root", cancelled=True)
+        hung_tasks = await _all_tasks(ignored=ignored)
+        hung_cancelled, hung_left = await _stop(hung_tasks, title="Hung", cancelled=True)
+        raise
+    else:
+        # If the operator is intact, but one of the root tasks has exited (successfully or not),
+        # cancel all the remaining root tasks, and gracefully exit other spawned sub-tasks.
+        root_cancelled, root_left = await _stop(root_pending, title="Root", cancelled=False)
+        hung_tasks = await _all_tasks(ignored=ignored)
+        try:
+            # After the root tasks are all gone, cancel any spawned sub-tasks (e.g. handlers).
+            # TODO: assumption! the loop is not fully ours! find a way to cancel our spawned tasks.
+            hung_done, hung_pending = await _wait(hung_tasks, timeout=5.0)
+        except asyncio.CancelledError:
+            # If the operator is cancelled, propagate the cancellation to all the sub-tasks.
+            hung_cancelled, hung_left = await _stop(hung_tasks, title="Hung", cancelled=True)
+            raise
+        else:
+            # If the operator is intact, but the timeout is reached, forcely cancel the sub-tasks.
+            hung_cancelled, hung_left = await _stop(hung_pending, title="Hung", cancelled=False)
+
+    # If succeeded or if cancellation is silenced, re-raise from failed tasks (if any).
+    await _reraise(root_done | root_cancelled | hung_done | hung_cancelled)
+    # assert not root_left
+    # assert not hung_left
+
+
+async def _all_tasks(ignored: Collection[asyncio.Task] = frozenset()) -> Collection[asyncio.Task]:
+    current_task = asyncio.current_task()
+    return {task for task in asyncio.all_tasks()
+            if task is not current_task and task not in ignored}
+
+
+async def _wait(tasks, *, timeout=None, return_when=asyncio.ALL_COMPLETED):
+    if not tasks:
+        return set(), ()
+    done, pending = await asyncio.wait(tasks, timeout=timeout, return_when=return_when)
     return done, pending
 
 
-def _wait_cancelled(loop, tasks, *, timeout=None):
+async def _stop(tasks, title, cancelled):
+    if not tasks:
+        logger.debug(f"{title} tasks stopping is skipped: no tasks given.")
+        return set(), set()
+
     for task in tasks:
         task.cancel()
-    if tasks:
-        done, pending = loop.run_until_complete(asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED, timeout=timeout))
-        assert not pending
-        return done, pending
+
+    # If the waiting (current) task is cancelled before the wait is over,
+    # propagate the cancellation to all the awaited (sub-) tasks, and let them finish.
+    try:
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+    except asyncio.CancelledError:
+        # If the waiting (current) task is cancelled while propagating the cancellation
+        # (i.e. double-cancelled), let it fail without graceful cleanup. It is urgent, it seems.
+        pending = {task for task in tasks if not task.done()}
+        are = 'are' if not pending else 'are not'
+        why = 'double-cancelled at stopping' if cancelled else 'cancelled at stopping'
+        logger.debug(f"{title} tasks {are} stopped: {why}; tasks left: {pending!r}")
+        raise  # the repeated cancellation, handled specially.
     else:
-        return [], []
+        # If the cancellation is propagated normally and the awaited (sub-) tasks exited,
+        # consider it as a successful cleanup.
+        are = 'are' if not pending else 'are not'
+        why = 'cancelled normally' if cancelled else 'finished normally'
+        logger.debug(f"{title} tasks {are} stopped: {why}; tasks left: {pending!r}")
+        return done, pending
 
 
-def _reraise(loop, tasks):
+async def _reraise(tasks):
     for task in tasks:
         try:
             task.result()  # can raise the regular (non-cancellation) exceptions.
@@ -167,3 +258,13 @@ async def _stop_flag_checker(should_stop):
         pass  # operator is stopping for any other reason
     else:
         logger.debug("Stop-flag is raised. Operator is stopping.")
+
+
+def create_tasks(loop: asyncio.AbstractEventLoop, *arg, **kwargs):
+    """
+    .. deprecated:: 1.0
+        This is a synchronous interface to `spawn_tasks`.
+        It is only kept for backward compatibility, as it was exposed
+        via the public interface of the framework.
+    """
+    return loop.run_until_complete(spawn_tasks(*arg, **kwargs))


### PR DESCRIPTION
Make operator termination even more graceful (resource-cleanable), the task orchestration — async, and the operator core — embeddable (and officially documented).

> Issue : #142.

## Description

Previously in #147, there was an attempt to rework the asyncio task management with the "should-stop" event and asyncio task cancellations. It made the operator to react to the existing signals, but still had some problems with proper cleanups.

Specifically, when a `aiohttp.ClientSession` is added (a PR based on this one — to be created), there is no place to properly create it and close it, since all the tasks are orchestrated in a synchronous function.

This led to few issues with some `aiohttp` connections not being closed properly, issuing the warnings/prints on the process exiting (and a lot of them in tests).


### Fully async coroutines

With this PR, and operator's body is extracted into a self-contained coroutine (`operator()`), which does everything: task spawning, task orchestration, resource creation and cleanups, etc.

The synchronous functions `run()` and `create_tasks()` are left as wrappers for `operator()` and `spawn_tasks()` respectively. (`create_tasks()` is also deprecated.)

### Graceful termination

With this PR, the operator termination is now even more graceful both in case of normal exit ("should-stop" event set) and in case of error. In the latter case, all tasks & sub-tasks are cancelled without a tolerable graceful timeout, but they are still given time to cleanup their resources (e.g. in `try-finally`).

## Embeddability

These function were already exposed via the public interface (accessible via `kopf.run`/`kopf.create_tasks`). 

With this PR, all the new functions are also exposed, and this is made a documented feature of embeddability — i.e. ability to embed Kopf operators into third-party applications by explicit invocation/orchestration of the Kopf tasks.

_(As an example of potential usage (not in the plans): an application that listens for the resources updates and keeps their state in-memory, while showing that state in a UI/WebUI.)_ 


## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
- Documentation / non-code

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
