### PR TITLE
Revert "Ensure that all handlers get the latest state (eventually)"

### DIFF
--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -67,7 +67,6 @@ class Cause(NamedTuple):
     initial: bool
     body: MutableMapping
     patch: MutableMapping
-    digest: Union[str, int]
     diff: Optional[diffs.Diff] = None
     old: Optional[Any] = None
     new: Optional[Any] = None
@@ -106,7 +105,6 @@ def detect_cause(
             initial=initial,
             **kwargs)
 
-    # Marked for deletion, but we still hold it with our finalizer.
     if finalizers.is_deleted(body):
         return Cause(
             event=DELETE,
@@ -138,7 +136,6 @@ def detect_cause(
     # For an object seen for the first time (i.e. just-created), call the creation handlers,
     # then mark the state as if it was seen when the creation has finished.
     if not lastseen.has_state(body):
-        kwargs['digest'] = True  # or any other true'ish constant (str/int)
         return Cause(
             event=CREATE,
             body=body,

--- a/kopf/structs/status.py
+++ b/kopf/structs/status.py
@@ -20,11 +20,11 @@ The structure is this:
                 handler1:
                     started: 2018-12-31T23:59:59,999999
                     stopped: 2018-01-01T12:34:56,789000
-                    success: abcdef1234567890fedcba
+                    success: true
                 handler2:
                     started: 2018-12-31T23:59:59,999999
                     stopped: 2018-01-01T12:34:56,789000
-                    failure: abcdef1234567890fedcba
+                    failure: true
                     message: "Error message."
                 handler3:
                     started: 2018-12-31T23:59:59,999999
@@ -37,46 +37,16 @@ The structure is this:
                 handler3/sub2:
                     started: 2018-12-31T23:59:59,999999
 
-* ``status.kopf.progress`` stores the state of each individual handler in the
-  current handling cycle (by their ids, which are usually the function names).
-
-For each handler's status, the following is stored:
-
-* ``started``: when the handler was attempted for the first time (used for timeouts & durations).
-* ``stopped``: when the handler has failed or succeeded.
-* ``delayed``: when the handler can retry again.
-* ``retries``: the number of retried attempted so far (including reruns and successful attempts).
-* ``success``: a digest of where the handler has succeeded (and thus no retries are needed).
-* ``failure``: a digest of where the handler has failed completely (no retries will be done).
-* ``message``: a brief error message from the last exception (as a hint).
+* ``status.kopf.success`` are the handlers that succeeded (no re-execution).
+* ``status.kopf.failure`` are the handlers that failed completely (no retries).
+* ``status.kopf.delayed`` are the timestamps, until which these handlers sleep.
+* ``status.kopf.retries`` are number of retries for succeeded, failed,
+  and for the progressing handlers.
 
 When the full event cycle is executed (possibly including multiple re-runs),
 the whole ``status.kopf`` section is purged. The life-long persistence of status
 is not intended: otherwise, multiple distinct causes will clutter the status
 and collide with each other (especially critical for multiple updates).
-
-The digest of each handler's success or failure can be considered a "version"
-of an object being handled, as it was when the handler has finished.
-If the object is changed during the remaining handling cycle, the digest
-of the finished handlers will be mismatching the actual digest of the object,
-and so they will be re-executed.
-
-This is conceptually close to *reconciliation*: the handling is finished
-only when all handlers are executed on the latest state of the object.
-
-Creation is treated specially: the creation handlers will never be re-executed.
-In case of changes during the creation handling, the remaining creation handlers
-will get the new state (as normally), and then there will be an update cycle
-with all the changes since the first creation handler -- i.e. not from the last
-handler as usually, when the last-seen state is updated.
-
-Update handlers are assumed to be idempotent by concept, so it should be safe
-to call them with the changes that are already reflected in the system by some
-of the creation handlers.
-
-Note: The Kubernetes-provided "resource version" of the object is not used,
-as it increases with every change of the object, while this digest is used
-only for the changes relevant to the operator and framework (see `get_state`).
 """
 
 import collections.abc
@@ -89,24 +59,23 @@ def is_started(*, body, handler):
     return handler.id in progress
 
 
-def is_sleeping(*, body, digest, handler):
+def is_sleeping(*, body, handler):
     ts = get_awake_time(body=body, handler=handler)
-    finished = is_finished(body=body, digest=digest, handler=handler)
+    finished = is_finished(body=body, handler=handler)
     return not finished and ts is not None and ts > datetime.datetime.utcnow()
 
 
-def is_awakened(*, body, digest, handler):
-    finished = is_finished(body=body, digest=digest, handler=handler)
-    sleeping = is_sleeping(body=body, digest=digest, handler=handler)
+def is_awakened(*, body, handler):
+    finished = is_finished(body=body, handler=handler)
+    sleeping = is_sleeping(body=body, handler=handler)
     return bool(not finished and not sleeping)
 
 
-def is_finished(*, body, digest, handler):
+def is_finished(*, body, handler):
     progress = body.get('status', {}).get('kopf', {}).get('progress', {})
     success = progress.get(handler.id, {}).get('success', None)
     failure = progress.get(handler.id, {}).get('failure', None)
-    return ((success is not None and (success is True or success == digest)) or
-            (failure is not None and (failure is True or failure == digest)))
+    return bool(success or failure)
 
 
 def get_start_time(*, body, patch, handler):
@@ -157,23 +126,23 @@ def set_retry_time(*, body, patch, handler, delay=None):
     set_awake_time(body=body, patch=patch, handler=handler, delay=delay)
 
 
-def store_failure(*, body, patch, digest, handler, exc):
+def store_failure(*, body, patch, handler, exc):
     retry = get_retry_count(body=body, handler=handler)
     progress = patch.setdefault('status', {}).setdefault('kopf', {}).setdefault('progress', {})
     progress.setdefault(handler.id, {}).update({
         'stopped': datetime.datetime.utcnow().isoformat(),
-        'failure': digest,
+        'failure': True,
         'retries': retry + 1,
         'message': f'{exc}',
     })
 
 
-def store_success(*, body, patch, digest, handler, result=None):
+def store_success(*, body, patch, handler, result=None):
     retry = get_retry_count(body=body, handler=handler)
     progress = patch.setdefault('status', {}).setdefault('kopf', {}).setdefault('progress', {})
     progress.setdefault(handler.id, {}).update({
         'stopped': datetime.datetime.utcnow().isoformat(),
-        'success': digest,
+        'success': True,
         'retries': retry + 1,
         'message': None,
     })

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -15,7 +15,6 @@ def test_all_args(mocker):
     initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
-    digest = mocker.Mock()
     diff = mocker.Mock()
     old = mocker.Mock()
     new = mocker.Mock()
@@ -26,7 +25,6 @@ def test_all_args(mocker):
         initial=initial,
         body=body,
         patch=patch,
-        digest=digest,
         diff=diff,
         old=old,
         new=new,
@@ -37,7 +35,6 @@ def test_all_args(mocker):
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
-    assert cause.digest is digest
     assert cause.diff is diff
     assert cause.old is old
     assert cause.new is new
@@ -50,7 +47,6 @@ def test_required_args(mocker):
     initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
-    digest = mocker.Mock()
     cause = Cause(
         resource=resource,
         logger=logger,
@@ -58,7 +54,6 @@ def test_required_args(mocker):
         initial=initial,
         body=body,
         patch=patch,
-        digest=digest,
     )
     assert cause.resource is resource
     assert cause.logger is logger
@@ -66,7 +61,6 @@ def test_required_args(mocker):
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
-    assert cause.digest is digest
     assert cause.diff is None
     assert cause.old is None
     assert cause.new is None

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -117,7 +117,6 @@ def kwargs():
         resource=object(),
         logger=object(),
         patch=object(),
-        digest=object(),
     )
 
 def check_kwargs(cause, kwargs):
@@ -125,7 +124,6 @@ def check_kwargs(cause, kwargs):
     assert cause.resource is kwargs['resource']
     assert cause.logger is kwargs['logger']
     assert cause.patch is kwargs['patch']
-    assert cause.digest is kwargs['digest'] or cause.digest is True
 
 
 #

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -190,14 +190,12 @@ def cause_mock(mocker, resource):
         original_diff = kwargs.pop('diff', None)
         original_new = kwargs.pop('new', None)
         original_old = kwargs.pop('old', None)
-        original_digest = kwargs.pop('digest', None)
         event = mock.event if mock.event is not None else original_event
         initial = bool(event == RESUME)
         body = copy.deepcopy(mock.body) if mock.body is not None else original_body
         diff = copy.deepcopy(mock.diff) if mock.diff is not None else original_diff
         new = copy.deepcopy(mock.new) if mock.new is not None else original_new
         old = copy.deepcopy(mock.old) if mock.old is not None else original_old
-        digest = copy.deepcopy(mock.digest) if mock.digest is not None else original_digest
 
         # Remove requires_finalizer from kwargs as it shouldn't be passed to the Cause object
         kwargs.pop('requires_finalizer', None)
@@ -211,7 +209,6 @@ def cause_mock(mocker, resource):
             diff=diff,
             new=new,
             old=old,
-            digest=digest,
             **kwargs)
 
         # Needed for the k8s-event creation, as they are attached to objects.
@@ -227,11 +224,10 @@ def cause_mock(mocker, resource):
     mocker.patch('kopf.reactor.causation.detect_cause', new=new_detect_fn)
 
     # The mock object stores some values later used by the factory substitute.
-    mock = mocker.Mock(spec_set=['event', 'body', 'diff', 'new', 'old', 'digest'])
+    mock = mocker.Mock(spec_set=['event', 'body', 'diff', 'new', 'old'])
     mock.event = None
     mock.body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
     mock.diff = None
     mock.new = None
     mock.old = None
-    mock.digest = None
     return mock

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 
 import freezegun
@@ -70,15 +69,12 @@ async def test_delayed_handlers_sleep(
 
     cause_mock.event = cause_type
     cause_mock.body.update({
-        'status': {'kopf': {
-            'frozen-state': json.dumps({'spec': {}}),  # to prevent re-adding it
-            'progress': {
-                'create_fn': {'delayed': ts},
-                'update_fn': {'delayed': ts},
-                'delete_fn': {'delayed': ts},
-                'resume_fn': {'delayed': ts},
-            },
-        }}
+        'status': {'kopf': {'progress': {
+            'create_fn': {'delayed': ts},
+            'update_fn': {'delayed': ts},
+            'delete_fn': {'delayed': ts},
+            'resume_fn': {'delayed': ts},
+        }}}
     })
     # make sure the finalizer is added since there are mandatory deletion handlers
     cause_mock.body.setdefault('metadata', {})['finalizers'] = [FINALIZER]
@@ -101,7 +97,7 @@ async def test_delayed_handlers_sleep(
 
     # The dummy patch is needed to trigger the further changes. The value is irrelevant.
     assert k8s_mocked.patch_obj.called
-    assert k8s_mocked.patch_obj.call_args_list[-1][1]['patch']  # not empty, maybe with ['dummy']
+    assert 'dummy' in k8s_mocked.patch_obj.call_args_list[-1][1]['patch']['status']['kopf']
 
     # The duration of sleep should be as expected.
     assert k8s_mocked.sleep_or_wait.called

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -43,7 +43,7 @@ async def test_fatal_error_stops_handler(
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
     assert patch['status']['kopf']['progress'] is not None
-    assert patch['status']['kopf']['progress'][name1]['failure']  # evals to true
+    assert patch['status']['kopf']['progress'][name1]['failure'] is True
     assert patch['status']['kopf']['progress'][name1]['message'] == 'oops'
 
     assert_logs([

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -38,7 +38,7 @@ async def test_1st_step_stores_progress_by_patching(
     assert patch['status']['kopf']['progress'] is not None
 
     assert patch['status']['kopf']['progress'][name1]['retries'] == 1
-    assert patch['status']['kopf']['progress'][name1]['success']  # evals to true
+    assert patch['status']['kopf']['progress'][name1]['success'] is True
 
     assert 'retries' not in patch['status']['kopf']['progress'][name2]
     assert 'success' not in patch['status']['kopf']['progress'][name2]

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -53,7 +53,7 @@ async def test_timed_out_handler_fails(
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
     assert patch['status']['kopf']['progress'] is not None
-    assert patch['status']['kopf']['progress'][name1]['failure']  # evals to true
+    assert patch['status']['kopf']['progress'][name1]['failure'] is True
 
     assert_logs([
         "Handler .+ has timed out after",

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -53,213 +53,94 @@ def test_is_started(handler, expected, body):
     assert body == origbody  # not modified
 
 
-@pytest.mark.parametrize('body', [
-    {},
-    {'status': {}},
-    {'status': {'kopf': {}}},
-    {'status': {'kopf': {'progress': {}}}},
-    {'status': {'kopf': {'progress': {'some-id': {}}}}},
+@pytest.mark.parametrize('expected, body', [
+    (False, {}),
+    (False, {'status': {}}),
+    (False, {'status': {'kopf': {}}}),
+    (False, {'status': {'kopf': {'progress': {}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'success': False}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'failure': False}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'success': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'failure': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'success': True}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'failure': True}}}}}),
 ])
-def test_is_finished_with_partial_status_remains_readonly(handler, body):
+def test_is_finished(handler, expected, body):
     origbody = copy.deepcopy(body)
-    result = is_finished(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert not result
+    result = is_finished(body=body, handler=handler)
+    assert result == expected
     assert body == origbody  # not modified
 
 
-@pytest.mark.parametrize('finish_value', [None, False, 'bad'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-def test_is_finished_when_not_finished(handler, finish_field, finish_value):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_finished(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert not result
+@pytest.mark.parametrize('expected, body', [
 
+    # Everything that is finished is not sleeping, no matter the sleep/awake field.
+    (False, {'status': {'kopf': {'progress': {'some-id': {'success': True}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'failure': True}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'success': True, 'delayed': TS0_ISO}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'failure': True, 'delayed': TS0_ISO}}}}}),
 
-@pytest.mark.parametrize('finish_value', [True, 'good'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-def test_is_finished_when_finished(handler, finish_field, finish_value):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_finished(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert result
+    # Everything with no sleep/awake field set is not sleeping either.
+    (False, {'status': {'kopf': {'progress': {'some-id': {}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'success': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'failure': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'success': None, 'delayed': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'failure': None, 'delayed': None}}}}}),
 
-
-@pytest.mark.parametrize('body', [
-    {},
-    {'status': {}},
-    {'status': {'kopf': {}}},
-    {'status': {'kopf': {'progress': {}}}},
-    {'status': {'kopf': {'progress': {'some-id': {}}}}},
+    # When not finished and has awake time, the output depends on the relation to "now".
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TS0_ISO}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TS0_ISO, 'success': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TS0_ISO, 'failure': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TSB_ISO}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TSB_ISO, 'success': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TSB_ISO, 'failure': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TSA_ISO}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TSA_ISO, 'success': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TSA_ISO, 'failure': None}}}}}),
 ])
-def test_is_sleeping_with_partial_status_remains_readonly(handler, body):
+@freezegun.freeze_time(TS0)
+def test_is_sleeping(handler, expected, body):
     origbody = copy.deepcopy(body)
-    result = is_finished(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert not result
+    result = is_sleeping(body=body, handler=handler)
+    assert result == expected
     assert body == origbody  # not modified
 
 
-@pytest.mark.parametrize('finish_value', [True, 'good'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-@pytest.mark.parametrize('delayed_body', [
-    pytest.param({}, id='delayed-empty'),
-    pytest.param({'delayed': None}, id='delayed-none'),
-    pytest.param({'delayed': TSB_ISO}, id='delayed-before'),
-    pytest.param({'delayed': TS0_ISO}, id='delayed-exact'),
-    pytest.param({'delayed': TS1_ISO}, id='delayed-onesec'),
-    pytest.param({'delayed': TSA_ISO}, id='delayed-after'),
+@pytest.mark.parametrize('expected, body', [
+
+    # Everything that is finished never awakens, no matter the sleep/awake field.
+    (False, {'status': {'kopf': {'progress': {'some-id': {'success': True}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'failure': True}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'success': True, 'delayed': TS0_ISO}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'failure': True, 'delayed': TS0_ISO}}}}}),
+
+    # Everything with no sleep/awake field is not sleeping, thus by definition is awake.
+    (True , {'status': {'kopf': {'progress': {'some-id': {}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'success': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'failure': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'success': None, 'delayed': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'failure': None, 'delayed': None}}}}}),
+
+    # When not finished and has awake time, the output depends on the relation to "now".
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TS0_ISO}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TS0_ISO, 'success': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TS0_ISO, 'failure': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TSB_ISO}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TSB_ISO, 'success': None}}}}}),
+    (True , {'status': {'kopf': {'progress': {'some-id': {'delayed': TSB_ISO, 'failure': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TSA_ISO}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TSA_ISO, 'success': None}}}}}),
+    (False, {'status': {'kopf': {'progress': {'some-id': {'delayed': TSA_ISO, 'failure': None}}}}}),
 ])
 @freezegun.freeze_time(TS0)
-def test_is_sleeping_when_finished_regardless_of_delay(
-        handler, finish_field, finish_value, delayed_body):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'].update(delayed_body)
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_sleeping(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert not result
-
-
-@pytest.mark.parametrize('finish_value', [None, False, 'bad'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-@pytest.mark.parametrize('delayed_body', [
-    pytest.param({}, id='delayed-empty'),
-    pytest.param({'delayed': None}, id='delayed-none'),
-])
-@freezegun.freeze_time(TS0)
-def test_is_sleeping_when_not_finished_and_not_delayed(
-        handler, delayed_body, finish_field, finish_value):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'].update(delayed_body)
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_sleeping(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert not result
-
-
-@pytest.mark.parametrize('finish_value', [None, False, 'bad'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-@pytest.mark.parametrize('delayed_body', [
-    pytest.param({'delayed': TSB_ISO}, id='delayed-before'),
-    pytest.param({'delayed': TS0_ISO}, id='delayed-exact'),
-])
-@freezegun.freeze_time(TS0)
-def test_is_sleeping_when_not_finished_and_delayed_until_before_now(
-        handler, finish_field, finish_value, delayed_body):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'].update(delayed_body)
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_sleeping(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert not result
-
-
-@pytest.mark.parametrize('finish_value', [None, False, 'bad'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-@pytest.mark.parametrize('delayed_body', [
-    pytest.param({'delayed': TS1_ISO}, id='delayed-onesec'),
-    pytest.param({'delayed': TSA_ISO}, id='delayed-after'),
-])
-@freezegun.freeze_time(TS0)
-def test_is_sleeping_when_not_finished_and_delayed_until_after_now(
-        handler, finish_field, finish_value, delayed_body):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'].update(delayed_body)
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_sleeping(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert result
-
-
-@pytest.mark.parametrize('body', [
-    {},
-    {'status': {}},
-    {'status': {'kopf': {}}},
-    {'status': {'kopf': {'progress': {}}}},
-    {'status': {'kopf': {'progress': {'some-id': {}}}}},
-])
-def test_is_awakened_with_partial_status_remains_readonly(handler, body):
+def test_is_awakened(handler, expected, body):
     origbody = copy.deepcopy(body)
-    result = is_awakened(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert result
+    result = is_awakened(body=body, handler=handler)
+    assert result == expected
     assert body == origbody  # not modified
-
-
-@pytest.mark.parametrize('finish_value', [True, 'good'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-@pytest.mark.parametrize('delayed_body', [
-    pytest.param({}, id='delayed-empty'),
-    pytest.param({'delayed': None}, id='delayed-none'),
-    pytest.param({'delayed': TSB_ISO}, id='delayed-before'),
-    pytest.param({'delayed': TS0_ISO}, id='delayed-exact'),
-    pytest.param({'delayed': TS1_ISO}, id='delayed-onesec'),
-    pytest.param({'delayed': TSA_ISO}, id='delayed-after'),
-])
-@freezegun.freeze_time(TS0)
-def test_is_awakened_when_finished_regardless_of_delay(
-        handler, finish_field, finish_value, delayed_body):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'].update(delayed_body)
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_awakened(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert not result
-
-
-@pytest.mark.parametrize('finish_value', [None, False, 'bad'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-@pytest.mark.parametrize('delayed_body', [
-    pytest.param({}, id='delayed-empty'),
-    pytest.param({'delayed': None}, id='delayed-none'),
-])
-@freezegun.freeze_time(TS0)
-def test_is_awakened_when_not_finished_and_not_delayed(
-        handler, delayed_body, finish_field, finish_value):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'].update(delayed_body)
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_awakened(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert result
-
-
-@pytest.mark.parametrize('finish_value', [None, False, 'bad'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-@pytest.mark.parametrize('delayed_body', [
-    pytest.param({'delayed': TSB_ISO}, id='delayed-before'),
-    pytest.param({'delayed': TS0_ISO}, id='delayed-exact'),
-])
-@freezegun.freeze_time(TS0)
-def test_is_awakened_when_not_finished_and_delayed_until_before_now(
-        handler, finish_field, finish_value, delayed_body):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'].update(delayed_body)
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_awakened(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert result
-
-
-@pytest.mark.parametrize('finish_value', [None, False, 'bad'])
-@pytest.mark.parametrize('finish_field', ['failure', 'success'])
-@pytest.mark.parametrize('delayed_body', [
-    pytest.param({'delayed': TS1_ISO}, id='delayed-onesec'),
-    pytest.param({'delayed': TSA_ISO}, id='delayed-after'),
-])
-@freezegun.freeze_time(TS0)
-def test_is_awakened_when_not_finished_and_delayed_until_after_now(
-        handler, finish_field, finish_value, delayed_body):
-    body = {'status': {'kopf': {'progress': {'some-id': {}}}}}
-    body['status']['kopf']['progress']['some-id'].update(delayed_body)
-    body['status']['kopf']['progress']['some-id'][finish_field] = finish_value
-    result = is_awakened(body=body, digest='good', handler=handler)
-    assert isinstance(result, bool)
-    assert not result
 
 
 @pytest.mark.parametrize('expected, body', [
@@ -380,13 +261,13 @@ def test_set_retry_time(handler, expected, body, delay):
 @pytest.mark.parametrize('body, expected', [
     ({},
      {'status': {'kopf': {'progress': {'some-id': {'stopped': TS0_ISO,
-                                                   'failure': 'digest',
+                                                   'failure': True,
                                                    'retries': 1,
                                                    'message': 'some-error'}}}}}),
 
     ({'status': {'kopf': {'progress': {'some-id': {'retries': 5}}}}},
      {'status': {'kopf': {'progress': {'some-id': {'stopped': TS0_ISO,
-                                                   'failure': 'digest',
+                                                   'failure': True,
                                                    'retries': 6,
                                                    'message': 'some-error'}}}}}),
 ])
@@ -394,8 +275,7 @@ def test_set_retry_time(handler, expected, body, delay):
 def test_store_failure(handler, expected, body):
     origbody = copy.deepcopy(body)
     patch = {}
-    store_failure(body=body, patch=patch, digest='digest',
-                  handler=handler, exc=Exception("some-error"))
+    store_failure(body=body, patch=patch, handler=handler, exc=Exception("some-error"))
     assert patch == expected
     assert body == origbody  # not modified
 
@@ -406,13 +286,13 @@ def test_store_failure(handler, expected, body):
     (None,
      {},
      {'status': {'kopf': {'progress': {'some-id': {'stopped': TS0_ISO,
-                                                   'success': 'digest',
+                                                   'success': True,
                                                    'retries': 1,
                                                    'message': None}}}}}),
     (None,
      {'status': {'kopf': {'progress': {'some-id': {'retries': 5}}}}},
      {'status': {'kopf': {'progress': {'some-id': {'stopped': TS0_ISO,
-                                                   'success': 'digest',
+                                                   'success': True,
                                                    'retries': 6,
                                                    'message': None}}}}}),
 
@@ -420,14 +300,14 @@ def test_store_failure(handler, expected, body):
     ({'field': 'value'},
      {},
      {'status': {'kopf': {'progress': {'some-id': {'stopped': TS0_ISO,
-                                                   'success': 'digest',
+                                                   'success': True,
                                                    'retries': 1,
                                                    'message': None}}},
                  'some-id': {'field': 'value'}}}),
     ({'field': 'value'},
      {'status': {'kopf': {'progress': {'some-id': {'retries': 5}}}}},
      {'status': {'kopf': {'progress': {'some-id': {'stopped': TS0_ISO,
-                                                   'success': 'digest',
+                                                   'success': True,
                                                    'retries': 6,
                                                    'message': None}}},
                  'some-id': {'field': 'value'}}}),
@@ -436,8 +316,7 @@ def test_store_failure(handler, expected, body):
 def test_store_success(handler, expected, body, result):
     origbody = copy.deepcopy(body)
     patch = {}
-    store_success(body=body, patch=patch, digest='digest',
-                  handler=handler, result=result)
+    store_success(body=body, patch=patch, handler=handler, result=result)
     assert patch == expected
     assert body == origbody  # not modified
 


### PR DESCRIPTION
> Reverts zalando-incubator/kopf#163, affects #150 

This feature (per-handler reconciliation) has introduced inconsistent behaviour with field-handlers and sub-handlers.

Specifically, it causes the field-handlers and sub-handlers with side-effects to be executed again and again if the spec/status fields of interest are changed during the multi-step handling cycle (when it is not fast enough — e.g. due to errors & retries) — because the digest changes globally for the object in that case. And it only stabilises when there are not external changes of the fields during the full handling cycle (if it is fast enough).

Conceptually caused by misalignment of per-object and per-handling-cycle state persistence (last-handled-state/diff/old/new), and per-handler digest remembering and comparison — they must be aligned to the same level, so that the handlers are not re-executed when not needed.

**More investigation and debugging is needed.** Which can take some time. However, this **blocks the release 0.21** with other improvements. Therefore, this feature is reverted and excluded from 0.21 — to be revised and re-implemented later.

