### PR TITLE
Ignore "404 Not Found" when patching after deletion during handling

### DIFF
--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -40,8 +40,13 @@ async def patch_obj(*, resource, patch, namespace=None, name=None, body=None):
         await loop.run_in_executor(config.WorkersConfig.get_syn_executor(), obj.patch, patch)
     except pykube.ObjectDoesNotExist:
         pass
+    except pykube.exceptions.HTTPError as e:
+        if e.code == 404:
+            pass
+        else:
+            raise
     except requests.exceptions.HTTPError as e:
-        if e.response.status_code in [404]:
+        if e.response.status_code == 404:
             pass
         else:
             raise

--- a/tests/k8s/test_read_obj.py
+++ b/tests/k8s/test_read_obj.py
@@ -1,4 +1,3 @@
-import pykube
 import pytest
 import requests
 


### PR DESCRIPTION
Ignore errors when patching an object that was removed too quickly, during the handling cycle or inside of the handlers.

> Issue : #139

## Description

If a handler deletes the object being handled, Kopf will try to patch its status after the handler as usually, and will fail, since the object does not exist anymore.

The same happens if the object is deleted too quickly, while the handler is running. 

Previously, this was prevented by always having a finalizer before any handling. Since #24, the finalizer is added only when there are non-optional delete handlers, and skipped otherwise. So, it is now possible that the object is deleted while we handling it.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Review

- [ ] Tests
- [ ] Documentation
