### PR TITLE
Obey the configured levels when posting from `logging`

### DIFF
--- a/kopf/config.py
+++ b/kopf/config.py
@@ -8,13 +8,13 @@ from kopf.engines import logging as logging_engine
 format = '[%(asctime)s] %(name)-20.20s [%(levelname)-8.8s] %(message)s'
 
 
-LOGLEVEL_INFO = 20
+LOGLEVEL_INFO = logging.INFO
 """ Event loglevel to log all events. """
-LOGLEVEL_WARNING = 30
+LOGLEVEL_WARNING = logging.WARNING
 """ Event loglevel to log all events except informational. """
-LOGLEVEL_ERROR = 40
+LOGLEVEL_ERROR = logging.ERROR
 """ Event loglevel to log only errors and critical events. """
-LOGLEVEL_CRITICAL = 50
+LOGLEVEL_CRITICAL = logging.CRITICAL
 """ Event loglevel to log only critical events(basically - no events). """
 
 

--- a/kopf/engines/logging.py
+++ b/kopf/engines/logging.py
@@ -11,6 +11,7 @@ the operators' code, and can lead to information loss or mismatch
 import copy
 import logging
 
+from kopf import config
 from kopf.engines import posting
 
 
@@ -39,9 +40,10 @@ class K8sPoster(logging.Handler):
     def filter(self, record):
         # Only those which have a k8s object referred (see: `ObjectLogger`).
         # Otherwise, we have nothing to post, and nothing to do.
+        fit_lvl = record.levelno >= config.EventsConfig.events_loglevel
         has_ref = hasattr(record, 'k8s_ref')
         skipped = hasattr(record, 'k8s_skip') and record.k8s_skip
-        return has_ref and not skipped and super().filter(record)
+        return fit_lvl and has_ref and not skipped and super().filter(record)
 
     def emit(self, record):
         # Same try-except as in e.g. `logging.StreamHandler`.
@@ -105,4 +107,4 @@ class ObjectLogger(logging.LoggerAdapter):
 
 
 logger = logging.getLogger('kopf.objects')
-logger.addHandler(K8sPoster(level=logging.INFO))
+logger.addHandler(K8sPoster())

--- a/kopf/engines/logging.py
+++ b/kopf/engines/logging.py
@@ -40,10 +40,10 @@ class K8sPoster(logging.Handler):
     def filter(self, record):
         # Only those which have a k8s object referred (see: `ObjectLogger`).
         # Otherwise, we have nothing to post, and nothing to do.
-        fit_lvl = record.levelno >= config.EventsConfig.events_loglevel
+        level_ok = record.levelno >= config.EventsConfig.events_loglevel
         has_ref = hasattr(record, 'k8s_ref')
         skipped = hasattr(record, 'k8s_skip') and record.k8s_skip
-        return fit_lvl and has_ref and not skipped and super().filter(record)
+        return level_ok and has_ref and not skipped and super().filter(record)
 
     def emit(self, record):
         # Same try-except as in e.g. `logging.StreamHandler`.

--- a/kopf/engines/posting.py
+++ b/kopf/engines/posting.py
@@ -74,25 +74,22 @@ def event(objs, *, type, reason, message=''):
 
 
 def info(obj, *, reason, message=''):
-    if config.EventsConfig.events_loglevel > config.LOGLEVEL_INFO:
-        return
-    event(obj, type='Normal', reason=reason, message=message)
+    if config.EventsConfig.events_loglevel <= config.LOGLEVEL_INFO:
+        event(obj, type='Normal', reason=reason, message=message)
 
 
 def warn(obj, *, reason, message=''):
-    if config.EventsConfig.events_loglevel > config.LOGLEVEL_WARNING:
-        return
-    event(obj, type='Warning', reason=reason, message=message)
+    if config.EventsConfig.events_loglevel <= config.LOGLEVEL_WARNING:
+        event(obj, type='Warning', reason=reason, message=message)
 
 
 def exception(obj, *, reason='', message='', exc=None):
-    if config.EventsConfig.events_loglevel > config.LOGLEVEL_ERROR:
-        return
     if exc is None:
         _, exc, _ = sys.exc_info()
     reason = reason if reason else type(exc).__name__
     message = f'{message} {exc}' if message and exc else f'{exc}' if exc else f'{message}'
-    event(obj, type='Error', reason=reason, message=message)
+    if config.EventsConfig.events_loglevel <= config.LOGLEVEL_ERROR:
+        event(obj, type='Error', reason=reason, message=message)
 
 
 async def poster(

--- a/tests/posting/test_log2k8s.py
+++ b/tests/posting/test_log2k8s.py
@@ -1,5 +1,8 @@
+import logging
+
 import pytest
 
+from kopf.config import EventsConfig
 from kopf.engines.logging import ObjectLogger
 
 OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
@@ -29,6 +32,32 @@ async def test_posting_normal_levels(caplog, logstream, logfn, event_type, event
     assert caplog.messages == ["hello world"]
 
 
+@pytest.mark.parametrize('logfn, event_type, min_levelno', [
+    ['debug', "Debug", logging.DEBUG],
+    ['info', "Normal", logging.INFO],
+    ['warning', "Warning", logging.WARNING],
+    ['error', "Error", logging.ERROR],
+    ['critical', "Fatal", logging.CRITICAL],
+])
+async def test_posting_above_config(caplog, logstream, logfn, event_type, min_levelno,
+                                    event_queue, event_queue_loop, mocker):
+    logger = ObjectLogger(body=OBJ1)
+    logger_fn = getattr(logger, logfn)
+
+    mocker.patch.object(EventsConfig, 'events_loglevel', min_levelno)
+    logger_fn("hello %s", "world")
+    mocker.patch.object(EventsConfig, 'events_loglevel', min_levelno + 1)
+    logger_fn("must not be posted")
+
+    assert event_queue.qsize() == 1
+    event1 = event_queue.get_nowait()
+    assert event1.ref == REF1
+    assert event1.type == event_type
+    assert event1.reason == "Logging"
+    assert event1.message == "hello world"
+    assert caplog.messages == ["hello world", "must not be posted"]
+
+
 @pytest.mark.parametrize('logfn', [
     'debug',
 ])
@@ -37,6 +66,27 @@ async def test_skipping_hidden_levels(caplog, logstream, logfn, event_queue, eve
     logger_fn = getattr(logger, logfn)
 
     logger_fn("hello %s", "world")
+    logger.info("must be here")
+
+    assert event_queue.qsize() == 1  # not 2!
+    assert caplog.messages == ["hello world", "must be here"]
+
+
+@pytest.mark.parametrize('logfn', [
+    'debug',
+    'info',
+    'warning',
+    'error',
+    'critical',
+])
+async def test_skipping_below_config(caplog, logstream, logfn, event_queue, event_queue_loop,
+                                     mocker):
+    logger = ObjectLogger(body=OBJ1)
+    logger_fn = getattr(logger, logfn)
+
+    mocker.patch.object(EventsConfig, 'events_loglevel', 666)
+    logger_fn("hello %s", "world")
+    mocker.patch.object(EventsConfig, 'events_loglevel', 0)
     logger.info("must be here")
 
     assert event_queue.qsize() == 1  # not 2!


### PR DESCRIPTION
Fix an issue with k8s-events posted for log messages despite the configured levels.

> Issue : fixes #188

## Description

Configured log levels was ignored in the connector of the `logging` facilities to the k8s-event posting engine, so all events were posted. The docs were written for the event-posting shortcuts, but this was not taken into account when the log-posting engine was added.

In addition, some extra checks are added to verify that the shortcuts actually obey the configured levels.

**Note** that the debug level messages are now filtered not by the K8s-posting handler `K8sPoster` — the minimum level is removed from there— but by its `filter()` method, based on the Kopf's configs. Which is generally equivalent, as it was previously filtered by level in `super().filter(record)`, which stands in the same line.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
