### PR TITLE
Remove the default peering for embeddable operator

### DIFF
--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -22,7 +22,7 @@ def run(
         registry: Optional[registries.GlobalRegistry] = None,
         standalone: bool = False,
         priority: int = 0,
-        peering_name: str = peering.PEERING_DEFAULT_NAME,
+        peering_name: Optional[str] = None,
         namespace: Optional[str] = None,
 ):
     """
@@ -49,7 +49,7 @@ async def operator(
         registry: Optional[registries.GlobalRegistry] = None,
         standalone: bool = False,
         priority: int = 0,
-        peering_name: str = peering.PEERING_DEFAULT_NAME,
+        peering_name: Optional[str] = None,
         namespace: Optional[str] = None,
 ):
     """
@@ -77,7 +77,7 @@ async def spawn_tasks(
         registry: Optional[registries.GlobalRegistry] = None,
         standalone: bool = False,
         priority: int = 0,
-        peering_name: str = peering.PEERING_DEFAULT_NAME,
+        peering_name: Optional[str] = None,
         namespace: Optional[str] = None,
 ) -> Collection[asyncio.Task]:
     """


### PR DESCRIPTION
> Issue : #142 #156 

## Description

Introduced implicitly in #156: When the operator was made embeddable, the defaults were not removed from the function signatures. 

Normally, they were overridden by the CLI defaults and set to `None`. But not when the function was called as `kopf.operator()`.

As a result, the embedded operator (kopf==0.21rc1) failed on startup due to a peering error (because the name was explicitly set, as if `--peering=default` was passed to CLI).

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
