### PR TITLE
Log verbosely on the operator termination reasons

### DIFF
--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -87,11 +87,10 @@ async def watcher(
                 streams[key].replenished.set()  # interrupt current sleeps, if any.
                 await streams[key].watchevents.put(event)
                 await scheduler.spawn(worker(handler=handler, streams=streams, key=key))
-
+    finally:
         # Allow the existing workers to finish gracefully before killing them.
         await _wait_for_depletion(scheduler=scheduler, streams=streams)
 
-    finally:
         # Forcedly terminate all the fire-and-forget per-object jobs, of they are still running.
         await asyncio.shield(scheduler.close())
 


### PR DESCRIPTION
Make it clear what is the reason of operator exiting. 

> Issue : #178 

## Description

Add slightly more logs on the operator termination, to show which tasks are exiting, whether that happens normally or by exception or due to cancellation.

Show which signal was received — and do this on the INFO level of logging, to be visible even in non-verbose mode.

Before this PR (sometimes even with no "stop-flag" mentioned at all):

```
[2019-08-09 18:15:07,179] kopf.reactor.running [DEBUG   ] Stop-flag is raised. Operator is stopping.
[2019-08-09 18:15:07,216] kopf.reactor.running [DEBUG   ] Root tasks are stopped: finished normally; tasks left: set()
[2019-08-09 18:15:07,216] kopf.reactor.running [DEBUG   ] Hung tasks stopping is skipped: no tasks given.
```

After this PR:

```
[2019-08-09 18:14:20,780] kopf.reactor.running [INFO    ] Signal SIGINT is received. Operator is stopping.
[2019-08-09 18:14:20,781] kopf.reactor.running [DEBUG   ] Root task 'poster of events' is cancelled.
[2019-08-09 18:14:20,919] kopf.reactor.running [DEBUG   ] Root task 'watcher of kopfexamples.zalando.org' is cancelled.
[2019-08-09 18:14:20,919] kopf.reactor.running [DEBUG   ] Root task 'watcher of peering' is cancelled.
[2019-08-09 18:14:20,920] kopf.reactor.running [DEBUG   ] Root tasks are stopped: finished normally; tasks left: set()
[2019-08-09 18:14:20,921] kopf.reactor.running [DEBUG   ] Hung tasks stopping is skipped: no tasks given.
```

```
[2019-08-09 18:16:45,165] kopf.reactor.running [ERROR   ] Root task 'watcher of kopfexamples.zalando.org' is failed: Exception('Boo!')
[2019-08-09 18:16:45,166] kopf.reactor.running [DEBUG   ] Root task 'poster of events' is cancelled.
[2019-08-09 18:16:45,302] kopf.reactor.running [DEBUG   ] Root task 'watcher of peering' is cancelled.
[2019-08-09 18:16:45,303] kopf.reactor.running [DEBUG   ] Root tasks are stopped: finished normally; tasks left: set()
[2019-08-09 18:16:45,303] kopf.reactor.running [DEBUG   ] Hung tasks stopping is skipped: no tasks given.
Traceback (most recent call last):
………
Exception: Boo!
```

```
[2019-08-09 18:19:39,772] kopf.reactor.running [WARNING ] Root task 'watcher of kopfexamples.zalando.org' is finished unexpectedly.
[2019-08-09 18:19:39,773] kopf.reactor.running [DEBUG   ] Root task 'poster of events' is cancelled.
[2019-08-09 18:19:39,904] kopf.reactor.running [DEBUG   ] Root task 'watcher of peering' is cancelled.
[2019-08-09 18:19:39,906] kopf.reactor.running [DEBUG   ] Root tasks are stopped: finished normally; tasks left: set()
[2019-08-09 18:19:39,906] kopf.reactor.running [DEBUG   ] Hung tasks stopping is skipped: no tasks given.
```

Fix the queue depletion for the object workers: it would never run normally, since it was placed after the never-ending `for` loop.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
