### PR TITLE
Annotate all the code with the types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage.xml
 junit.xml
 *.cover
 .hypothesis/
+.mypy_cache
 
 # Documentation
 docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
   - coveralls
   - codecov --flags unit
   - pytest -v --only-e2e  # NB: after the coverage uploads!
+  - mypy kopf --strict --pretty
 
 deploy:
   provider: pypi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extlinks = {
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
+    'mypy': ('https://mypy.readthedocs.io/en/latest/', None),
 }
 
 

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -10,21 +10,17 @@ Configure logging events
 ========================
 
 `kopf.config.EventsConfig` allows to set what types of kopf logs should be
-reflected in events.
-
-Loglevels are:
-
-* ``kopf.config.LOGLEVEL_INFO``
-* ``kopf.config.LOGLEVEL_WARNING``
-* ``kopf.config.LOGLEVEL_ERROR``
-* ``kopf.config.LOGLEVEL_CRITICAL``
+reflected in events. Use `logging` constants or integer values to set the level:
+e.g., `logging.WARNING`, `logging.ERROR`, etc. The default is `logging.INFO`.
 
 .. code-block:: python
 
+    import logging
     import kopf
 
     # Now kopf will send events only when error or critical occasion happens
-    kopf.EventsConfig.events_loglevel = config.LOGLEVEL_ERROR
+    kopf.EventsConfig.events_loglevel = logging.ERROR
+
 
 Configure Workers
 =================

--- a/kopf/clients/auth.py
+++ b/kopf/clients/auth.py
@@ -19,7 +19,7 @@ class AccessError(Exception):
     """ Raised when the operator cannot access the cluster API. """
 
 
-def login(verify=False):
+def login(verify: bool = False) -> None:
     """
     Login to Kubernetes cluster, locally or remotely.
 
@@ -47,7 +47,7 @@ def login(verify=False):
         login_client(verify=verify)
 
 
-def login_pykube(verify=False):
+def login_pykube(verify: bool = False) -> None:
     global _pykube_cfg
     try:
         _pykube_cfg = pykube.KubeConfig.from_service_account()
@@ -63,7 +63,7 @@ def login_pykube(verify=False):
         verify_pykube()
 
 
-def login_client(verify=False):
+def login_client(verify: bool = False) -> None:
     import kubernetes.client
     try:
         kubernetes.config.load_incluster_config()  # cluster env vars
@@ -79,7 +79,7 @@ def login_client(verify=False):
         verify_client()
 
 
-def verify_pykube():
+def verify_pykube() -> None:
     """
     Verify if login has succeeded, and the access configuration is still valid.
 
@@ -105,7 +105,7 @@ def verify_pykube():
                               "Please login or configure the tokens.")
 
 
-def verify_client():
+def verify_client() -> None:
     """
     Verify if login has succeeded, and the access configuration is still valid.
 
@@ -133,6 +133,8 @@ def get_pykube_cfg() -> pykube.KubeConfig:
 
 
 # TODO: add some caching, but keep kwargs in mind. Maybe add a key= for purpose/use-place?
-def get_pykube_api(timeout=None) -> pykube.HTTPClient:
+def get_pykube_api(
+        timeout: Optional[float] = None,
+) -> pykube.HTTPClient:
     kwargs = dict(timeout=timeout)
     return pykube.HTTPClient(get_pykube_cfg(), **kwargs)

--- a/kopf/clients/classes.py
+++ b/kopf/clients/classes.py
@@ -3,9 +3,13 @@ from typing import Type
 import pykube
 
 from kopf.clients import auth
+from kopf.structs import resources
 
 
-def _make_cls(resource) -> Type[pykube.objects.APIObject]:
+def _make_cls(
+        resource: resources.Resource,
+) -> Type[pykube.objects.APIObject]:
+
     api = auth.get_pykube_api()
     api_resources = api.resource_list(resource.api_version)['resources']
     resource_kind = next((r['kind'] for r in api_resources if r['name'] == resource.plural), None)

--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -15,7 +15,7 @@ MAX_MESSAGE_LENGTH = 1024
 CUT_MESSAGE_INFIX = '...'
 
 
-async def post_event(*, obj=None, ref=None, type, reason, message=''):
+async def post_event(*, ref, type, reason, message=''):
     """
     Issue an event for the object.
 
@@ -23,15 +23,6 @@ async def post_event(*, obj=None, ref=None, type, reason, message=''):
     and where the rate-limits should be maintained. It can (and should)
     be done by the client library, as it is done in the Go client.
     """
-
-    # Object reference - similar to the owner reference, but different.
-    if obj is not None and ref is not None:
-        raise TypeError("Only one of obj= and ref= is allowed for a posted event. Got both.")
-    if obj is None and ref is None:
-        raise TypeError("One of obj= and ref= is required for a posted event. Got none.")
-    if ref is None:
-        ref = bodies.build_object_reference(obj)
-
     now = datetime.datetime.utcnow()
 
     # See #164. For cluster-scoped objects, use the current namespace from the current context.

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -1,13 +1,20 @@
+import enum
+
 import pykube
 import requests
+from typing import TypeVar, Optional, Union, Collection, List, Tuple, cast
 
 from kopf.clients import auth
 from kopf.clients import classes
 
-_UNSET_ = object()
+_T = TypeVar('_T')
 
 
-def read_crd(*, resource, default=_UNSET_):
+class _UNSET(enum.Enum):
+    token = enum.auto()
+
+
+def read_crd(*, resource, default=_UNSET.token):
     try:
         api = auth.get_pykube_api()
         cls = pykube.CustomResourceDefinition
@@ -15,16 +22,16 @@ def read_crd(*, resource, default=_UNSET_):
         return obj.obj
 
     except pykube.ObjectDoesNotExist:
-        if default is not _UNSET_:
+        if not isinstance(default, _UNSET):
             return default
         raise
     except requests.exceptions.HTTPError as e:
-        if e.response.status_code in [403, 404] and default is not _UNSET_:
+        if not isinstance(default, _UNSET) and e.response.status_code in [403, 404]:
             return default
         raise
 
 
-def read_obj(*, resource, namespace=None, name=None, default=_UNSET_):
+def read_obj(*, resource, namespace=None, name=None, default=_UNSET.token):
     try:
         api = auth.get_pykube_api()
         cls = classes._make_cls(resource=resource)
@@ -32,11 +39,11 @@ def read_obj(*, resource, namespace=None, name=None, default=_UNSET_):
         obj = cls.objects(api, namespace=namespace).get_by_name(name=name)
         return obj.obj
     except pykube.ObjectDoesNotExist:
-        if default is not _UNSET_:
+        if not isinstance(default, _UNSET):
             return default
         raise
     except requests.exceptions.HTTPError as e:
-        if e.response.status_code in [403, 404] and default is not _UNSET_:
+        if not isinstance(default, _UNSET) and e.response.status_code in [403, 404]:
             return default
         raise
 

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -6,6 +6,8 @@ from typing import TypeVar, Optional, Union, Collection, List, Tuple, cast
 
 from kopf.clients import auth
 from kopf.clients import classes
+from kopf.structs import bodies
+from kopf.structs import resources
 
 _T = TypeVar('_T')
 
@@ -14,12 +16,16 @@ class _UNSET(enum.Enum):
     token = enum.auto()
 
 
-def read_crd(*, resource, default=_UNSET.token):
+def read_crd(
+        *,
+        resource: resources.Resource,
+        default: Union[_T, _UNSET] = _UNSET.token,
+) -> Union[bodies.Body, _T]:
     try:
         api = auth.get_pykube_api()
         cls = pykube.CustomResourceDefinition
         obj = cls.objects(api, namespace=None).get_by_name(name=resource.name)
-        return obj.obj
+        return cast(bodies.Body, obj.obj)
 
     except pykube.ObjectDoesNotExist:
         if not isinstance(default, _UNSET):
@@ -31,13 +37,19 @@ def read_crd(*, resource, default=_UNSET.token):
         raise
 
 
-def read_obj(*, resource, namespace=None, name=None, default=_UNSET.token):
+def read_obj(
+        *,
+        resource: resources.Resource,
+        namespace: Optional[str] = None,
+        name: Optional[str] = None,
+        default: Union[_T, _UNSET] = _UNSET.token,
+) -> Union[bodies.Body, _T]:
     try:
         api = auth.get_pykube_api()
         cls = classes._make_cls(resource=resource)
         namespace = namespace if issubclass(cls, pykube.objects.NamespacedAPIObject) else None
         obj = cls.objects(api, namespace=namespace).get_by_name(name=name)
-        return obj.obj
+        return cast(bodies.Body, obj.obj)
     except pykube.ObjectDoesNotExist:
         if not isinstance(default, _UNSET):
             return default
@@ -48,7 +60,11 @@ def read_obj(*, resource, namespace=None, name=None, default=_UNSET.token):
         raise
 
 
-def list_objs_rv(*, resource, namespace=None):
+def list_objs_rv(
+        *,
+        resource: resources.Resource,
+        namespace: Optional[str] = None,
+) -> Tuple[Collection[bodies.Body], str]:
     """
     List the objects of specific resource type.
 
@@ -67,7 +83,7 @@ def list_objs_rv(*, resource, namespace=None):
     lst = cls.objects(api, namespace=pykube.all if namespace is None else namespace)
     rsp = lst.response
 
-    items = []
+    items: List[bodies.Body] = []
     resource_version = rsp.get('metadata', {}).get('resourceVersion', None)
     for item in rsp['items']:
         # FIXME: fix in pykube to inject the missing item's fields from the list's metainfo.

--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional, cast
 
 import pykube
 import requests
@@ -6,9 +7,19 @@ import requests
 from kopf import config
 from kopf.clients import auth
 from kopf.clients import classes
+from kopf.structs import bodies
+from kopf.structs import patches
+from kopf.structs import resources
 
 
-async def patch_obj(*, resource, patch, namespace=None, name=None, body=None):
+async def patch_obj(
+        *,
+        resource: resources.Resource,
+        patch: patches.Patch,
+        namespace: Optional[str] = None,
+        name: Optional[str] = None,
+        body: Optional[bodies.Body] = None,
+) -> None:
     """
     Patch a resource of specific kind.
 
@@ -26,9 +37,9 @@ async def patch_obj(*, resource, patch, namespace=None, name=None, body=None):
     namespace = body.get('metadata', {}).get('namespace') if body is not None else namespace
     name = body.get('metadata', {}).get('name') if body is not None else name
     if body is None:
-        nskw = {} if namespace is None else dict(namespace=namespace)
-        body = {'metadata': {'name': name}}
-        body['metadata'].update(nskw)
+        body = cast(bodies.Body, {'metadata': {'name': name}})
+        if namespace is not None:
+            body['metadata']['namespace'] = namespace
 
     api = auth.get_pykube_api()
     cls = classes._make_cls(resource=resource)

--- a/kopf/config.py
+++ b/kopf/config.py
@@ -15,7 +15,11 @@ LOGLEVEL_ERROR = logging.ERROR
 LOGLEVEL_CRITICAL = logging.CRITICAL
 
 
-def configure(debug=None, verbose=None, quiet=None):
+def configure(
+        debug: Optional[bool] = None,
+        verbose: Optional[bool] = None,
+        quiet: Optional[bool] = None,
+) -> None:
     log_level = 'DEBUG' if debug or verbose else 'WARNING' if quiet else 'INFO'
 
     logger = logging.getLogger()
@@ -44,12 +48,12 @@ def configure(debug=None, verbose=None, quiet=None):
         del logger.handlers[1:]  # everything except the default NullHandler
 
     # Prevent the low-level logging unless in the debug verbosity mode. Keep only the operator's messages.
-    logging.getLogger('urllib3').propagate = debug
-    logging.getLogger('asyncio').propagate = debug
-    logging.getLogger('kubernetes').propagate = debug
+    logging.getLogger('urllib3').propagate = bool(debug)
+    logging.getLogger('asyncio').propagate = bool(debug)
+    logging.getLogger('kubernetes').propagate = bool(debug)
 
     loop = asyncio.get_event_loop()
-    loop.set_debug(debug)
+    loop.set_debug(bool(debug))
 
 
 class EventsConfig:
@@ -57,7 +61,7 @@ class EventsConfig:
     Used to configure events sending behaviour.
     """
 
-    events_loglevel = LOGLEVEL_INFO
+    events_loglevel: int = logging.INFO
     """ What events should be logged. """
 
 
@@ -92,7 +96,7 @@ class WorkersConfig:
         return WorkersConfig.threadpool_executor
 
     @staticmethod
-    def set_synchronous_tasks_threadpool_limit(new_limit: int):
+    def set_synchronous_tasks_threadpool_limit(new_limit: int) -> None:
         """
         Call this static method at any time to change synchronous_tasks_threadpool_limit in runtime.
         """
@@ -101,7 +105,7 @@ class WorkersConfig:
 
         WorkersConfig.synchronous_tasks_threadpool_limit = new_limit
         if WorkersConfig.threadpool_executor:
-            WorkersConfig.threadpool_executor._max_workers = new_limit
+            WorkersConfig.threadpool_executor._max_workers = new_limit  # type: ignore
 
 
 class WatchersConfig:
@@ -109,8 +113,8 @@ class WatchersConfig:
     Used to configure the K8s API watchers and streams.
     """
 
-    default_stream_timeout = None
+    default_stream_timeout: Optional[float] = None
     """ The maximum duration of one streaming request. Patched in some tests. """
 
-    watcher_retry_delay = 0.1
+    watcher_retry_delay: float = 0.1
     """ How long should a pause be between watch requests (to prevent flooding). """

--- a/kopf/config.py
+++ b/kopf/config.py
@@ -8,14 +8,11 @@ from kopf.engines import logging as logging_engine
 format = '[%(asctime)s] %(name)-20.20s [%(levelname)-8.8s] %(message)s'
 
 
+# Deprecated: use ``logging.*`` constants instead. Kept here for backward-compatibility.
 LOGLEVEL_INFO = logging.INFO
-""" Event loglevel to log all events. """
 LOGLEVEL_WARNING = logging.WARNING
-""" Event loglevel to log all events except informational. """
 LOGLEVEL_ERROR = logging.ERROR
-""" Event loglevel to log only errors and critical events. """
 LOGLEVEL_CRITICAL = logging.CRITICAL
-""" Event loglevel to log only critical events(basically - no events). """
 
 
 def configure(debug=None, verbose=None, quiet=None):

--- a/kopf/engines/logging.py
+++ b/kopf/engines/logging.py
@@ -97,22 +97,24 @@ class ObjectLogger(logging.LoggerAdapter):
             ),
         ))
 
-    def process(self,
-                msg: str,
-                kwargs: MutableMapping[str, Any],
-                ) -> Tuple[str, MutableMapping[str, Any]]:
+    def process(
+            self,
+            msg: str,
+            kwargs: MutableMapping[str, Any],
+    ) -> Tuple[str, MutableMapping[str, Any]]:
         # Native logging overwrites the message's extra with the adapter's extra.
         # We merge them, so that both message's & adapter's extras are available.
         kwargs["extra"] = dict(self.extra, **kwargs.get('extra', {}))
         return msg, kwargs
 
-    def log(self,
+    def log(
+            self,
             level: int,
             msg: str,
             *args: Any,
             local: bool = False,
             **kwargs: Any,
-            ) -> None:
+    ) -> None:
         if local:
             kwargs['extra'] = dict(kwargs.pop('extra', {}), k8s_skip=True)
         super().log(level, msg, *args, **kwargs)

--- a/kopf/engines/logging.py
+++ b/kopf/engines/logging.py
@@ -10,17 +10,19 @@ the operators' code, and can lead to information loss or mismatch
 """
 import copy
 import logging
+from typing import Tuple, MutableMapping, Any
 
 from kopf import config
 from kopf.engines import posting
+from kopf.structs import bodies
 
 
 class ObjectPrefixingFormatter(logging.Formatter):
     """ An utility to prefix the per-object log messages. """
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         if hasattr(record, 'k8s_ref'):
-            ref = record.k8s_ref
+            ref = getattr(record, 'k8s_ref')
             prefix = f"[{ref.get('namespace', '')}/{ref.get('name', '')}]"
             record = copy.copy(record)  # shallow
             record.msg = f"{prefix} {record.msg}"
@@ -32,22 +34,23 @@ class K8sPoster(logging.Handler):
     A handler to post all log messages as K8s events.
     """
 
-    def createLock(self):
+    def createLock(self) -> None:
         # Save some time on unneeded locks. Events are posted in the background.
         # We only put events to the queue, which is already lock-protected.
         self.lock = None
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         # Only those which have a k8s object referred (see: `ObjectLogger`).
         # Otherwise, we have nothing to post, and nothing to do.
         level_ok = record.levelno >= config.EventsConfig.events_loglevel
         has_ref = hasattr(record, 'k8s_ref')
-        skipped = hasattr(record, 'k8s_skip') and record.k8s_skip
+        skipped = hasattr(record, 'k8s_skip') and getattr(record, 'k8s_skip')
         return level_ok and has_ref and not skipped and super().filter(record)
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
         # Same try-except as in e.g. `logging.StreamHandler`.
         try:
+            ref = getattr(record, 'k8s_ref')
             type = (
                 "Debug" if record.levelno <= logging.DEBUG else
                 "Normal" if record.levelno <= logging.INFO else
@@ -58,7 +61,7 @@ class K8sPoster(logging.Handler):
             reason = 'Logging'
             message = self.format(record)
             posting.enqueue(
-                ref=record.k8s_ref,
+                ref=ref,
                 type=type,
                 reason=reason,
                 message=message)
@@ -82,7 +85,7 @@ class ObjectLogger(logging.LoggerAdapter):
     (e.g. in case of background posting via the queue; see `K8sPoster`).
     """
 
-    def __init__(self, *, body):
+    def __init__(self, *, body: bodies.Body):
         super().__init__(logger, dict(
             k8s_skip=False,
             k8s_ref=dict(
@@ -94,13 +97,22 @@ class ObjectLogger(logging.LoggerAdapter):
             ),
         ))
 
-    def process(self, msg, kwargs):
+    def process(self,
+                msg: str,
+                kwargs: MutableMapping[str, Any],
+                ) -> Tuple[str, MutableMapping[str, Any]]:
         # Native logging overwrites the message's extra with the adapter's extra.
         # We merge them, so that both message's & adapter's extras are available.
         kwargs["extra"] = dict(self.extra, **kwargs.get('extra', {}))
         return msg, kwargs
 
-    def log(self, level, msg, *args, local=False, **kwargs):
+    def log(self,
+            level: int,
+            msg: str,
+            *args: Any,
+            local: bool = False,
+            **kwargs: Any,
+            ) -> None:
         if local:
             kwargs['extra'] = dict(kwargs.pop('extra', {}), k8s_skip=True)
         super().log(level, msg, *args, **kwargs)

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -59,17 +59,18 @@ PEERING_DEFAULT_NAME = 'default'
 # The extra fields are for easier calculation when and if the peer is dead to the moment.
 class Peer:
 
-    def __init__(self,
-                 id: str,
-                 *,
-                 name: str,
-                 priority: int = 0,
-                 lastseen: Optional[str] = None,
-                 lifetime: int = 60,
-                 namespace: Optional[str] = None,
-                 legacy: bool = False,
-                 **_: Any,  # for the forward-compatibility with the new fields
-                 ):
+    def __init__(
+            self,
+            id: str,
+            *,
+            name: str,
+            priority: int = 0,
+            lastseen: Optional[str] = None,
+            lifetime: int = 60,
+            namespace: Optional[str] = None,
+            legacy: bool = False,
+            **_: Any,  # for the forward-compatibility with the new fields
+    ):
         super().__init__()
         self.id = id
         self.name = name
@@ -93,12 +94,13 @@ class Peer:
         return LEGACY_PEERING_RESOURCE if self.legacy else CLUSTER_PEERING_RESOURCE if self.namespace is None else NAMESPACED_PEERING_RESOURCE
 
     @classmethod
-    def detect(cls,
-               standalone: bool,
-               namespace: Optional[str],
-               name: Optional[str],
-               **kwargs: Any,
-               ) -> Optional["Peer"]:
+    def detect(
+            cls,
+            standalone: bool,
+            namespace: Optional[str],
+            name: Optional[str],
+            **kwargs: Any,
+    ) -> Optional["Peer"]:
 
         if standalone:
             return None

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -36,12 +36,14 @@ import logging
 import os
 import random
 import socket
-from typing import Iterable, Mapping, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union, NoReturn
 
 import iso8601
 
 from kopf.clients import fetching
 from kopf.clients import patching
+from kopf.structs import bodies
+from kopf.structs import patches
 from kopf.structs import resources
 
 logger = logging.getLogger(__name__)
@@ -58,14 +60,16 @@ PEERING_DEFAULT_NAME = 'default'
 class Peer:
 
     def __init__(self,
-                 id: str, *,
+                 id: str,
+                 *,
                  name: str,
                  priority: int = 0,
                  lastseen: Optional[str] = None,
                  lifetime: int = 60,
                  namespace: Optional[str] = None,
                  legacy: bool = False,
-                 **kwargs):  # for the forward-compatibility with the new fields
+                 **_: Any,  # for the forward-compatibility with the new fields
+                 ):
         super().__init__()
         self.id = id
         self.name = name
@@ -81,11 +85,11 @@ class Peer:
         self.is_dead = self.deadline <= datetime.datetime.utcnow()
         self.legacy = legacy
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.id}, namespace={self.namespace}, priority={self.priority}, lastseen={self.lastseen}, lifetime={self.lifetime})"
 
     @property
-    def resource(self):
+    def resource(self) -> resources.Resource:
         return LEGACY_PEERING_RESOURCE if self.legacy else CLUSTER_PEERING_RESOURCE if self.namespace is None else NAMESPACED_PEERING_RESOURCE
 
     @classmethod
@@ -93,7 +97,8 @@ class Peer:
                standalone: bool,
                namespace: Optional[str],
                name: Optional[str],
-               **kwargs) -> Optional:
+               **kwargs: Any,
+               ) -> Optional["Peer"]:
 
         if standalone:
             return None
@@ -114,7 +119,7 @@ class Peer:
         logger.warning(f"Default peering object not found, falling back to the standalone mode.")
         return None
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, Any]:
         # Only the non-calculated and non-identifying fields.
         return {
             'namespace': self.namespace,
@@ -123,7 +128,7 @@ class Peer:
             'lifetime': self.lifetime.total_seconds(),
         }
 
-    def touch(self, *, lifetime: Optional[int] = None):
+    def touch(self, *, lifetime: Optional[int] = None) -> None:
         self.lastseen = datetime.datetime.utcnow()
         self.lifetime = (self.lifetime if lifetime is None else
                          lifetime if isinstance(lifetime, datetime.timedelta) else
@@ -131,14 +136,14 @@ class Peer:
         self.deadline = self.lastseen + self.lifetime
         self.is_dead = self.deadline <= datetime.datetime.utcnow()
 
-    async def keepalive(self):
+    async def keepalive(self) -> None:
         """
         Add a peer to the peers, and update its alive status.
         """
         self.touch()
         await apply_peers([self], name=self.name, namespace=self.namespace, legacy=self.legacy)
 
-    async def disappear(self):
+    async def disappear(self) -> None:
         """
         Remove a peer from the peers (gracefully).
         """
@@ -146,13 +151,13 @@ class Peer:
         await apply_peers([self], name=self.name, namespace=self.namespace, legacy=self.legacy)
 
     @staticmethod
-    def _is_peering_exist(name: str, namespace: Optional[str]):
+    def _is_peering_exist(name: str, namespace: Optional[str]) -> bool:
         resource = CLUSTER_PEERING_RESOURCE if namespace is None else NAMESPACED_PEERING_RESOURCE
         obj = fetching.read_obj(resource=resource, namespace=namespace, name=name, default=None)
         return obj is not None
 
     @staticmethod
-    def _is_peering_legacy(name: str, namespace: Optional[str]):
+    def _is_peering_legacy(name: str, namespace: Optional[str]) -> bool:
         """
         Legacy mode for the peering: cluster-scoped KopfPeering (new mode: namespaced).
 
@@ -177,14 +182,15 @@ async def apply_peers(
         name: str,
         namespace: Union[None, str],
         legacy: bool = False,
-):
+) -> None:
     """
     Apply the changes in the peers to the sync-object.
 
     The dead peers are removed, the new or alive peers are stored.
     Note: this does NOT change their `lastseen` field, so do it explicitly with ``touch()``.
     """
-    patch = {'status': {peer.id: None if peer.is_dead else peer.as_dict() for peer in peers}}
+    patch = patches.Patch()
+    patch.update({'status': {peer.id: None if peer.is_dead else peer.as_dict() for peer in peers}})
     resource = (LEGACY_PEERING_RESOURCE if legacy else
                 CLUSTER_PEERING_RESOURCE if namespace is None else
                 NAMESPACED_PEERING_RESOURCE)
@@ -193,12 +199,12 @@ async def apply_peers(
 
 async def peers_handler(
         *,
-        event: Mapping,
+        event: bodies.Event,
         freeze: asyncio.Event,
         ourselves: Peer,
         autoclean: bool = True,
         replenished: asyncio.Event,
-):
+) -> None:
     """
     Handle a single update of the peers by us or by other operators.
 
@@ -214,7 +220,7 @@ async def peers_handler(
     body = event['object']
     name = body.get('metadata', {}).get('name', None)
     namespace = body.get('metadata', {}).get('namespace', None)
-    if namespace != ourselves.namespace or name != ourselves.name:
+    if namespace != ourselves.namespace or name != ourselves.name or name is None:
         return
 
     # Find if we are still the highest priority operator.
@@ -245,7 +251,7 @@ async def peers_handler(
 async def peers_keepalive(
         *,
         ourselves: Peer,
-):
+) -> NoReturn:
     """
     An ever-running coroutine to regularly send our own keep-alive status for the peers.
     """

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -50,10 +50,11 @@ class PermanentError(Exception):
 
 class TemporaryError(Exception):
     """ A potentially recoverable error, should be retried. """
-    def __init__(self,
-                 __msg: Optional[str] = None,
-                 delay: Optional[float] = DEFAULT_RETRY_DELAY,
-                 ):
+    def __init__(
+            self,
+            __msg: Optional[str] = None,
+            delay: Optional[float] = DEFAULT_RETRY_DELAY,
+    ):
         super().__init__(__msg)
         self.delay = delay
 

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -465,8 +465,8 @@ async def _call_handler(
     """
 
     # For the field-handlers, the old/new/diff values must match the field, not the whole object.
-    old = cause.old if handler.field is None else dicts.resolve(cause.old, handler.field, None)
-    new = cause.new if handler.field is None else dicts.resolve(cause.new, handler.field, None)
+    old = cause.old if handler.field is None else dicts.resolve(cause.old, handler.field, None, assume_empty=True)
+    new = cause.new if handler.field is None else dicts.resolve(cause.new, handler.field, None, assume_empty=True)
     diff = cause.diff if handler.field is None else diffs.reduce(cause.diff, handler.field)
     cause = causation.enrich_cause(cause=cause, old=old, new=new, diff=diff)
 

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -11,47 +11,70 @@ execute in the order they are registered, one by one.
 
 import logging
 import random
+from typing import Sequence, Any, Optional
 
+from typing_extensions import Protocol
+
+from kopf.reactor import registries
 from kopf.reactor import state
+from kopf.structs import bodies
 
 logger = logging.getLogger(__name__)
 
+Handlers = Sequence[registries.Handler]
 
-def all_at_once(handlers, **kwargs):
+
+class LifeCycleFn(Protocol):
+    """
+    A callback type for handlers selection based on the event/cause.
+
+    It is basically `Invokable` extended with an additional positional parameter
+    and specific return type. But we cannot express it with `typing`.
+    For the names and types of kwargs, see `Invokable`.
+    """
+    def __call__(self,
+                 handlers: Handlers,
+                 *,
+                 body: bodies.Body,
+                 **kwargs: Any,
+                 ) -> Handlers: ...
+
+
+def all_at_once(handlers: Handlers, **kwargs: Any) -> Handlers:
     """ Execute all handlers at once, in one event reaction cycle, if possible. """
     return handlers
 
 
-def one_by_one(handlers, **kwargs):
+def one_by_one(handlers: Handlers, **kwargs: Any) -> Handlers:
     """ Execute handlers one at a time, in the order they were registered. """
     return handlers[:1]
 
 
-def randomized(handlers, **kwargs):
+def randomized(handlers: Handlers, **kwargs: Any) -> Handlers:
     """ Execute one handler at a time, in the random order. """
     return [random.choice(handlers)] if handlers else []
 
 
-def shuffled(handlers, **kwargs):
+def shuffled(handlers: Handlers, **kwargs: Any) -> Handlers:
     """ Execute all handlers at once, but in the random order. """
     return random.sample(handlers, k=len(handlers)) if handlers else []
 
 
-def asap(handlers, *, body, **kwargs):
+def asap(handlers: Handlers, *, body: bodies.Body, **kwargs: Any) -> Handlers:
     """ Execute one handler at a time, skip on failure, try the next one, retry after the full cycle. """
     retryfn = lambda handler: state.get_retry_count(body=body, handler=handler)
     return sorted(handlers, key=retryfn)[:1]
 
 
-_default_lifecycle = None
+_default_lifecycle: LifeCycleFn = asap
 
 
-def get_default_lifecycle():
-    return _default_lifecycle if _default_lifecycle is not None else asap
+def get_default_lifecycle() -> LifeCycleFn:
+    return _default_lifecycle
 
 
-def set_default_lifecycle(lifecycle):
+def set_default_lifecycle(lifecycle: Optional[LifeCycleFn]) -> None:
     global _default_lifecycle
     if _default_lifecycle is not None:
         logger.warning(f"The default lifecycle is already set to {_default_lifecycle}, overriding it to {lifecycle}.")
-    _default_lifecycle = lifecycle
+    _default_lifecycle = lifecycle if lifecycle is not None else asap

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -32,12 +32,13 @@ class LifeCycleFn(Protocol):
     and specific return type. But we cannot express it with `typing`.
     For the names and types of kwargs, see `Invokable`.
     """
-    def __call__(self,
-                 handlers: Handlers,
-                 *,
-                 body: bodies.Body,
-                 **kwargs: Any,
-                 ) -> Handlers: ...
+    def __call__(
+            self,
+            handlers: Handlers,
+            *,
+            body: bodies.Body,
+            **kwargs: Any,
+    ) -> Handlers: ...
 
 
 def all_at_once(handlers: Handlers, **kwargs: Any) -> Handlers:

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -41,11 +41,12 @@ logger = logging.getLogger(__name__)
 
 
 class WatcherCallback(Protocol):
-    async def __call__(self,
-                 *,
-                 event: bodies.Event,
-                 replenished: asyncio.Event,
-                 ) -> None: ...
+    async def __call__(
+            self,
+            *,
+            event: bodies.Event,
+            replenished: asyncio.Event,
+    ) -> None: ...
 
 
 # An end-of-stream marker sent from the watcher to the workers.

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -13,22 +13,56 @@ of the handlers to be executed on each reaction cycle.
 """
 import abc
 import functools
+import logging
 from types import FunctionType, MethodType
-from typing import MutableMapping, NamedTuple, Text, Optional, Tuple, Callable, Mapping
+from typing import (Any, MutableMapping, Optional, Sequence, Collection, Iterable, Iterator,
+                    NamedTuple, Union, Tuple, List, Set, FrozenSet, Mapping, NewType, cast)
 
+from typing_extensions import Protocol
+
+from kopf.reactor import causation
+from kopf.structs import bodies
+from kopf.structs import dicts
+from kopf.structs import diffs
+from kopf.structs import patches
 from kopf.structs import resources as resources_
+
+# Strings are taken from the users, but then tainted as this type for stricter type-checking:
+# to prevent usage of some other strings (e.g. operator id) as the handlers ids.
+HandlerId = NewType('HandlerId', str)
+
+
+class HandlerFn(Protocol):
+    def __call__(self,
+                 *args: Any,
+                 type: str,
+                 event: Union[str, bodies.Event],  # FIXME: or str for cause-handlers.
+                 body: bodies.Body,
+                 meta: bodies.Meta,
+                 spec: bodies.Spec,
+                 status: bodies.Status,
+                 uid: str,
+                 name: str,
+                 namespace: Optional[str],
+                 patch: patches.Patch,
+                 logger: Union[logging.Logger, logging.LoggerAdapter],
+                 diff: diffs.Diff,  # TODO:? Optional[diffs.Diff]?
+                 old: bodies.Body,  # TODO: or Any for field-handlers.
+                 new: bodies.Body,  # TODO: or Any for field-handlers.
+                 **kwargs: Any,
+                 ) -> Any: ...
 
 
 # A registered handler (function + event meta info).
 class Handler(NamedTuple):
-    fn: Callable
-    id: Text
-    event: Text
+    fn: HandlerFn
+    id: HandlerId
+    event: Optional[str]
     field: Optional[Tuple[str, ...]]
     timeout: Optional[float] = None
     initial: Optional[bool] = None
-    labels: Optional[Mapping] = None
-    annotations: Optional[Mapping] = None
+    labels: Optional[bodies.Labels] = None
+    annotations: Optional[bodies.Annotations] = None
 
 
 class BaseRegistry(metaclass=abc.ABCMeta):
@@ -36,29 +70,39 @@ class BaseRegistry(metaclass=abc.ABCMeta):
     A registry stores the handlers and provides them to the reactor.
     """
 
-    def get_cause_handlers(self, cause):
+    def get_cause_handlers(self,
+                           cause: causation.Cause,
+                           ) -> Sequence[Handler]:
         return list(self._deduplicated(self.iter_cause_handlers(cause=cause)))
 
     @abc.abstractmethod
-    def iter_cause_handlers(self, cause):
+    def iter_cause_handlers(self,
+                            cause: causation.Cause,
+                            ) -> Iterator[Handler]:
         pass
 
-    def get_event_handlers(self, resource, event):
+    def get_event_handlers(self,
+                           resource: resources_.Resource,
+                           event: bodies.Event,
+                           ) -> Sequence[Handler]:
         return list(self._deduplicated(self.iter_event_handlers(resource=resource, event=event)))
 
     @abc.abstractmethod
-    def iter_event_handlers(self, resource, event):
+    def iter_event_handlers(self,
+                            resource: resources_.Resource,
+                            event: bodies.Event,
+                            ) -> Iterator[Handler]:
         pass
 
-    def get_extra_fields(self, resource):
+    def get_extra_fields(self, resource: resources_.Resource) -> Set[dicts.FieldPath]:
         return set(self.iter_extra_fields(resource=resource))
 
     @abc.abstractmethod
-    def iter_extra_fields(self, resource):
+    def iter_extra_fields(self, resource: resources_.Resource) -> Iterator[dicts.FieldPath]:
         pass
 
     @staticmethod
-    def _deduplicated(handlers):
+    def _deduplicated(handlers: Iterable[Handler]) -> Iterator[Handler]:
         """
         Yield the handlers deduplicated.
 
@@ -79,7 +123,7 @@ class BaseRegistry(metaclass=abc.ABCMeta):
         handled) **AND** it is detected as per-existing before operator start.
         But `fn()` should be called only once for this cause.
         """
-        seen_ids = set()
+        seen_ids: Set[int] = set()
         for handler in handlers:
             if id(handler.fn) in seen_ids:
                 pass
@@ -93,20 +137,29 @@ class SimpleRegistry(BaseRegistry):
     A simple registry is just a list of handlers, no grouping.
     """
 
-    def __init__(self, prefix=None):
+    def __init__(self, prefix: Optional[str] = None) -> None:
         super().__init__()
         self.prefix = prefix
-        self._handlers = []  # [Handler, ...]
-        self._handlers_requiring_finalizer = []
+        self._handlers: List[Handler] = []  # [Handler, ...]
+        self._handlers_requiring_finalizer: List[Handler] = []
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self._handlers)
 
-    def append(self, handler):
+    def append(self, handler: Handler) -> None:
         self._handlers.append(handler)
 
-    def register(self, fn, id=None, event=None, field=None, timeout=None, initial=None, requires_finalizer=False,
-                 labels=None, annotations=None):
+    def register(self,
+                 fn: HandlerFn,
+                 id: Optional[str] = None,
+                 event: Optional[str] = None,
+                 field: Optional[dicts.FieldSpec] = None,
+                 timeout: Optional[float] = None,
+                 initial: Optional[bool] = None,
+                 requires_finalizer: bool = False,
+                 labels: Optional[bodies.Labels] = None,
+                 annotations: Optional[bodies.Annotations] = None,
+                 ) -> HandlerFn:
         if field is None:
             field = None  # for the non-field events
         elif isinstance(field, str):
@@ -116,11 +169,12 @@ class SimpleRegistry(BaseRegistry):
         else:
             raise ValueError(f"Field must be either a str, or a list/tuple. Got {field!r}")
 
-        id = id if id is not None else get_callable_id(fn)
-        id = id if field is None else f'{id}/{".".join(field)}'
-        id = id if self.prefix is None else f'{self.prefix}/{id}'
-        handler = Handler(id=id, fn=fn, event=event, field=field, timeout=timeout, initial=initial,
-                          labels=labels, annotations=annotations)
+        real_id: HandlerId
+        real_id = cast(HandlerId, id) if id is not None else cast(HandlerId, get_callable_id(fn))
+        real_id = real_id if field is None else cast(HandlerId, f'{real_id}/{".".join(field)}')
+        real_id = real_id if self.prefix is None else cast(HandlerId, f'{self.prefix}/{real_id}')
+        handler = Handler(id=real_id, fn=fn, event=event, field=field, timeout=timeout,
+                          initial=initial, labels=labels, annotations=annotations)
 
         self.append(handler)
 
@@ -129,8 +183,10 @@ class SimpleRegistry(BaseRegistry):
 
         return fn  # to be usable as a decorator too.
 
-    def iter_cause_handlers(self, cause):
-        changed_fields = {field for _, field, _, _ in cause.diff or []}
+    def iter_cause_handlers(self,
+                            cause: causation.Cause,
+                            ) -> Iterator[Handler]:
+        changed_fields = frozenset(field for _, field, _, _ in cause.diff or [])
         for handler in self._handlers:
             if handler.event is None or handler.event == cause.event:
                 if handler.initial and not cause.initial:
@@ -138,17 +194,25 @@ class SimpleRegistry(BaseRegistry):
                 elif match(handler=handler, body=cause.body, changed_fields=changed_fields):
                     yield handler
 
-    def iter_event_handlers(self, resource, event):
+    def iter_event_handlers(self,
+                            resource: resources_.Resource,
+                            event: bodies.Event,
+                            ) -> Iterator[Handler]:
         for handler in self._handlers:
             if match(handler=handler, body=event['object']):
                 yield handler
 
-    def iter_extra_fields(self, resource):
+    def iter_extra_fields(self,
+                          resource: resources_.Resource,
+                          ) -> Iterator[dicts.FieldPath]:
         for handler in self._handlers:
             if handler.field:
                 yield handler.field
 
-    def requires_finalizer(self, resource, body):
+    def requires_finalizer(self,
+                           resource: resources_.Resource,
+                           body: bodies.Body,
+                           ) -> bool:
         # check whether the body matches a deletion handler
         for handler in self._handlers_requiring_finalizer:
             if match(handler=handler, body=body):
@@ -157,14 +221,14 @@ class SimpleRegistry(BaseRegistry):
         return False
 
 
-def get_callable_id(c):
+def get_callable_id(c: HandlerFn) -> str:
     """ Get an reasonably good id of any commonly used callable. """
     if c is None:
-        return None
+        raise ValueError("Cannot build a persistent id of None.")
     elif isinstance(c, functools.partial):
         return get_callable_id(c.func)
     elif hasattr(c, '__wrapped__'):  # @functools.wraps()
-        return get_callable_id(c.__wrapped__)
+        return get_callable_id(getattr(c, '__wrapped__'))
     elif isinstance(c, FunctionType) and c.__name__ == '<lambda>':
         # The best we can do to keep the id stable across the process restarts,
         # assuming at least no code changes. The code changes are not detectable.
@@ -172,7 +236,7 @@ def get_callable_id(c):
         path = c.__code__.co_filename
         return f'lambda:{path}:{line}'
     elif isinstance(c, (FunctionType, MethodType)):
-        return getattr(c, '__qualname__', getattr(c, '__name__', repr(c)))
+        return str(getattr(c, '__qualname__', getattr(c, '__name__', repr(c))))
     else:
         raise ValueError(f"Cannot get id of {c!r}.")
 
@@ -183,14 +247,25 @@ class GlobalRegistry(BaseRegistry):
     It is usually populated by the `@kopf.on...` decorators.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._cause_handlers: MutableMapping[resources_.Resource, SimpleRegistry] = {}
         self._event_handlers: MutableMapping[resources_.Resource, SimpleRegistry] = {}
 
-    def register_cause_handler(self, group, version, plural, fn,
-                               id=None, event=None, field=None, timeout=None, initial=None, requires_finalizer=False,
-                               labels=None, annotations=None):
+    def register_cause_handler(self,
+                               group: str,
+                               version: str,
+                               plural: str,
+                               fn: HandlerFn,
+                               id: Optional[str] = None,
+                               event: Optional[str] = None,
+                               field: Optional[dicts.FieldSpec] = None,
+                               timeout: Optional[float] = None,
+                               initial: Optional[bool] = None,
+                               requires_finalizer: bool = False,
+                               labels: Optional[bodies.Labels] = None,
+                               annotations: Optional[bodies.Annotations] = None,
+                               ) -> HandlerFn:
         """
         Register an additional handler function for the specific resource and specific event.
         """
@@ -200,8 +275,15 @@ class GlobalRegistry(BaseRegistry):
                           labels=labels, annotations=annotations)
         return fn  # to be usable as a decorator too.
 
-    def register_event_handler(self, group, version, plural, fn, id=None, labels=None,
-                               annotations=None):
+    def register_event_handler(self,
+                               group: str,
+                               version: str,
+                               plural: str,
+                               fn: HandlerFn,
+                               id: Optional[str] = None,
+                               labels: Optional[bodies.Labels] = None,
+                               annotations: Optional[bodies.Annotations] = None,
+                               ) -> HandlerFn:
         """
         Register an additional handler function for low-level events.
         """
@@ -211,19 +293,25 @@ class GlobalRegistry(BaseRegistry):
         return fn  # to be usable as a decorator too.
 
     @property
-    def resources(self):
+    def resources(self) -> FrozenSet[resources_.Resource]:
         """ All known resources in the registry. """
         return frozenset(self._cause_handlers) | frozenset(self._event_handlers)
 
-    def has_cause_handlers(self, resource):
+    def has_cause_handlers(self,
+                           resource: resources_.Resource,
+                           ) -> bool:
         resource_registry = self._cause_handlers.get(resource, None)
         return bool(resource_registry)
 
-    def has_event_handlers(self, resource):
+    def has_event_handlers(self,
+                           resource: resources_.Resource,
+                           ) -> bool:
         resource_registry = self._event_handlers.get(resource, None)
         return bool(resource_registry)
 
-    def iter_cause_handlers(self, cause):
+    def iter_cause_handlers(self,
+                            cause: causation.Cause,
+                            ) -> Iterator[Handler]:
         """
         Iterate all handlers that match this cause/event, in the order they were registered (even if mixed).
         """
@@ -231,7 +319,10 @@ class GlobalRegistry(BaseRegistry):
         if resource_registry is not None:
             yield from resource_registry.iter_cause_handlers(cause=cause)
 
-    def iter_event_handlers(self, resource, event):
+    def iter_event_handlers(self,
+                            resource: resources_.Resource,
+                            event: bodies.Event,
+                            ) -> Iterator[Handler]:
         """
         Iterate all handlers for the low-level events.
         """
@@ -239,12 +330,17 @@ class GlobalRegistry(BaseRegistry):
         if resource_registry is not None:
             yield from resource_registry.iter_event_handlers(resource=resource, event=event)
 
-    def iter_extra_fields(self, resource):
+    def iter_extra_fields(self,
+                          resource: resources_.Resource,
+                          ) -> Iterator[dicts.FieldPath]:
         resource_registry = self._cause_handlers.get(resource, None)
         if resource_registry is not None:
             yield from resource_registry.iter_extra_fields(resource=resource)
 
-    def requires_finalizer(self, resource, body):
+    def requires_finalizer(self,
+                           resource: resources_.Resource,
+                           body: bodies.Body,
+                           ) -> bool:
         """
         Return whether a finalizer should be added to
         the given resource or not.
@@ -255,7 +351,7 @@ class GlobalRegistry(BaseRegistry):
         return resource_registry.requires_finalizer(resource, body)
 
 
-_default_registry = GlobalRegistry()
+_default_registry: GlobalRegistry = GlobalRegistry()
 
 
 def get_default_registry() -> GlobalRegistry:
@@ -266,7 +362,7 @@ def get_default_registry() -> GlobalRegistry:
     return _default_registry
 
 
-def set_default_registry(registry: GlobalRegistry):
+def set_default_registry(registry: GlobalRegistry) -> None:
     """
     Set the default registry to be used by the decorators and the reactor
     unless the explicit registry is provided to them.
@@ -275,36 +371,54 @@ def set_default_registry(registry: GlobalRegistry):
     _default_registry = registry
 
 
-def match(handler, body, changed_fields=None):
-    return (
-        (not handler.field or _matches_field(handler, changed_fields or [])) and
-        (not handler.labels or _matches_labels(handler, body)) and
-        (not handler.annotations or _matches_annotations(handler, body))
-    )
+def match(
+        handler: Handler,
+        body: bodies.Body,
+        changed_fields: Collection[dicts.FieldPath] = frozenset(),
+) -> bool:
+    return all([
+        _matches_field(handler, changed_fields or {}),
+        _matches_labels(handler, body),
+        _matches_annotations(handler, body),
+    ])
 
 
-def _matches_field(handler, changed_fields):
-    return any(field[:len(handler.field)] == handler.field for field in changed_fields)
+def _matches_field(
+        handler: Handler,
+        changed_fields: Collection[dicts.FieldPath] = frozenset(),
+) -> bool:
+    return (not handler.field or
+            any(field[:len(handler.field)] == handler.field for field in changed_fields))
 
 
-def _matches_labels(handler, body):
-    return _matches_metadata(handler=handler, body=body, metadata_type='labels')
+def _matches_labels(
+        handler: Handler,
+        body: bodies.Body,
+) -> bool:
+    return (not handler.labels or
+            _matches_metadata(pattern=handler.labels,
+                              content=body.get('metadata', {}).get('labels', {})))
 
 
-def _matches_annotations(handler, body):
-    return _matches_metadata(handler=handler, body=body, metadata_type='annotations')
+def _matches_annotations(
+        handler: Handler,
+        body: bodies.Body,
+) -> bool:
+    return (not handler.annotations or
+            _matches_metadata(pattern=handler.annotations,
+                              content=body.get('metadata', {}).get('annotations', {})))
 
 
-def _matches_metadata(handler, body, metadata_type):
-    metadata = getattr(handler, metadata_type)
-    object_metadata = body.get('metadata', {}).get(metadata_type, {})
-
-    for key, value in metadata.items():
-        if key not in object_metadata:
+def _matches_metadata(
+        *,
+        pattern: Mapping[str, str],  # from the handler
+        content: Mapping[str, str],  # from the body
+) -> bool:
+    for key, value in pattern.items():
+        if key not in content:
             return False
-        elif value is not None and value != object_metadata[key]:
+        elif value is not None and value != content[key]:
             return False
         else:
             continue
-
     return True

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -37,7 +37,7 @@ class HandlerFn(Protocol):
             self,
             *args: Any,
             type: str,
-            event: Union[str, bodies.Event],  # FIXME: or str for cause-handlers.
+            event: Union[str, bodies.Event],
             body: bodies.Body,
             meta: bodies.Meta,
             spec: bodies.Spec,
@@ -47,9 +47,9 @@ class HandlerFn(Protocol):
             namespace: Optional[str],
             patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
-            diff: diffs.Diff,  # TODO:? Optional[diffs.Diff]?
-            old: bodies.Body,  # TODO: or Any for field-handlers.
-            new: bodies.Body,  # TODO: or Any for field-handlers.
+            diff: diffs.Diff,
+            old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
+            new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             **kwargs: Any,
     ) -> Any: ...
 

--- a/kopf/structs/bodies.py
+++ b/kopf/structs/bodies.py
@@ -1,9 +1,156 @@
 """
 All the structures coming from/to the Kubernetes API.
+
+The usage of these classes is spread over the codebase, so they are extracted
+into a separate module of such type definitions.
+
+For strict type-checking, they are detailed to the per-field level
+(e.g. `TypedDict` instead of just ``Mapping[Any, Any]``) --
+as used by the framework. The operators can use arbitrary fields at runtime,
+which are not declared in the type definitions at type-checking time.
+
+In case the operators are also type-checked, type casting can be used
+(without `cast`, this code fails at type-checking, though works at runtime)::
+
+    from typing import cast
+    import kopf
+
+    class MyMeta(kopf.Meta):
+        unknownField: str
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
+    def create_fn(*args, meta: kopf.Meta, **kwargs):
+        meta = cast(MyMeta, meta)
+        print(meta['unknownField'])
+
+.. note::
+
+    There is a strict separation of objects coming from/to the Kubernetes API
+    and from (but not to) the users:
+
+    The Kubernetes-originated objects are dicts or dict-like custom classes.
+    The framework internally expect them to be such. Arbitrary 3rd-party
+    classes are not supported and are not delivered to the handlers.
+
+    The user-originated objects can be either one of the Kubernetes-originated
+    framework-supported types (dicts/dict-like), or a 3rd-party class,
+    such as from ``pykube-ng``, ``kubernetes`` client, etc -- as long as it is
+    supported by the framework's object-processing functions.
+
+    In the future, extra classes can be added for the user-originated objects
+    and object-processing functions. The internal dicts will remain the same.
 """
 
+from typing import Any, Mapping, Union, List, Optional, cast
 
-def build_object_reference(body):
+from typing_extensions import TypedDict, Literal
+
+#
+# The bodies and body parts, as specially used by the framework.
+# All non-used payload falls into `Any`, and is not type-checked.
+#
+
+Labels = Mapping[str, str]
+Annotations = Mapping[str, str]
+Spec = Mapping[str, Any]
+Status = Mapping[str, Any]
+
+
+class Meta(TypedDict, total=False):
+    uid: str
+    name: str
+    namespace: str
+    labels: Labels
+    annotations: Annotations
+    finalizers: List[str]
+    resourceVersion: str
+    deletionTimestamp: str
+    creationTimestamp: str
+    selfLink: str
+
+
+class Body(TypedDict, total=False):
+    apiVersion: str
+    kind: str
+    metadata: Meta
+    spec: Spec
+    status: Status
+
+
+#
+# Body/Meta essences only contain the fields relevant for object diff tracking.
+# They are presented to the user as part of the diff's `old`/`new` fields & kwargs.
+# Added for stricter type checking, to differentiate from the actual Body/Meta.
+#
+
+
+class MetaEssence(TypedDict, total=False):
+    labels: Labels
+    annotations: Annotations
+
+
+class BodyEssence(TypedDict, total=False):
+    metadata: MetaEssence
+    spec: Spec
+
+
+#
+# Watch-events, as received from the watch-streams
+# and passed through the framework to the handlers.
+#
+
+# ``None`` is used for the listing, when the pseudo-watch-stream is simulated.
+RawEventType = Literal[None, 'ADDED', 'MODIFIED', 'DELETED', 'ERROR']
+EventType = Literal[None, 'ADDED', 'MODIFIED', 'DELETED']
+
+
+# A special payload for type==ERROR (this is not a connection or client error).
+class Error(TypedDict, total=False):
+    apiVersion: str     # usually: Literal['v1']
+    kind: str           # usually: Literal['Status']
+    metadata: Mapping[Any, Any]
+    code: int
+    reason: str
+    status: str
+    message: str
+
+
+# As received from the stream before processing the errors and special cases.
+class RawEvent(TypedDict):
+    type: RawEventType
+    object: Union[Body, Error]
+
+
+# As passed to the framework after processing the errors and special cases.
+class Event(TypedDict):
+    type: EventType
+    object: Body
+
+
+#
+# Other API types, which are not body parts.
+#
+
+class ObjectReference(TypedDict, total=False):
+    apiVersion: str
+    kind: str
+    namespace: Optional[str]
+    name: str
+    uid: str
+
+
+class OwnerReference(TypedDict, total=False):
+    controller: bool
+    blockOwnerDeletion: bool
+    apiVersion: str
+    kind: str
+    name: str
+    uid: str
+
+
+def build_object_reference(
+        body: Body,
+) -> ObjectReference:
     """
     Construct an object reference for the events.
 
@@ -17,10 +164,12 @@ def build_object_reference(body):
         uid=body.get('metadata', {}).get('uid'),
         namespace=body.get('metadata', {}).get('namespace'),
     )
-    return {key: val for key, val in ref.items() if val}
+    return cast(ObjectReference, {key: val for key, val in ref.items() if val})
 
 
-def build_owner_reference(body):
+def build_owner_reference(
+        body: Body,
+) -> OwnerReference:
     """
     Construct an owner reference object for the parent-children relationships.
 
@@ -38,4 +187,4 @@ def build_owner_reference(body):
         name=body.get('metadata', {}).get('name'),
         uid=body.get('metadata', {}).get('uid'),
     )
-    return {key: val for key, val in ref.items() if val}
+    return cast(OwnerReference, {key: val for key, val in ref.items() if val})

--- a/kopf/structs/finalizers.py
+++ b/kopf/structs/finalizers.py
@@ -5,6 +5,8 @@ Finalizers are used to block the actual deletion until the finalizers
 are removed, meaning that the operator has done all its duties
 to "release" the object (e.g. cleanups; delete-handlers in our case).
 """
+from kopf.structs import bodies
+from kopf.structs import patches
 
 # A string marker to be put on the list of the finalizers to block
 # the object from being deleted without the permission of the framework.
@@ -12,23 +14,35 @@ FINALIZER = 'kopf.zalando.org/KopfFinalizerMarker'
 LEGACY_FINALIZER = 'KopfFinalizerMarker'
 
 
-def is_deleted(body):
+def is_deleted(
+        body: bodies.Body,
+) -> bool:
     return body.get('metadata', {}).get('deletionTimestamp', None) is not None
 
 
-def has_finalizers(body):
+def has_finalizers(
+        body: bodies.Body,
+) -> bool:
     finalizers = body.get('metadata', {}).get('finalizers', [])
     return FINALIZER in finalizers or LEGACY_FINALIZER in finalizers
 
 
-def append_finalizers(*, body, patch):
+def append_finalizers(
+        *,
+        body: bodies.Body,
+        patch: patches.Patch,
+) -> None:
     if not has_finalizers(body=body):
         finalizers = body.get('metadata', {}).get('finalizers', [])
         patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))
         patch['metadata']['finalizers'].append(FINALIZER)
 
 
-def remove_finalizers(*, body, patch):
+def remove_finalizers(
+        *,
+        body: bodies.Body,
+        patch: patches.Patch,
+) -> None:
     if has_finalizers(body=body):
         finalizers = body.get('metadata', {}).get('finalizers', [])
         patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))

--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -15,15 +15,21 @@ https://kubernetes.io/docs/concepts/overview/object-management-kubectl/declarati
 
 import copy
 import json
+from typing import Optional, Iterable, Tuple, Dict, Any, cast
 
+from kopf.structs import bodies
 from kopf.structs import dicts
 from kopf.structs import diffs
+from kopf.structs import patches
 
 LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 """ The annotation name for the last stored state of the resource. """
 
 
-def get_state(body, extra_fields=None):
+def get_state(
+        body: bodies.Body,
+        extra_fields: Optional[Iterable[dicts.FieldSpec]] = None,
+) -> bodies.BodyEssence:
     """
     Extract only the relevant fields for the state comparisons.
 
@@ -38,29 +44,29 @@ def get_state(body, extra_fields=None):
     """
 
     # Always use a copy, so that future changes do not affect the extracted state.
-    orig = copy.deepcopy(body)
-    body = copy.deepcopy(body)
+    # TODO: is it possible to declare state as a Body, to ensure the proper keys are used?
+    essence = cast(Dict[Any, Any], copy.deepcopy(body))
 
     # The top-level identifying fields never change, so there is not need to track them.
-    if 'apiVersion' in body:
-        del body['apiVersion']
-    if 'kind' in body:
-        del body['kind']
+    if 'apiVersion' in essence:
+        del essence['apiVersion']
+    if 'kind' in essence:
+        del essence['kind']
 
     # Purge the whole stenzas with system info (extra-fields are restored below).
-    if 'metadata' in body:
-        del body['metadata']
-    if 'status' in body:
-        del body['status']
+    if 'metadata' in essence:
+        del essence['metadata']
+    if 'status' in essence:
+        del essence['status']
 
     # We want some selected metadata to be tracked implicitly.
-    dicts.cherrypick(src=orig, dst=body, fields=[
+    dicts.cherrypick(src=body, dst=essence, fields=[
         'metadata.labels',
         'metadata.annotations',  # but not all of them! deleted below.
     ])
 
     # But we do not want not all of the annotations, only potentially useful.
-    annotations = body.get('metadata', {}).get('annotations', {})
+    annotations = essence.get('metadata', {}).get('annotations', {})
     for annotation in list(annotations):
         if annotation == LAST_SEEN_ANNOTATION:
             del annotations[annotation]
@@ -68,35 +74,50 @@ def get_state(body, extra_fields=None):
             del annotations[annotation]
 
     # Restore all explicitly whitelisted extra-fields from the original body.
-    dicts.cherrypick(src=orig, dst=body, fields=extra_fields)
+    dicts.cherrypick(src=body, dst=essence, fields=extra_fields)
 
     # Cleanup the parent structs if they have become empty, for consistent state comparison.
-    if 'annotations' in body.get('metadata', {}) and not body['metadata']['annotations']:
-        del body['metadata']['annotations']
-    if 'metadata' in body and not body['metadata']:
-        del body['metadata']
-    if 'status' in body and not body['status']:
-        del body['status']
-    return body
+    if 'annotations' in essence.get('metadata', {}) and not essence['metadata']['annotations']:
+        del essence['metadata']['annotations']
+    if 'metadata' in essence and not essence['metadata']:
+        del essence['metadata']
+    if 'status' in essence and not essence['status']:
+        del essence['status']
+
+    return cast(bodies.BodyEssence, essence)
 
 
-def has_state(body):
+def has_essence_stored(
+        body: bodies.Body,
+) -> bool:
     annotations = body.get('metadata', {}).get('annotations', {})
     return LAST_SEEN_ANNOTATION in annotations
 
 
-def get_state_diffs(body, extra_fields=None):
-    old = retreive_state(body)
-    new = get_state(body, extra_fields=extra_fields)
+def get_essential_diffs(
+        body: bodies.Body,
+        extra_fields: Optional[Iterable[dicts.FieldSpec]] = None,
+) -> Tuple[Optional[bodies.BodyEssence], Optional[bodies.BodyEssence], diffs.Diff]:
+    old: Optional[bodies.BodyEssence] = retreive_essence(body)
+    new: Optional[bodies.BodyEssence] = get_state(body, extra_fields=extra_fields)
     return old, new, diffs.diff(old, new)
 
 
-def retreive_state(body):
-    state_str = body.get('metadata', {}).get('annotations', {}).get(LAST_SEEN_ANNOTATION, None)
-    state_obj = json.loads(state_str) if state_str is not None else None
+def retreive_essence(
+        body: bodies.Body,
+) -> Optional[bodies.BodyEssence]:
+    if not has_essence_stored(body):
+        return None
+    state_str: str = body['metadata']['annotations'][LAST_SEEN_ANNOTATION]
+    state_obj: bodies.BodyEssence = json.loads(state_str)
     return state_obj
 
 
-def refresh_state(*, body, patch, extra_fields=None):
+def refresh_essence(
+        *,
+        body: bodies.Body,
+        patch: patches.Patch,
+        extra_fields: Optional[Iterable[dicts.FieldSpec]] = None,
+) -> None:
     state = get_state(body, extra_fields=extra_fields)
     patch.setdefault('metadata', {}).setdefault('annotations', {})[LAST_SEEN_ANNOTATION] = json.dumps(state)

--- a/kopf/structs/patches.py
+++ b/kopf/structs/patches.py
@@ -1,0 +1,16 @@
+"""
+All the structures needed for Kubernetes patching.
+
+Currently, it is implemented via a JSON merge-patch (RFC 7386),
+i.e. a simple dictionary with field overrides, and ``None`` for field deletions.
+
+In the future, it can be extended to a standalone object, which exposes
+a dict-like behaviour, and remembers the changes in order of their execution,
+and then generates the JSON patch (RFC 6902).
+"""
+from typing import Any, Dict
+
+
+# Event-handling structures, used internally in the framework and handlers only.
+class Patch(Dict[Any, Any]):
+    pass

--- a/kopf/structs/resources.py
+++ b/kopf/structs/resources.py
@@ -8,10 +8,10 @@ class Resource(NamedTuple):
     plural: str
 
     @property
-    def name(self):
+    def name(self) -> str:
         return f'{self.plural}.{self.group}'
 
     @property
-    def api_version(self):
+    def api_version(self) -> str:
         # Strip heading/trailing slashes if group is absent (e.g. for pods).
         return f'{self.group}/{self.version}'.strip('/')

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -1,45 +1,62 @@
 """
 All the functions to properly build the object hierarchies.
 """
+from typing import Optional, Iterable, Iterator, cast, MutableMapping, Any, Union
+
 from kopf.structs import bodies
 from kopf.structs import dicts
 
+K8sObject = MutableMapping[Any, Any]
+K8sObjects = Union[K8sObject, Iterable[K8sObject]]
 
-def append_owner_reference(objs, owner):
+
+def append_owner_reference(
+        objs: K8sObjects,
+        owner: bodies.Body,
+) -> None:
     """
     Append an owner reference to the resource(s), if it is not yet there.
 
     Note: the owned objects are usually not the one being processed,
     so the whole body can be modified, no patches are needed.
     """
-    owner = bodies.build_owner_reference(owner)
-    for obj in dicts.walk(objs):
+    owner_ref = bodies.build_owner_reference(owner)
+    for obj in cast(Iterator[K8sObject], dicts.walk(objs)):
         refs = obj.setdefault('metadata', {}).setdefault('ownerReferences', [])
-        matching = [ref for ref in refs if ref.get('uid') == owner.get('uid')]
+        matching = [ref for ref in refs if ref.get('uid') == owner_ref['uid']]
         if not matching:
-            refs.append(owner)
+            refs.append(owner_ref)
 
 
-def remove_owner_reference(objs, owner):
+def remove_owner_reference(
+        objs: K8sObjects,
+        owner: bodies.Body,
+) -> None:
     """
     Remove an owner reference to the resource(s), if it is there.
 
     Note: the owned objects are usually not the one being processed,
     so the whole body can be modified, no patches are needed.
     """
-    owner = bodies.build_owner_reference(owner)
-    for obj in dicts.walk(objs):
+    owner_ref = bodies.build_owner_reference(owner)
+    for obj in cast(Iterator[K8sObject], dicts.walk(objs)):
         refs = obj.setdefault('metadata', {}).setdefault('ownerReferences', [])
-        matching = [ref for ref in refs if ref.get('uid') == owner.get('uid')]
+        matching = [ref for ref in refs if ref.get('uid') == owner_ref['uid']]
         for ref in matching:
             refs.remove(ref)
 
 
-def label(objs, labels, *, force=False, nested=None):
+def label(
+        objs: K8sObjects,
+        labels: bodies.Labels,
+        *,
+        force: bool = False,
+        nested: Optional[Iterable[dicts.FieldSpec]] = None,
+) -> None:
     """
     Apply the labels to the object(s).
     """
-    for obj in dicts.walk(objs, nested=nested):
+    for obj in cast(Iterator[K8sObject], dicts.walk(objs, nested=nested)):
         obj_labels = obj.setdefault('metadata', {}).setdefault('labels', {})
         for key, val in labels.items():
             if force:
@@ -48,7 +65,11 @@ def label(objs, labels, *, force=False, nested=None):
                 obj_labels.setdefault(key, val)
 
 
-def harmonize_naming(objs, name=None, strict=False):
+def harmonize_naming(
+        objs: K8sObjects,
+        name: Optional[str] = None,
+        strict: bool = False,
+) -> None:
     """
     Adjust the names or prefixes of the objects.
 
@@ -63,7 +84,7 @@ def harmonize_naming(objs, name=None, strict=False):
     If the objects already have their own names, auto-naming is not applied,
     and the existing names are used as is.
     """
-    for obj in dicts.walk(objs):
+    for obj in cast(Iterator[K8sObject], dicts.walk(objs)):
         if obj.get('metadata', {}).get('name', None) is None:
             if strict:
                 obj.setdefault('metadata', {}).setdefault('name', name)
@@ -71,7 +92,10 @@ def harmonize_naming(objs, name=None, strict=False):
                 obj.setdefault('metadata', {}).setdefault('generateName', f'{name}-')
 
 
-def adjust_namespace(objs, namespace=None):
+def adjust_namespace(
+        objs: K8sObjects,
+        namespace: Optional[str] = None,
+) -> None:
     """
     Adjust the namespace of the objects.
 
@@ -80,11 +104,16 @@ def adjust_namespace(objs, namespace=None):
     It is a common practice to keep the children objects in the same
     namespace as their owner, unless explicitly overridden at time of creation.
     """
-    for obj in dicts.walk(objs):
+    for obj in cast(Iterator[K8sObject], dicts.walk(objs)):
         obj.setdefault('metadata', {}).setdefault('namespace', namespace)
 
 
-def adopt(objs, owner, *, nested=None):
+def adopt(
+        objs: K8sObjects,
+        owner: bodies.Body,
+        *,
+        nested: Optional[Iterable[dicts.FieldSpec]] = None,
+) -> None:
     """
     The children should be in the same namespace, named after their parent, and owned by it.
     """

--- a/kopf/toolkits/runner.py
+++ b/kopf/toolkits/runner.py
@@ -54,11 +54,13 @@ class KopfRunner(_AbstractKopfRunner):
     """
     _future: ResultFuture
 
-    def __init__(self,
-                 *args: Any,
-                 reraise: bool = True,
-                 timeout: Optional[float] = None,
-                 **kwargs: Any):
+    def __init__(
+            self,
+            *args: Any,
+            reraise: bool = True,
+            timeout: Optional[float] = None,
+            **kwargs: Any,
+    ):
         super().__init__()
         self.args = args
         self.kwargs = kwargs
@@ -74,11 +76,12 @@ class KopfRunner(_AbstractKopfRunner):
         self._ready.wait()  # should be nanosecond-fast
         return self
 
-    def __exit__(self,
-                 exc_type: Optional[Type[BaseException]],
-                 exc_val: Optional[BaseException],
-                 exc_tb: Optional[types.TracebackType],
-                 ) -> Optional[bool]:
+    def __exit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc_val: Optional[BaseException],
+            exc_tb: Optional[types.TracebackType],
+    ) -> Optional[bool]:
 
         # A coroutine that is injected into the loop to cancel everything in it.
         # Cancellations are caught in `run`, so that it exits gracefully.

--- a/kopf/toolkits/runner.py
+++ b/kopf/toolkits/runner.py
@@ -1,13 +1,28 @@
 import asyncio
 import concurrent.futures
+import contextlib
 import threading
+import types
+from typing import cast, Any, Optional, Tuple, Type, TYPE_CHECKING
 
 import click.testing
 
 from kopf import cli
 
+_ExcType = BaseException
+_ExcInfo = Tuple[Type[_ExcType], _ExcType, types.TracebackType]
 
-class KopfRunner:
+if TYPE_CHECKING:
+    ResultFuture = concurrent.futures.Future[click.testing.Result]
+    class _AbstractKopfRunner(contextlib.AbstractContextManager["_AbstractKopfRunner"]):
+        pass
+else:
+    ResultFuture = concurrent.futures.Future
+    class _AbstractKopfRunner(contextlib.AbstractContextManager):
+        pass
+
+
+class KopfRunner(_AbstractKopfRunner):
     """
     A context manager to run a Kopf-based operator in parallel with the tests.
 
@@ -37,8 +52,13 @@ class KopfRunner:
     Second, mocking works within one process (all threads),
     but not across processes --- the mock's calls (counts, arrgs) are lost.
     """
+    _future: ResultFuture
 
-    def __init__(self, *args, reraise=True, timeout=None, **kwargs):
+    def __init__(self,
+                 *args: Any,
+                 reraise: bool = True,
+                 timeout: Optional[float] = None,
+                 **kwargs: Any):
         super().__init__()
         self.args = args
         self.kwargs = kwargs
@@ -49,17 +69,21 @@ class KopfRunner:
         self._thread = threading.Thread(target=self._target)
         self._future = concurrent.futures.Future()
 
-    def __enter__(self):
+    def __enter__(self) -> "KopfRunner":
         self._thread.start()
         self._ready.wait()  # should be nanosecond-fast
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[types.TracebackType],
+                 ) -> Optional[bool]:
 
         # A coroutine that is injected into the loop to cancel everything in it.
         # Cancellations are caught in `run`, so that it exits gracefully.
         # TODO: also cancel/stop the streaming API calls in the thread executor.
-        async def shutdown():
+        async def shutdown() -> None:
             current_task = asyncio.current_task()
             tasks = [task for task in asyncio.all_tasks() if task is not current_task]
             for task in tasks:
@@ -79,16 +103,18 @@ class KopfRunner:
         # Re-raise the exceptions of the threading & invocation logic.
         if self._future.exception() is not None:
             if exc_val is None:
-                raise self._future.exception()
+                raise self._future.exception()  # type: ignore
             else:
-                raise self._future.exception() from exc_val
+                raise self._future.exception() from exc_val  # type: ignore
         if self._future.result().exception is not None and self.reraise:
             if exc_val is None:
                 raise self._future.result().exception
             else:
                 raise self._future.result().exception from exc_val
 
-    def _target(self):
+        return False
+
+    def _target(self) -> None:
 
         # Every thread must have its own loop. The parent thread (pytest)
         # needs to know when the loop is set up, to be able to shut it down.
@@ -106,37 +132,37 @@ class KopfRunner:
             self._future.set_result(result)
 
     @property
-    def future(self):
+    def future(self) -> ResultFuture:
         return self._future
 
     @property
-    def output(self):
+    def output(self) -> str:
         return self.future.result().output
 
     @property
-    def stdout(self):
+    def stdout(self) -> str:
         return self.future.result().stdout
 
     @property
-    def stdout_bytes(self):
+    def stdout_bytes(self) -> bytes:
         return self.future.result().stdout_bytes
 
     @property
-    def stderr(self):
+    def stderr(self) -> str:
         return self.future.result().stderr
 
     @property
-    def stderr_bytes(self):
+    def stderr_bytes(self) -> bytes:
         return self.future.result().stderr_bytes
 
     @property
-    def exit_code(self):
+    def exit_code(self) -> int:
         return self.future.result().exit_code
 
     @property
-    def exception(self):
-        return self.future.result().exception
+    def exception(self) -> _ExcType:
+        return cast(_ExcType, self.future.result().exception)
 
     @property
-    def exc_info(self):
-        return self.future.result().exc_info
+    def exc_info(self) -> _ExcInfo:
+        return cast(_ExcInfo, self.future.result().exc_info)

--- a/kopf/utilities/loaders.py
+++ b/kopf/utilities/loaders.py
@@ -18,9 +18,13 @@ import importlib
 import importlib.util
 import os.path
 import sys
+from typing import Iterable
 
 
-def preload(paths, modules):
+def preload(
+        paths: Iterable[str],
+        modules: Iterable[str],
+) -> None:
     """
     Ensure the handlers are registered by loading/importing the files/modules.
     """
@@ -30,7 +34,7 @@ def preload(paths, modules):
         name, _ = os.path.splitext(os.path.basename(path))
         spec = importlib.util.spec_from_file_location(name, path)
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        spec.loader.exec_module(module)  # type: ignore
 
     for name in modules:
         importlib.import_module(name)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+warn_unused_configs = True
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ asynctest
 freezegun
 codecov
 coveralls
+mypy

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'setuptools_scm',
     ],
     install_requires=[
+        'typing_extensions',
         'click',
         'iso8601',
         'aiojobs',

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -61,6 +61,7 @@ def test_required_args(mocker):
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
-    assert cause.diff is None
+    assert cause.diff is not None
+    assert not cause.diff
     assert cause.old is None
     assert cause.new is None

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -5,6 +5,7 @@ import pytest
 
 from kopf.reactor.causation import CREATE, UPDATE, DELETE, NOOP, FREE, GONE, ACQUIRE, RELEASE
 from kopf.reactor.causation import detect_cause
+from kopf.structs.diffs import Diff
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 

--- a/tests/hierarchies/test_owner_referencing.py
+++ b/tests/hierarchies/test_owner_referencing.py
@@ -3,23 +3,24 @@ import copy
 from unittest.mock import call, Mock
 
 import kopf
+from kopf.structs.bodies import Body, Meta, Labels
 
 OWNER_API_VERSION = 'owner-api-version'
 OWNER_NAMESPACE = 'owner-namespace'
 OWNER_KIND = 'OwnerKind'
 OWNER_NAME = 'owner-name'
 OWNER_UID = 'owner-uid'
-OWNER_LABELS = {'label-1': 'value-1', 'label-2': 'value-2'}
-OWNER = {
-    'apiVersion': OWNER_API_VERSION,
-    'kind': OWNER_KIND,
-    'metadata': {
-        'namespace': OWNER_NAMESPACE,
-        'name': OWNER_NAME,
-        'uid': OWNER_UID,
-        'labels': OWNER_LABELS,
-    },
-}
+OWNER_LABELS: Labels = {'label-1': 'value-1', 'label-2': 'value-2'}
+OWNER = Body(
+    apiVersion=OWNER_API_VERSION,
+    kind=OWNER_KIND,
+    metadata=Meta(
+        namespace=OWNER_NAMESPACE,
+        name=OWNER_NAME,
+        uid=OWNER_UID,
+        labels=OWNER_LABELS,
+    ),
+)
 
 
 def test_appending_to_dict():

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -117,7 +117,7 @@ syncasyncparams = pytest.mark.parametrize(
 
 async def test_detection_for_none():
     is_async = is_async_fn(None)
-    assert is_async is None
+    assert not is_async
 
 
 @syncasyncparams

--- a/tests/lifecycles/test_global_defaults.py
+++ b/tests/lifecycles/test_global_defaults.py
@@ -7,14 +7,14 @@ def test_getting_default_lifecycle():
 
 
 def test_setting_default_lifecycle():
-    lifecycle_expected = lambda *args, **kwargs: None
+    lifecycle_expected = lambda handlers, *args, **kwargs: handlers
     kopf.set_default_lifecycle(lifecycle_expected)
     lifecycle_actual = kopf.get_default_lifecycle()
     assert lifecycle_actual is lifecycle_expected
 
 
 def test_resetting_default_lifecycle():
-    lifecycle_distracting = lambda *args, **kwargs: None
+    lifecycle_distracting = lambda handlers, *args, **kwargs: handlers
     kopf.set_default_lifecycle(lifecycle_distracting)
     kopf.set_default_lifecycle(None)
     lifecycle_actual = kopf.get_default_lifecycle()

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -85,7 +85,7 @@ async def test_watchevent_demultiplexing(worker_mock, timer, resource, handler,
             queue_events.append(streams[key].watchevents.get_nowait())
 
         assert len(queue_events) == cnt + 1
-        assert queue_events[-1] is EOS
+        assert queue_events[-1] is EOS.token
         assert all(queue_event['object']['metadata']['uid'] == uid
                    for queue_event in queue_events[:-1])
 

--- a/tests/test_lastseen.py
+++ b/tests/test_lastseen.py
@@ -3,9 +3,9 @@ import json
 import pytest
 
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
-from kopf.structs.lastseen import has_state, get_state
-from kopf.structs.lastseen import get_state_diffs
-from kopf.structs.lastseen import retreive_state, refresh_state
+from kopf.structs.lastseen import has_essence_stored, get_state
+from kopf.structs.lastseen import get_essential_diffs
+from kopf.structs.lastseen import retreive_essence, refresh_essence
 
 
 def test_annotation_is_fqdn():
@@ -19,7 +19,7 @@ def test_annotation_is_fqdn():
     pytest.param(True, {'metadata': {'annotations': {LAST_SEEN_ANNOTATION: ''}}}, id='present'),
 ])
 def test_has_state(expected, body):
-    result = has_state(body=body)
+    result = has_essence_stored(body=body)
     assert result == expected
 
 
@@ -111,7 +111,7 @@ def test_refresh_state():
     body = {'spec': {'depth': {'field': 'x'}}}
     patch = {}
     encoded = json.dumps(body)  # json formatting can vary across interpreters
-    refresh_state(body=body, patch=patch)
+    refresh_essence(body=body, patch=patch)
     assert patch['metadata']['annotations'][LAST_SEEN_ANNOTATION] == encoded
 
 
@@ -119,13 +119,13 @@ def test_retreive_state_when_present():
     data = {'spec': {'depth': {'field': 'x'}}}
     encoded = json.dumps(data)  # json formatting can vary across interpreters
     body = {'metadata': {'annotations': {LAST_SEEN_ANNOTATION: encoded}}}
-    state = retreive_state(body=body)
+    state = retreive_essence(body=body)
     assert state == data
 
 
 def test_retreive_state_when_absent():
     body = {}
-    state = retreive_state(body=body)
+    state = retreive_essence(body=body)
     assert state is None
 
 
@@ -133,7 +133,7 @@ def test_state_changed_detected():
     data = {'spec': {'depth': {'field': 'x'}}}
     encoded = json.dumps(data)  # json formatting can vary across interpreters
     body = {'metadata': {'annotations': {LAST_SEEN_ANNOTATION: encoded}}}
-    old, new, diff = get_state_diffs(body=body)
+    old, new, diff = get_essential_diffs(body=body)
     assert diff
 
 
@@ -142,7 +142,7 @@ def test_state_change_ignored_with_garbage_annotations():
     encoded = json.dumps(data)  # json formatting can vary across interpreters
     body = {'metadata': {'annotations': {LAST_SEEN_ANNOTATION: encoded}},
             'spec': {'depth': {'field': 'x'}}}
-    old, new, diff = get_state_diffs(body=body)
+    old, new, diff = get_essential_diffs(body=body)
     assert not diff
 
 
@@ -162,7 +162,7 @@ def test_state_changed_ignored_with_system_fields():
                        'other': 'x'
                        },
             'spec': {'depth': {'field': 'x'}}}
-    old, new, diff = get_state_diffs(body=body)
+    old, new, diff = get_essential_diffs(body=body)
     assert not diff
 
 
@@ -174,7 +174,7 @@ def test_state_diff():
     body = {'metadata': {'annotations': {LAST_SEEN_ANNOTATION: encoded}},
             'status': {'x': 'y'},
             'spec': {'depth': {'field': 'y'}}}
-    old, new, diff = get_state_diffs(body=body, extra_fields=['status.x'])
+    old, new, diff = get_essential_diffs(body=body, extra_fields=['status.x'])
     assert old == {'spec': {'depth': {'field': 'x'}}}
     assert new == {'spec': {'depth': {'field': 'y'}}, 'status': {'x': 'y'}}
     assert len(diff) == 2  # spec.depth.field & status.x, but the order is not known.


### PR DESCRIPTION
Add type-hints all over the code. Enable strict type-checker.

> Issue : #194 
> ~**Requires #199 first** — due to unrelated external changes.~

## Description

After few preparational refactorings in #195, #196, #197, #198, the code is now ready to get all the type-hints for all the methods.

Generally, there are no behavioural changes. However, in some places, the code is changed to allow the type-checker to properly infer (guess) the type of variables.

The **strict-mode** type-checker is now a mandatory step of CI/CD. All the new code (functions, methods, classes) since now MUST be type-annotated.

## Types of Changes

- Refactor/improvements
