### PR TITLE
Automatically test with the latest Kubernetes version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
     - MINIKUBE_HOME=$HOME
     - MINIKUBE_VERSION=v1.0.1
   matrix:
-    - KUBERNETES_VERSION=v1.14.0 CLIENT=yes  # only one "yes" is enough
-    - KUBERNETES_VERSION=v1.14.0 CLIENT=no
+    - KUBERNETES_VERSION=latest CLIENT=yes  # only one "yes" is enough
+    - KUBERNETES_VERSION=latest CLIENT=no
     - KUBERNETES_VERSION=v1.13.0 CLIENT=no
     - KUBERNETES_VERSION=v1.12.0 CLIENT=no
 #    - KUBERNETES_VERSION=v1.11.10  # Minikube fails on CRI preflight checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ env:
   matrix:
     - KUBERNETES_VERSION=latest CLIENT=yes  # only one "yes" is enough
     - KUBERNETES_VERSION=latest CLIENT=no
+    - KUBERNETES_VERSION=v1.16.0 CLIENT=no
+    - KUBERNETES_VERSION=v1.15.0 CLIENT=no
+    - KUBERNETES_VERSION=v1.14.0 CLIENT=no
     - KUBERNETES_VERSION=v1.13.0 CLIENT=no
     - KUBERNETES_VERSION=v1.12.0 CLIENT=no
 #    - KUBERNETES_VERSION=v1.11.10  # Minikube fails on CRI preflight checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - MINIKUBE_WANTREPORTERRORPROMPT=false
     - MINIKUBE_IN_STYLE=true
     - MINIKUBE_HOME=$HOME
-    - MINIKUBE_VERSION=v1.0.1
+    - MINIKUBE_VERSION=latest
   matrix:
     - KUBERNETES_VERSION=latest CLIENT=yes  # only one "yes" is enough
     - KUBERNETES_VERSION=latest CLIENT=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ env:
     - MINIKUBE_WANTREPORTERRORPROMPT=false
     - MINIKUBE_IN_STYLE=true
     - MINIKUBE_HOME=$HOME
-    - MINIKUBE_VERSION=1.0.1
+    - MINIKUBE_VERSION=v1.0.1
   matrix:
-    - KUBERNETES_VERSION=1.14.0 CLIENT=yes  # only one "yes" is enough
-    - KUBERNETES_VERSION=1.14.0 CLIENT=no
-    - KUBERNETES_VERSION=1.13.0 CLIENT=no
-    - KUBERNETES_VERSION=1.12.0 CLIENT=no
-#    - KUBERNETES_VERSION=1.11.10  # Minikube fails on CRI preflight checks
-#    - KUBERNETES_VERSION=1.10.13  # CRDs require spec.version, which fails on 1.14
+    - KUBERNETES_VERSION=v1.14.0 CLIENT=yes  # only one "yes" is enough
+    - KUBERNETES_VERSION=v1.14.0 CLIENT=no
+    - KUBERNETES_VERSION=v1.13.0 CLIENT=no
+    - KUBERNETES_VERSION=v1.12.0 CLIENT=no
+#    - KUBERNETES_VERSION=v1.11.10  # Minikube fails on CRI preflight checks
+#    - KUBERNETES_VERSION=v1.10.13  # CRDs require spec.version, which fails on 1.14
 
 python:
   - "3.7"

--- a/tools/kubernetes-client.sh
+++ b/tools/kubernetes-client.sh
@@ -4,5 +4,5 @@ set -x
 
 if [[ "${CLIENT:-}" = "yes" ]] ; then
     # FIXME: See https://github.com/kubernetes-client/python/issues/866
-    pip install 'kubernetes<10.0.0'
+    pip install 'kubernetes>=10.0.1'
 fi

--- a/tools/minikube-for-travis.sh
+++ b/tools/minikube-for-travis.sh
@@ -3,11 +3,11 @@
 set -eu
 set -x
 
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBERNETES_VERSION}"/bin/linux/amd64/kubectl
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin/
 
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-amd64
 chmod +x minikube
 sudo mv minikube /usr/local/bin/
 
@@ -18,6 +18,6 @@ sudo minikube start \
     --vm-driver=none \
     --extra-config=apiserver.authorization-mode=RBAC \
     --extra-config=apiserver.runtime-config=events.k8s.io/v1beta1=false \
-    --kubernetes-version=v${KUBERNETES_VERSION}
+    --kubernetes-version="${KUBERNETES_VERSION}"
 
 sudo chown -R travis: /home/travis/.minikube/

--- a/tools/minikube-for-travis.sh
+++ b/tools/minikube-for-travis.sh
@@ -3,6 +3,13 @@
 set -eu
 set -x
 
+: ${KUBERNETES_VERSION:=latest}
+: ${MINIKUBE_VERSION:=latest}
+
+if [[ "${KUBERNETES_VERSION}" == latest ]] ; then
+    KUBERNETES_VERSION=$( curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt )
+fi
+
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBERNETES_VERSION}"/bin/linux/amd64/kubectl
 chmod +x kubectl
 sudo mv kubectl /usr/local/bin/


### PR DESCRIPTION
Replace the explicit Kubernetes versions in CI/CD with the "latest" aliases.

> Issue : #13

## Description

Previously, all Kubernetes versions were explicitly enumerated in the CI/CD config. We had to add new Kubernetes versions from time to time. Same for Minikube.

Now, the "latest" will be used for both. Extra versions versions to test still have to be listed explicitly  (to my knowledge, there is no "latest minus 1", "latest minus 2", or so).

Now, the Travis build looks like [this](https://travis-ci.org/nolar/kopf/builds/589950167):

![image](https://user-images.githubusercontent.com/544296/65696118-028d7380-e079-11e9-9a6c-9a5cae926fe8.png)


## Types of Changes

- Refactor/improvements
