### PR TITLE
Add --version command to print the version of kopf

### DIFF
--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -28,9 +28,11 @@ def logging_options(fn):
     def wrapper(verbose, quiet, debug, *args, **kwargs):
         config.configure(debug=debug, verbose=verbose, quiet=quiet)
         return fn(*args, **kwargs)
+
     return wrapper
 
 
+@click.version_option(prog_name='kopf')
 @click.group(name='kopf', context_settings=dict(
     auto_envvar_prefix='KOPF',
 ))


### PR DESCRIPTION
# One-line summary
add `--version` command to print the version of kopf

> Issue : #172

## Types of Changes
- New feature (non-breaking change which adds functionality)
