### PR TITLE
Post events for cluster-scoped objects to current namespace

### DIFF
--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -33,7 +33,7 @@ async def post_event(*, obj=None, ref=None, type, reason, message=''):
         ref = hierarchies.build_object_reference(obj)
 
     now = datetime.datetime.utcnow()
-    namespace = ref['namespace'] or 'default'
+    namespace = ref.get('namespace') or 'default'
 
     # Prevent a common case of event posting errors but shortening the message.
     if len(message) > MAX_MESSAGE_LENGTH:

--- a/kopf/engines/logging.py
+++ b/kopf/engines/logging.py
@@ -20,7 +20,7 @@ class ObjectPrefixingFormatter(logging.Formatter):
     def format(self, record):
         if hasattr(record, 'k8s_ref'):
             ref = record.k8s_ref
-            prefix = f"[{ref['namespace']}/{ref['name']}]"
+            prefix = f"[{ref.get('namespace', '')}/{ref.get('name', '')}]"
             record = copy.copy(record)  # shallow
             record.msg = f"{prefix} {record.msg}"
         return super().format(record)


### PR DESCRIPTION
K8s-events cannot be posted cluster-scoped (?), and attached to cluster-scoped resources via API. However, we post them to the current namespace — so that they are not lost completely.

> Issue : #164

## Description

See #164 for details. 

Brief summary: K8s events are namespaced, there are no cluster-scoped events. Also, k8s events can refer to an object via spec.involvedObject of type ObjectReference. This structure contains namespace field, to refer to the involved object's namespace (also, name, uid, etc).

I could not find a way to post namespaced events for cluster-scoped resources. It always fails with namespace mismatch (regardless of which library is used). Event via `curl` — see the issue comments.

So, we post the k8s-events to the current namespace, so that they are available via `kubectl get events`, despite they are not seen in `kubectl describe` on the involved objects. 

It is not a full problem solution, but it is a bit better than just losing them completely.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
