### PR TITLE
Interrupt the sleep for the delayed handlers on new changes

### DIFF
--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -196,6 +196,7 @@ async def peers_handler(
         freeze: asyncio.Event,
         ourselves: Peer,
         autoclean: bool = True,
+        replenished: asyncio.Event,
 ):
     """
     Handle a single update of the peers by us or by other operators.

--- a/kopf/engines/sleeping.py
+++ b/kopf/engines/sleeping.py
@@ -1,0 +1,29 @@
+"""
+Advanced modes of sleeping.
+"""
+import asyncio
+from typing import Optional
+
+
+async def sleep_or_wait(
+        delay: float,
+        event: asyncio.Event,
+) -> Optional[float]:
+    """
+    Measure the sleep time: either until the timeout, or until the event is set.
+
+    Returns the number of seconds left to sleep, or ``None`` if the sleep was
+    not interrupted and reached its specified delay (an equivalent of ``0``).
+    In theory, the result can be ``0`` if the sleep was interrupted precisely
+    the last moment before timing out; this is unlikely to happen though.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        start_time = loop.time()
+        await asyncio.wait_for(event.wait(), timeout=delay)
+    except asyncio.TimeoutError:
+        return None  # interruptable sleep is over: uninterrupted.
+    else:
+        end_time = loop.time()
+        duration = end_time - start_time
+        return max(0, delay - duration)

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -23,6 +23,7 @@ from typing import Optional, Callable, Iterable, Collection
 from kopf.clients import patching
 from kopf.engines import logging as logging_engine
 from kopf.engines import posting
+from kopf.engines import sleeping
 from kopf.reactor import causation
 from kopf.reactor import invocation
 from kopf.reactor import registries
@@ -120,11 +121,6 @@ async def custom_object_handler(
         )
         delay = await handle_cause(lifecycle=lifecycle, registry=registry, cause=cause)
 
-    # Provoke a dummy change to trigger the reactor after sleep.
-    # TODO: reimplement via the handler delayed statuses properly.
-    if delay and not patch:
-        patch.setdefault('status', {}).setdefault('kopf', {})['dummy'] = datetime.datetime.utcnow().isoformat()
-
     # Whatever was done, apply the accumulated changes to the object.
     # But only once, to reduce the number of API calls and the generated irrelevant events.
     if patch:
@@ -132,9 +128,16 @@ async def custom_object_handler(
         await patching.patch_obj(resource=resource, patch=patch, body=body)
 
     # Sleep strictly after patching, never before -- to keep the status proper.
-    if delay:
+    # The patching above, if done, interrupts the sleep instantly, so we skip it at all.
+    if delay and not patch:
         logger.debug(f"Sleeping for {delay} seconds for the delayed handlers.")
-        await asyncio.sleep(delay)
+        unslept = await sleeping.sleep_or_wait(delay, replenished)
+        if unslept is not None:
+            logger.debug(f"Sleeping was interrupted by new changes, {unslept} seconds left.")
+        else:
+            dummy = {'status': {'kopf': {'dummy': datetime.datetime.utcnow().isoformat()}}}
+            logger.debug("Provoking reaction with: %r", dummy)
+            await patching.patch_obj(resource=resource, patch=dummy, body=body)
 
 
 async def handle_event(

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -73,6 +73,7 @@ async def custom_object_handler(
         resource: registries.Resource,
         event: dict,
         freeze: asyncio.Event,
+        replenished: asyncio.Event,
         event_queue: asyncio.Queue,
 ) -> None:
     """

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -49,6 +49,7 @@ class K8sMocks:
     patch_obj: Mock
     post_event: Mock
     asyncio_sleep: Mock
+    sleep_or_wait: Mock
 
 
 @pytest.fixture(autouse=True)
@@ -58,6 +59,7 @@ def k8s_mocked(mocker, req_mock):
         patch_obj=mocker.patch('kopf.clients.patching.patch_obj'),
         post_event=mocker.patch('kopf.clients.events.post_event'),
         asyncio_sleep=mocker.patch('asyncio.sleep'),
+        sleep_or_wait=mocker.patch('kopf.engines.sleeping.sleep_or_wait', return_value=None),
     )
 
 

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -22,6 +22,7 @@ async def test_acquire(registry, handlers, resource, cause_mock,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -56,6 +57,7 @@ async def test_create(registry, handlers, resource, cause_mock,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -97,6 +99,7 @@ async def test_update(registry, handlers, resource, cause_mock,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -138,6 +141,7 @@ async def test_delete(registry, handlers, resource, cause_mock,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -187,6 +191,7 @@ async def test_release(registry, resource, handlers, cause_mock, caplog, k8s_moc
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -225,6 +230,7 @@ async def test_gone(registry, handlers, resource, cause_mock,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -253,6 +259,7 @@ async def test_free(registry, handlers, resource, cause_mock,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -281,6 +288,7 @@ async def test_noop(registry, handlers, resource, cause_mock,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -31,6 +31,7 @@ async def test_acquire(registry, handlers, resource, cause_mock,
     assert not handlers.delete_mock.called
 
     assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.sleep_or_wait.call_count == 0
     assert k8s_mocked.patch_obj.call_count == 1
     assert event_queue.empty()
 
@@ -66,6 +67,7 @@ async def test_create(registry, handlers, resource, cause_mock,
     assert not handlers.delete_mock.called
 
     assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.sleep_or_wait.call_count == 0
     assert k8s_mocked.patch_obj.call_count == 1
     assert not event_queue.empty()
 
@@ -108,6 +110,7 @@ async def test_update(registry, handlers, resource, cause_mock,
     assert not handlers.delete_mock.called
 
     assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.sleep_or_wait.call_count == 0
     assert k8s_mocked.patch_obj.call_count == 1
     assert not event_queue.empty()
 
@@ -150,6 +153,7 @@ async def test_delete(registry, handlers, resource, cause_mock,
     assert handlers.delete_mock.call_count == 1
 
     assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.sleep_or_wait.call_count == 0
     assert k8s_mocked.patch_obj.call_count == 1
     assert not event_queue.empty()
 
@@ -200,6 +204,7 @@ async def test_release(registry, resource, handlers, cause_mock, caplog, k8s_moc
     assert not handlers.delete_mock.called
 
     assert k8s_mocked.asyncio_sleep.call_count == 0
+    assert k8s_mocked.sleep_or_wait.call_count == 0
     assert k8s_mocked.patch_obj.call_count == 1
     assert event_queue.empty()
 
@@ -239,6 +244,7 @@ async def test_gone(registry, handlers, resource, cause_mock,
     assert not handlers.delete_mock.called
 
     assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert not k8s_mocked.patch_obj.called
     assert event_queue.empty()
 
@@ -268,6 +274,7 @@ async def test_free(registry, handlers, resource, cause_mock,
     assert not handlers.delete_mock.called
 
     assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert not k8s_mocked.patch_obj.called
     assert event_queue.empty()
 
@@ -297,6 +304,7 @@ async def test_noop(registry, handlers, resource, cause_mock,
     assert not handlers.delete_mock.called
 
     assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert not k8s_mocked.patch_obj.called
     assert event_queue.empty()
 

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -19,6 +19,7 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -47,6 +48,7 @@ async def test_diffs_logged_if_present(registry, resource, handlers, cause_type,
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
     assert_logs([
@@ -68,6 +70,7 @@ async def test_diffs_not_logged_if_absent(registry, resource, handlers, cause_ty
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
     assert_logs([

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -35,6 +35,7 @@ async def test_delayed_handlers_progress(
             resource=resource,
             event={'type': 'irrelevant', 'object': cause_mock.body},
             freeze=asyncio.Event(),
+            replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
 
@@ -85,6 +86,7 @@ async def test_delayed_handlers_sleep(
             resource=resource,
             event={'type': 'irrelevant', 'object': cause_mock.body},
             freeze=asyncio.Event(),
+            replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
 

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -44,7 +44,7 @@ async def test_delayed_handlers_progress(
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
-    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
 
     fname = f'{cause_type}_fn'
@@ -97,11 +97,11 @@ async def test_delayed_handlers_sleep(
 
     # The dummy patch is needed to trigger the further changes. The value is irrelevant.
     assert k8s_mocked.patch_obj.called
-    assert 'dummy' in k8s_mocked.patch_obj.call_args_list[0][1]['patch']['status']['kopf']
+    assert 'dummy' in k8s_mocked.patch_obj.call_args_list[-1][1]['patch']['status']['kopf']
 
     # The duration of sleep should be as expected.
-    assert k8s_mocked.asyncio_sleep.called
-    assert k8s_mocked.asyncio_sleep.call_args_list[0][0][0] == delay
+    assert k8s_mocked.sleep_or_wait.called
+    assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] == delay
 
     assert_logs([
         r"Sleeping for [\d\.]+ seconds",

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -38,7 +38,7 @@ async def test_fatal_error_stops_handler(
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
-    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
@@ -80,7 +80,7 @@ async def test_retry_error_delays_handler(
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
-    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
@@ -123,7 +123,7 @@ async def test_arbitrary_error_delays_handler(
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
-    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -29,6 +29,7 @@ async def test_fatal_error_stops_handler(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -70,6 +71,7 @@ async def test_retry_error_delays_handler(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -112,6 +114,7 @@ async def test_arbitrary_error_delays_handler(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -21,6 +21,7 @@ async def test_handlers_called_always(
         resource=resource,
         event={'type': 'ev-type', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -55,6 +56,7 @@ async def test_errors_are_ignored(
         resource=resource,
         event={'type': 'ev-type', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -29,6 +29,7 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
         resource=resource,
         event=event,
         freeze=freeze,
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -22,6 +22,7 @@ async def test_1st_step_stores_progress_by_patching(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -67,6 +68,7 @@ async def test_2nd_step_finishes_the_handlers(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -31,7 +31,7 @@ async def test_1st_step_stores_progress_by_patching(
     assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
-    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
@@ -77,7 +77,7 @@ async def test_2nd_step_finishes_the_handlers(
     assert extrahandlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
     assert extrahandlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
 
-    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -37,6 +37,7 @@ async def test_skipped_with_no_handlers(
     )
 
     assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
 
     # The patch must contain ONLY the last-seen update, and nothing else.

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -32,6 +32,7 @@ async def test_skipped_with_no_handlers(
         resource=resource,
         event={'type': 'irrelevant', 'object': cause_mock.body},
         freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -38,6 +38,7 @@ async def test_timed_out_handler_fails(
             resource=resource,
             event={'type': 'irrelevant', 'object': cause_mock.body},
             freeze=asyncio.Event(),
+            replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
 

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -48,7 +48,7 @@ async def test_timed_out_handler_fails(
     assert not handlers.resume_mock.called
 
     # Progress is reset, as the handler is not going to retry.
-    assert not k8s_mocked.asyncio_sleep.called
+    assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']

--- a/tests/reactor/conftest.py
+++ b/tests/reactor/conftest.py
@@ -39,7 +39,11 @@ def watcher_limited(mocker):
 
 
 @pytest.fixture()
-def watcher_in_background(resource, handler, event_loop, worker_spy, stream):
+def watcher_in_background(resource, event_loop, worker_spy, stream):
+
+    # Prevent remembering the streaming objects in the mocks.
+    async def no_op_handler(*args, **kwargs):
+        pass
 
     # Prevent any real streaming for the very beginning, before it even starts.
     stream.feed([])
@@ -48,7 +52,7 @@ def watcher_in_background(resource, handler, event_loop, worker_spy, stream):
     coro = watcher(
         namespace=None,
         resource=resource,
-        handler=handler,
+        handler=no_op_handler,
     )
     task = event_loop.create_task(coro)
 

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -19,7 +19,7 @@ import pytest
 from kopf.reactor.queueing import watcher, EOS
 
 # Some overhead for the synchronous logic in async tests: it also takes time.
-CODE_OVERHEAD = 0.1  # 0.01 is too fast, 0.1 is too slow, 0.05 is good enough.
+CODE_OVERHEAD = 0.13  # 0.01 is too fast, 0.1 is too slow, 0.05 is good enough.
 
 
 @pytest.mark.parametrize('uids, cnts, events', [

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -18,8 +18,9 @@ import pytest
 
 from kopf.reactor.queueing import watcher, EOS
 
-# Some overhead for the synchronous logic in async tests: it also takes time.
-CODE_OVERHEAD = 0.13  # 0.01 is too fast, 0.1 is too slow, 0.05 is good enough.
+# An overhead for the sync logic in async tests. Guesstimated empirically:
+# 10ms is too fast, 200ms is too slow, 50-150ms is good enough (can vary).
+CODE_OVERHEAD = 0.130
 
 
 @pytest.mark.parametrize('uids, cnts, events', [

--- a/tests/test_sleeping.py
+++ b/tests/test_sleeping.py
@@ -1,0 +1,38 @@
+import asyncio
+
+from kopf.engines.sleeping import sleep_or_wait
+
+
+async def test_sleep_or_wait_by_delay_reached(timer):
+    event = asyncio.Event()
+    with timer:
+        unslept = await asyncio.wait_for(sleep_or_wait(0.10, event), timeout=1.0)
+    assert 0.10 <= timer.seconds < 0.11
+    assert unslept is None
+
+
+async def test_sleep_or_wait_by_event_set(timer):
+    event = asyncio.Event()
+    asyncio.get_running_loop().call_later(0.07, event.set)
+    with timer:
+        unslept = await asyncio.wait_for(sleep_or_wait(0.10, event), timeout=1.0)
+    assert 0.06 <= timer.seconds <= 0.08
+    assert 0.02 <= unslept  <= 0.04
+
+
+async def test_sleep_or_wait_with_zero_time_and_event_cleared(timer):
+    event = asyncio.Event()
+    event.clear()
+    with timer:
+        unslept = await asyncio.wait_for(sleep_or_wait(0, event), timeout=1.0)
+    assert timer.seconds <= 0.01
+    assert unslept is None
+
+
+async def test_sleep_or_wait_with_zero_time_and_event_preset(timer):
+    event = asyncio.Event()
+    event.set()
+    with timer:
+        unslept = await asyncio.wait_for(sleep_or_wait(0, event), timeout=1.0)
+    assert timer.seconds <= 0.01
+    assert not unslept  # 0/None; undefined for such case: both goals reached.


### PR DESCRIPTION
Wake up and react immediately when new watch-events arrive while operator is sleeping until the next delayed/postponed handler.

> Issue : #161, indirectly #142 

## Description

Previously, Kopf used `asyncio.sleep()` for shortest sleep duration until the next postponed handler. If new events arrived for that object — e.g. it was changed or deleted — the sleep continued unconditionally.

With this PR, the sleep until the next postponed handler will be interrupted as soon as a new event arrives (i.e. the object's event queue is replenished). Kopf will reconsider the next steps based on the new object's state, and either process the new state (e.g. finish handling the deleted object), or continue sleeping for the remaining time.

Both intended and remaining time are logged. For example:

```
[2019-08-02 02:21:21,414] kopf.objects         [DEBUG   ] [default/kopf-example-1] Creation event: ...
[2019-08-02 02:21:21,415] kopf.objects         [DEBUG   ] [default/kopf-example-1] Invoking handler 'create_fn'.
[2019-08-02 02:21:23,421] kopf.objects         [ERROR   ] [default/kopf-example-1] Handler 'create_fn' failed with an exception. Will retry.
Traceback (most recent call last):
  ...
  File "example.py", line 14, in create_fn
    raise Exception("First failure.")
Exception: First failure.
[2019-08-02 02:21:23,427] kopf.objects         [DEBUG   ] [default/kopf-example-1] Patching with: {'status': {'kopf': {'progress': {'create_fn': {'started': '2019-08-02T00:21:21.415865', 'retries': 1, 'delayed': '2019-08-02T00:22:23.427267'}}}}}
[2019-08-02 02:21:23,599] kopf.objects         [DEBUG   ] [default/kopf-example-1] Creation event: ...
[2019-08-02 02:21:23,601] kopf.objects         [DEBUG   ] [default/kopf-example-1] Sleeping for 59.825606 seconds for the delayed handlers.
[2019-08-02 02:21:29,755] kopf.objects         [DEBUG   ] [default/kopf-example-1] Sleeping was interrupted by new changes, 53.672287957 seconds left.
[2019-08-02 02:21:29,862] kopf.objects         [DEBUG   ] [default/kopf-example-1] Creation event: ...
[2019-08-02 02:21:29,864] kopf.objects         [DEBUG   ] [default/kopf-example-1] Sleeping for 53.562986 seconds for the delayed handlers.
[2019-08-02 02:21:45,136] kopf.objects         [DEBUG   ] [default/kopf-example-1] Sleeping was interrupted by new changes, 38.291081867 seconds left.
[2019-08-02 02:21:45,238] kopf.objects         [DEBUG   ] [default/kopf-example-1] Deleted, really deleted, and we are notified.
```

This speeds up the responsiveness of the operators in case of object changes.


## Types of Changes

- Refactor/improvements

## Review

- [ ] Tests
- [ ] Documentation
