### PR TITLE
Remove an abstraction leak of a Response object — for type-hinting

### DIFF
--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -98,12 +98,8 @@ async def streaming_watch(
 
     # First, list the resources regularly, and get the list's resource version.
     # Simulate the events with type "None" event - used in detection of causes.
-    rsp = fetching.list_objs(resource=resource, namespace=namespace)
-    resource_version = rsp['metadata']['resourceVersion']
-    for item in rsp['items']:
-        # FIXME: fix in pykube to inject the missing item's fields from the list's metainfo.
-        item.setdefault('kind', rsp['kind'][:-4] if rsp['kind'][-4:] == 'List' else rsp['kind'])
-        item.setdefault('apiVersion', rsp['apiVersion'])
+    items, resource_version = fetching.list_objs_rv(resource=resource, namespace=namespace)
+    for item in items:
         yield {'type': None, 'object': item}
 
     # Then, watch the resources starting from the list's resource version.

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -1,15 +1,15 @@
 import pytest
 import requests
 
-from kopf.clients.fetching import list_objs
+from kopf.clients.fetching import list_objs_rv
 
 
 def test_when_successful_clustered(req_mock, resource):
-    result = {'items': []}
+    result = {'items': [{}, {}]}
     req_mock.get.return_value.json.return_value = result
 
-    lst = list_objs(resource=resource, namespace=None)
-    assert lst is result
+    items, resource_version = list_objs_rv(resource=resource, namespace=None)
+    assert items == result['items']
 
     assert req_mock.get.called
     assert req_mock.get.call_count == 1
@@ -20,11 +20,11 @@ def test_when_successful_clustered(req_mock, resource):
 
 
 def test_when_successful_namespaced(req_mock, resource):
-    result = {'items': []}
+    result = {'items': [{}, {}]}
     req_mock.get.return_value.json.return_value = result
 
-    lst = list_objs(resource=resource, namespace='ns1')
-    assert lst is result
+    items, resource_version = list_objs_rv(resource=resource, namespace='ns1')
+    assert items == result['items']
 
     assert req_mock.get.called
     assert req_mock.get.call_count == 1
@@ -42,5 +42,5 @@ def test_raises_api_error(req_mock, resource, namespace, status):
     req_mock.get.side_effect = error
 
     with pytest.raises(requests.exceptions.HTTPError) as e:
-        list_objs(resource=resource, namespace=namespace)
+        list_objs_rv(resource=resource, namespace=namespace)
     assert e.value.response.status_code == status


### PR DESCRIPTION
Refactor clients-to-reactor communication to prepare for the overall type-hinting.

> Issue : #194 

## Description

Since the switch to pykube-ng (#71 #110), there was an [_abstraction leak_](https://en.wikipedia.org/wiki/Leaky_abstraction) in the list-fetching client wrapper: the `requests.Response` object was returned, thus exposing the internal implementation of a sibling module.

In this PR, the leak is removed, and the function now exposes only the data needed. It also takes the hacky data recovery (missing `apiVersion` & `kind` in the lists) from the Kopf's reactor into the client wrapper.

Having this in place will also simplify future switch to other HTTP clients, such as asyncio (see #176), as there is no such a specific response object in other implementations.

The function is intentionally renamed: to break things if someone for some reason uses this _private_ function in their code — since its signature is now different (another result type).


## Types of Changes

- Refactor/improvements

**There are no behavioural changes. Only the code refactoring.** The tests show that all the protocols and interfaces are kept in place — except for the imports of the internal modules (not exposed via `kopf/__init__.py`).

