### PR TITLE
Fix the tests for the new pytest-mock package structure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ urllib3<1.25
 
 # Everything needed to develop (test, debug) the framework.
 pytest-asyncio
-pytest-mock
+pytest-mock>=1.11.1
 pytest-cov
 pytest
 asynctest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,8 @@ def pytest_collection_modifyitems(config, items):
 # Substitute the regular mock with the async-aware mock in the `mocker` fixture.
 @pytest.fixture(scope='session', autouse=True)
 def enforce_asyncio_mocker():
-    pytest_mock._get_mock_module = lambda config: asynctest
+    pytest_mock.plugin._get_mock_module = lambda config: asynctest
+    pytest_mock._get_mock_module = pytest_mock.plugin._get_mock_module
 
 
 @pytest.fixture()


### PR DESCRIPTION
Adjust to the changed pytest-mock internal structure.

> Issue : #13 

## Description

In https://github.com/pytest-dev/pytest-mock/pull/160, on 2019-10-04 23:56 CEST, `pytest-mock=1.11.1` has changed its internal package-module structure. 

Kopf used its structure to replace one internal method to properly replace all mocks with async/awaitable mocks for total async transparency of the tests. After the change, Kopf's hack stopped having any effect.

_Yes, it is a bad practice, but this simplifies testing a lot, and there is no public interface for this._

This does not affect the Kopf itself, but only its tests (and therefore, all PRs that are (not) happening after this release).

This PR adjusts for the new structure of pytest-mock.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
