### PR TITLE
Disable CodeCov's PR spamming

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,1 @@
-comment:
-  layout: "header, sunburst, diff, tree"
-  flags:
-    - unit
+comment: off


### PR DESCRIPTION
> Issues: #99 

## Description

Despite using the "default" behaviour (post if new, update if existing), CodeCov continues to re-create the comments with the coverage, spamming the email.

This PR disables the CodeCov's comments completely.

PS: A similar issue existed for numpy in 2018: `https://github.com/numpy/numpy/issues/11984`