### PR TITLE
Resolve a terminology conflict: cause.event → cause.reason

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -36,7 +36,7 @@ def resume(
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
         actual_registry.register_cause_handler(
             group=group, version=version, plural=plural,
-            event=None, initial=True, id=id, timeout=timeout,
+            reason=None, initial=True, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
         return fn
     return decorator
@@ -56,7 +56,7 @@ def create(
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
         actual_registry.register_cause_handler(
             group=group, version=version, plural=plural,
-            event=causation.CREATE, id=id, timeout=timeout,
+            reason=causation.Reason.CREATE, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
         return fn
     return decorator
@@ -76,7 +76,7 @@ def update(
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
         actual_registry.register_cause_handler(
             group=group, version=version, plural=plural,
-            event=causation.UPDATE, id=id, timeout=timeout,
+            reason=causation.Reason.UPDATE, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
         return fn
     return decorator
@@ -97,7 +97,7 @@ def delete(
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
         actual_registry.register_cause_handler(
             group=group, version=version, plural=plural,
-            event=causation.DELETE, id=id, timeout=timeout,
+            reason=causation.Reason.DELETE, id=id, timeout=timeout,
             fn=fn, requires_finalizer=bool(not optional),
             labels=labels, annotations=annotations)
         return fn
@@ -119,7 +119,7 @@ def field(
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
         actual_registry.register_cause_handler(
             group=group, version=version, plural=plural,
-            event=None, field=field, id=id, timeout=timeout,
+            reason=None, field=field, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
         return fn
     return decorator

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -92,6 +92,11 @@ class Cause(NamedTuple):
     old: Optional[bodies.BodyEssence] = None
     new: Optional[bodies.BodyEssence] = None
 
+    @property
+    def event(self) -> Reason:
+        warnings.warn("`cause.event` is deprecated; use `cause.reason`.", DeprecationWarning)
+        return self.reason
+
 
 def detect_cause(
         *,

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -205,8 +205,8 @@ async def handle_cause(
     skip = None
 
     # Regular causes invoke the handlers.
-    if cause.event in causation.HANDLER_CAUSES:
-        title = causation.TITLES.get(cause.event, repr(cause.event))
+    if cause.reason in causation.HANDLER_REASONS:
+        title = causation.TITLES.get(cause.reason, repr(cause.reason))
         logger.debug(f"{title.capitalize()} event: %r", body)
         if cause.diff is not None and cause.old is not None and cause.new is not None:
             logger.debug(f"{title.capitalize()} diff: %r", cause.diff)
@@ -235,18 +235,18 @@ async def handle_cause(
         lastseen.refresh_essence(body=body, patch=patch, extra_fields=extra_fields)
         if done:
             state.purge_progress(body=body, patch=patch)
-        if cause.event == causation.DELETE:
+        if cause.reason == causation.Reason.DELETE:
             logger.debug("Removing the finalizer, thus allowing the actual deletion.")
             finalizers.remove_finalizers(body=body, patch=patch)
 
     # Informational causes just print the log lines.
-    if cause.event == causation.GONE:
+    if cause.reason == causation.Reason.GONE:
         logger.debug("Deleted, really deleted, and we are notified.")
 
-    if cause.event == causation.FREE:
+    if cause.reason == causation.Reason.FREE:
         logger.debug("Deletion event, but we are done with it, and we do not care.")
 
-    if cause.event == causation.NOOP:
+    if cause.reason == causation.Reason.NOOP:
         logger.debug("Something has changed, but we are not interested (state is the same).")
 
     # For the case of a newly created object, or one that doesn't have the correct
@@ -254,13 +254,13 @@ async def handle_cause(
     # produce an 'ACQUIRE' causation event. This only happens when there are
     # mandatory deletion handlers registered for the given object, i.e. if finalizers
     # are required.
-    if cause.event == causation.ACQUIRE:
+    if cause.reason == causation.Reason.ACQUIRE:
         logger.debug("Adding the finalizer, thus preventing the actual deletion.")
         finalizers.append_finalizers(body=body, patch=patch)
 
     # Remove finalizers from an object, since the object currently has finalizers, but
     # shouldn't, thus releasing the locking of the object to this operator.
-    if cause.event == causation.RELEASE:
+    if cause.reason == causation.Reason.RELEASE:
         logger.debug("Removing the finalizer, as there are no handlers requiring it.")
         finalizers.remove_finalizers(body=body, patch=patch)
 

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -57,7 +57,8 @@ async def invoke(
     if cause is not None:
         kwargs.update(
             cause=cause,
-            event=cause.event,
+            event=cause.reason,  # deprecated; kept for backward-compatibility
+            reason=cause.reason,
             body=cause.body,
             diff=cause.diff,
             old=cause.old,

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -14,9 +14,10 @@ of the handlers to be executed on each reaction cycle.
 import abc
 import functools
 import logging
+import warnings
 from types import FunctionType, MethodType
 from typing import (Any, MutableMapping, Optional, Sequence, Collection, Iterable, Iterator,
-                    NamedTuple, Union, Tuple, List, Set, FrozenSet, Mapping, NewType, cast)
+                    NamedTuple, Union, List, Set, FrozenSet, Mapping, NewType, cast)
 
 from typing_extensions import Protocol
 
@@ -58,12 +59,13 @@ class HandlerFn(Protocol):
 class Handler(NamedTuple):
     fn: HandlerFn
     id: HandlerId
-    event: Optional[str]
-    field: Optional[Tuple[str, ...]]
+    reason: Optional[causation.Reason]
+    field: Optional[dicts.FieldPath]
     timeout: Optional[float] = None
     initial: Optional[bool] = None
     labels: Optional[bodies.Labels] = None
     annotations: Optional[bodies.Annotations] = None
+
 
 
 class BaseRegistry(metaclass=abc.ABCMeta):
@@ -158,7 +160,7 @@ class SimpleRegistry(BaseRegistry):
             self,
             fn: HandlerFn,
             id: Optional[str] = None,
-            event: Optional[str] = None,
+            reason: Optional[causation.Reason] = None,
             field: Optional[dicts.FieldSpec] = None,
             timeout: Optional[float] = None,
             initial: Optional[bool] = None,
@@ -179,7 +181,7 @@ class SimpleRegistry(BaseRegistry):
         real_id = cast(HandlerId, id) if id is not None else cast(HandlerId, get_callable_id(fn))
         real_id = real_id if field is None else cast(HandlerId, f'{real_id}/{".".join(field)}')
         real_id = real_id if self.prefix is None else cast(HandlerId, f'{self.prefix}/{real_id}')
-        handler = Handler(id=real_id, fn=fn, event=event, field=field, timeout=timeout,
+        handler = Handler(id=real_id, fn=fn, reason=reason, field=field, timeout=timeout,
                           initial=initial, labels=labels, annotations=annotations)
 
         self.append(handler)
@@ -195,7 +197,7 @@ class SimpleRegistry(BaseRegistry):
     ) -> Iterator[Handler]:
         changed_fields = frozenset(field for _, field, _, _ in cause.diff or [])
         for handler in self._handlers:
-            if handler.event is None or handler.event == cause.event:
+            if handler.reason is None or handler.reason == cause.reason:
                 if handler.initial and not cause.initial:
                     pass  # ignore initial handlers in non-initial causes.
                 elif match(handler=handler, body=cause.body, changed_fields=changed_fields):
@@ -269,7 +271,7 @@ class GlobalRegistry(BaseRegistry):
             plural: str,
             fn: HandlerFn,
             id: Optional[str] = None,
-            event: Optional[str] = None,
+            reason: Optional[causation.Reason] = None,
             field: Optional[dicts.FieldSpec] = None,
             timeout: Optional[float] = None,
             initial: Optional[bool] = None,
@@ -278,11 +280,12 @@ class GlobalRegistry(BaseRegistry):
             annotations: Optional[bodies.Annotations] = None,
     ) -> HandlerFn:
         """
-        Register an additional handler function for the specific resource and specific event.
+        Register an additional handler function for the specific resource and specific reason.
         """
         resource = resources_.Resource(group, version, plural)
         registry = self._cause_handlers.setdefault(resource, SimpleRegistry())
-        registry.register(event=event, field=field, fn=fn, id=id, timeout=timeout, initial=initial, requires_finalizer=requires_finalizer,
+        registry.register(reason=reason, field=field, fn=fn, id=id, timeout=timeout,
+                          initial=initial, requires_finalizer=requires_finalizer,
                           labels=labels, annotations=annotations)
         return fn  # to be usable as a decorator too.
 

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -11,7 +11,7 @@ def test_no_args():
 def test_all_args(mocker):
     logger = mocker.Mock()
     resource = mocker.Mock()
-    event = mocker.Mock()
+    reason = mocker.Mock()
     initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
@@ -21,7 +21,7 @@ def test_all_args(mocker):
     cause = Cause(
         resource=resource,
         logger=logger,
-        event=event,
+        reason=reason,
         initial=initial,
         body=body,
         patch=patch,
@@ -31,7 +31,7 @@ def test_all_args(mocker):
     )
     assert cause.resource is resource
     assert cause.logger is logger
-    assert cause.event is event
+    assert cause.reason is reason
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
@@ -43,21 +43,21 @@ def test_all_args(mocker):
 def test_required_args(mocker):
     logger = mocker.Mock()
     resource = mocker.Mock()
-    event = mocker.Mock()
+    reason = mocker.Mock()
     initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
     cause = Cause(
         resource=resource,
         logger=logger,
-        event=event,
+        reason=reason,
         initial=initial,
         body=body,
         patch=patch,
     )
     assert cause.resource is resource
     assert cause.logger is logger
-    assert cause.event is event
+    assert cause.reason is reason
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -32,6 +32,7 @@ def test_all_args(mocker):
     assert cause.resource is resource
     assert cause.logger is logger
     assert cause.reason is reason
+    assert cause.event is reason  # deprecated
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
@@ -58,6 +59,7 @@ def test_required_args(mocker):
     assert cause.resource is resource
     assert cause.logger is logger
     assert cause.reason is reason
+    assert cause.event is reason  # deprecated
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -30,6 +30,7 @@ def test_all_args(mocker):
     assert handler.fn is fn
     assert handler.id is id
     assert handler.reason is reason
+    assert handler.event is reason  # deprecated
     assert handler.field is field
     assert handler.timeout is timeout
     assert handler.initial is initial

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -11,7 +11,7 @@ def test_no_args():
 def test_all_args(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
-    event = mocker.Mock()
+    reason = mocker.Mock()
     field = mocker.Mock()
     timeout = mocker.Mock()
     initial = mocker.Mock()
@@ -20,7 +20,7 @@ def test_all_args(mocker):
     handler = Handler(
         fn=fn,
         id=id,
-        event=event,
+        reason=reason,
         field=field,
         timeout=timeout,
         initial=initial,
@@ -29,7 +29,7 @@ def test_all_args(mocker):
     )
     assert handler.fn is fn
     assert handler.id is id
-    assert handler.event is event
+    assert handler.reason is reason
     assert handler.field is field
     assert handler.timeout is timeout
     assert handler.initial is initial

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -3,9 +3,7 @@ import json
 
 import pytest
 
-from kopf.reactor.causation import CREATE, UPDATE, DELETE, NOOP, FREE, GONE, ACQUIRE, RELEASE
-from kopf.reactor.causation import detect_cause
-from kopf.structs.diffs import Diff
+from kopf.reactor.causation import Reason, detect_cause
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 
@@ -140,7 +138,7 @@ def test_for_gone(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
-    assert cause.event == GONE
+    assert cause.reason == Reason.GONE
     check_kwargs(cause, kwargs)
 
 
@@ -153,7 +151,7 @@ def test_for_free(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
-    assert cause.event == FREE
+    assert cause.reason == Reason.FREE
     check_kwargs(cause, kwargs)
 
 
@@ -166,7 +164,7 @@ def test_for_delete(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
-    assert cause.event == DELETE
+    assert cause.reason == Reason.DELETE
     check_kwargs(cause, kwargs)
 
 
@@ -179,7 +177,7 @@ def test_for_acquire(kwargs, event, finalizers, deletion_ts, requires_finalizer)
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
-    assert cause.event == ACQUIRE
+    assert cause.reason == Reason.ACQUIRE
     check_kwargs(cause, kwargs)
 
 
@@ -192,7 +190,7 @@ def test_for_release(kwargs, event, finalizers, deletion_ts, requires_finalizer)
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
-    assert cause.event == RELEASE
+    assert cause.reason == Reason.RELEASE
     check_kwargs(cause, kwargs)
 
 
@@ -208,7 +206,7 @@ def test_for_create(kwargs, event, finalizers, deletion_ts, annotations, content
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
-    assert cause.event == CREATE
+    assert cause.reason == Reason.CREATE
     check_kwargs(cause, kwargs)
 
 
@@ -221,7 +219,7 @@ def test_for_create_skip_acquire(kwargs, event, finalizers, deletion_ts, require
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
-    assert cause.event == CREATE
+    assert cause.reason == Reason.CREATE
     check_kwargs(cause, kwargs)
 
 
@@ -237,7 +235,7 @@ def test_for_no_op(kwargs, event, finalizers, deletion_ts, annotations, content,
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
-    assert cause.event == NOOP
+    assert cause.reason == Reason.NOOP
     check_kwargs(cause, kwargs)
 
 
@@ -253,5 +251,5 @@ def test_for_update(kwargs, event, finalizers, deletion_ts, annotations, content
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
     cause = detect_cause(event=event, requires_finalizer=requires_finalizer, diff=True, **kwargs)
-    assert cause.event == UPDATE
+    assert cause.reason == Reason.UPDATE
     check_kwargs(cause, kwargs)

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -41,7 +41,7 @@ from unittest.mock import Mock
 import pytest
 
 import kopf
-from kopf.reactor.causation import Cause, RESUME
+from kopf.reactor.causation import Cause, Reason
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
@@ -186,12 +186,13 @@ def cause_mock(mocker, resource):
 
         # Avoid collision of our mocked values with the passed kwargs.
         original_event = kwargs.pop('event', None)
+        original_reason = kwargs.pop('reason', None)
         original_body = kwargs.pop('body', None)
         original_diff = kwargs.pop('diff', None)
         original_new = kwargs.pop('new', None)
         original_old = kwargs.pop('old', None)
-        event = mock.event if mock.event is not None else original_event
-        initial = bool(event == RESUME)
+        reason = mock.reason if mock.reason is not None else original_reason
+        initial = bool(reason == Reason.RESUME)
         body = copy.deepcopy(mock.body) if mock.body is not None else original_body
         diff = copy.deepcopy(mock.diff) if mock.diff is not None else original_diff
         new = copy.deepcopy(mock.new) if mock.new is not None else original_new
@@ -201,9 +202,9 @@ def cause_mock(mocker, resource):
         kwargs.pop('requires_finalizer', None)
 
         # Pass through kwargs: resource, logger, patch, diff, old, new.
-        # I.e. everything except what we mock: event & body.
+        # I.e. everything except what we mock: reason & body.
         cause = Cause(
-            event=event,
+            reason=reason,
             initial=initial,
             body=body,
             diff=diff,
@@ -224,8 +225,8 @@ def cause_mock(mocker, resource):
     mocker.patch('kopf.reactor.causation.detect_cause', new=new_detect_fn)
 
     # The mock object stores some values later used by the factory substitute.
-    mock = mocker.Mock(spec_set=['event', 'body', 'diff', 'new', 'old'])
-    mock.event = None
+    mock = mocker.Mock(spec_set=['reason', 'body', 'diff', 'new', 'old'])
+    mock.reason = None
     mock.body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
     mock.diff = None
     mock.new = None

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -1,10 +1,8 @@
 import asyncio
 import logging
 
-import pytest
-
 import kopf
-from kopf.reactor.causation import CREATE, UPDATE, DELETE, GONE, FREE, NOOP, RESUME, ACQUIRE, RELEASE
+from kopf.reactor.causation import Reason
 from kopf.reactor.handling import custom_object_handler
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
@@ -13,7 +11,7 @@ from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 async def test_acquire(registry, handlers, resource, cause_mock,
                    caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = ACQUIRE
+    cause_mock.reason = Reason.ACQUIRE
 
     event_queue = asyncio.Queue()
     await custom_object_handler(
@@ -49,7 +47,7 @@ async def test_acquire(registry, handlers, resource, cause_mock,
 async def test_create(registry, handlers, resource, cause_mock,
                       caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = CREATE
+    cause_mock.reason = Reason.CREATE
 
     event_queue = asyncio.Queue()
     await custom_object_handler(
@@ -92,7 +90,7 @@ async def test_create(registry, handlers, resource, cause_mock,
 async def test_update(registry, handlers, resource, cause_mock,
                       caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = UPDATE
+    cause_mock.reason = Reason.UPDATE
 
     event_queue = asyncio.Queue()
     await custom_object_handler(
@@ -135,7 +133,7 @@ async def test_update(registry, handlers, resource, cause_mock,
 async def test_delete(registry, handlers, resource, cause_mock,
                       caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = DELETE
+    cause_mock.reason = Reason.DELETE
 
     event_queue = asyncio.Queue()
     await custom_object_handler(
@@ -175,7 +173,7 @@ async def test_delete(registry, handlers, resource, cause_mock,
 
 async def test_release(registry, resource, handlers, cause_mock, caplog, k8s_mocked, assert_logs):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = RELEASE
+    cause_mock.reason = Reason.RELEASE
     cause_mock.body.setdefault('metadata', {})['finalizers'] = [FINALIZER]
 
     # register handlers (no deletion handlers)
@@ -183,7 +181,7 @@ async def test_release(registry, resource, handlers, cause_mock, caplog, k8s_moc
         group=resource.group,
         version=resource.version,
         plural=resource.plural,
-        event=RESUME,
+        reason=Reason.RESUME,
         fn=lambda **_: None,
         requires_finalizer=False,
     )
@@ -226,7 +224,7 @@ async def test_release(registry, resource, handlers, cause_mock, caplog, k8s_moc
 async def test_gone(registry, handlers, resource, cause_mock,
                     caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = GONE
+    cause_mock.reason = Reason.GONE
 
     event_queue = asyncio.Queue()
     await custom_object_handler(
@@ -256,7 +254,7 @@ async def test_gone(registry, handlers, resource, cause_mock,
 async def test_free(registry, handlers, resource, cause_mock,
                     caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = FREE
+    cause_mock.reason = Reason.FREE
 
     event_queue = asyncio.Queue()
     await custom_object_handler(
@@ -286,7 +284,7 @@ async def test_free(registry, handlers, resource, cause_mock,
 async def test_noop(registry, handlers, resource, cause_mock,
                     caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = NOOP
+    cause_mock.reason = Reason.NOOP
 
     event_queue = asyncio.Queue()
     await custom_object_handler(

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -4,14 +4,14 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import ALL_CAUSES, HANDLER_CAUSES
+from kopf.reactor.causation import ALL_REASONS, HANDLER_REASONS
 from kopf.reactor.handling import custom_object_handler
 
 
-@pytest.mark.parametrize('cause_type', ALL_CAUSES)
+@pytest.mark.parametrize('cause_type', ALL_REASONS)
 async def test_all_logs_are_prefixed(registry, resource, handlers,
                                      logstream, cause_type, cause_mock):
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
 
     await custom_object_handler(
         lifecycle=kopf.lifecycles.all_at_once,
@@ -33,11 +33,11 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
     pytest.param((), id='empty-tuple-diff'),
     pytest.param([], id='empty-list-diff'),
 ])
-@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+@pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_diffs_logged_if_present(registry, resource, handlers, cause_type, cause_mock,
                                        caplog, assert_logs, diff):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
     cause_mock.diff = diff
     cause_mock.new = object()  # checked for `not None`
     cause_mock.old = object()  # checked for `not None`
@@ -57,11 +57,11 @@ async def test_diffs_logged_if_present(registry, resource, handlers, cause_type,
     ])
 
 
-@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+@pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_diffs_not_logged_if_absent(registry, resource, handlers, cause_type, cause_mock,
                                           caplog, assert_logs):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
     cause_mock.diff = None  # same as the default, but for clarity
 
     await custom_object_handler(

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -4,20 +4,20 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import HANDLER_CAUSES, CREATE, UPDATE, DELETE, RESUME
+from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.handling import custom_object_handler
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
-@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+@pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_fatal_error_stops_handler(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
     handlers.create_mock.side_effect = PermanentError("oops")
     handlers.update_mock.side_effect = PermanentError("oops")
     handlers.delete_mock.side_effect = PermanentError("oops")
@@ -33,10 +33,10 @@ async def test_fatal_error_stops_handler(
         event_queue=asyncio.Queue(),
     )
 
-    assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
-    assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
-    assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
-    assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
+    assert handlers.create_mock.call_count == (1 if cause_type == Reason.CREATE else 0)
+    assert handlers.update_mock.call_count == (1 if cause_type == Reason.UPDATE else 0)
+    assert handlers.delete_mock.call_count == (1 if cause_type == Reason.DELETE else 0)
+    assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
@@ -52,14 +52,14 @@ async def test_fatal_error_stops_handler(
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
-@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+@pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_retry_error_delays_handler(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
     handlers.create_mock.side_effect = TemporaryError("oops")
     handlers.update_mock.side_effect = TemporaryError("oops")
     handlers.delete_mock.side_effect = TemporaryError("oops")
@@ -75,10 +75,10 @@ async def test_retry_error_delays_handler(
         event_queue=asyncio.Queue(),
     )
 
-    assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
-    assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
-    assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
-    assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
+    assert handlers.create_mock.call_count == (1 if cause_type == Reason.CREATE else 0)
+    assert handlers.update_mock.call_count == (1 if cause_type == Reason.UPDATE else 0)
+    assert handlers.delete_mock.call_count == (1 if cause_type == Reason.DELETE else 0)
+    assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called
@@ -95,14 +95,14 @@ async def test_retry_error_delays_handler(
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
-@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+@pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_arbitrary_error_delays_handler(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
     handlers.create_mock.side_effect = Exception("oops")
     handlers.update_mock.side_effect = Exception("oops")
     handlers.delete_mock.side_effect = Exception("oops")
@@ -118,10 +118,10 @@ async def test_arbitrary_error_delays_handler(
         event_queue=asyncio.Queue(),
     )
 
-    assert handlers.create_mock.call_count == (1 if cause_type == CREATE else 0)
-    assert handlers.update_mock.call_count == (1 if cause_type == UPDATE else 0)
-    assert handlers.delete_mock.call_count == (1 if cause_type == DELETE else 0)
-    assert handlers.resume_mock.call_count == (1 if cause_type == RESUME else 0)
+    assert handlers.create_mock.call_count == (1 if cause_type == Reason.CREATE else 0)
+    assert handlers.update_mock.call_count == (1 if cause_type == Reason.UPDATE else 0)
+    assert handlers.delete_mock.call_count == (1 if cause_type == Reason.DELETE else 0)
+    assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep_or_wait.called
     assert k8s_mocked.patch_obj.called

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -4,16 +4,16 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import ALL_CAUSES
+from kopf.reactor.causation import ALL_REASONS
 from kopf.reactor.handling import custom_object_handler
 
 
-@pytest.mark.parametrize('cause_type', ALL_CAUSES)
+@pytest.mark.parametrize('cause_type', ALL_REASONS)
 async def test_handlers_called_always(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
 
     await custom_object_handler(
         lifecycle=kopf.lifecycles.all_at_once,
@@ -42,12 +42,12 @@ async def test_handlers_called_always(
     ])
 
 
-@pytest.mark.parametrize('cause_type', ALL_CAUSES)
+@pytest.mark.parametrize('cause_type', ALL_REASONS)
 async def test_errors_are_ignored(
         registry, handlers, extrahandlers, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
     handlers.event_mock.side_effect = Exception("oops")
 
     await custom_object_handler(

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -4,24 +4,24 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import HANDLER_CAUSES
+from kopf.reactor.causation import HANDLER_REASONS
 from kopf.reactor.handling import custom_object_handler
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 
 
-@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+@pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_skipped_with_no_handlers(
         registry, resource, cause_mock, cause_type,
         caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
 
     assert not registry.has_cause_handlers(resource=resource)  # prerequisite
     registry.register_cause_handler(
         group=resource.group,
         version=resource.version,
         plural=resource.plural,
-        event='a-non-existent-cause-type',
+        reason='a-non-existent-cause-type',
         fn=lambda **_: None,
     )
     assert registry.has_cause_handlers(resource=resource)  # prerequisite

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -5,13 +5,13 @@ import freezegun
 import pytest
 
 import kopf
-from kopf.reactor.causation import HANDLER_CAUSES
+from kopf.reactor.causation import HANDLER_REASONS
 from kopf.reactor.handling import custom_object_handler
 
 
 # The timeout is hard-coded in conftest.py:handlers().
 # The extrahandlers are needed to prevent the cycle ending and status purging.
-@pytest.mark.parametrize('cause_type', HANDLER_CAUSES)
+@pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 @pytest.mark.parametrize('now, ts', [
     ['2099-12-31T23:59:59', '2020-01-01T00:00:00'],
 ], ids=['slow'])
@@ -21,7 +21,7 @@ async def test_timed_out_handler_fails(
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
-    cause_mock.event = cause_type
+    cause_mock.reason = cause_type
     cause_mock.body.update({
         'status': {'kopf': {'progress': {
             'create_fn': {'started': ts},

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -170,7 +170,8 @@ async def test_special_kwargs_added(fn):
 
     assert len(fn.call_args[1]) >= 2
     assert fn.call_args[1]['cause'] is cause
-    assert fn.call_args[1]['event'] is cause.event
+    assert fn.call_args[1]['event'] is cause.reason  # deprecated
+    assert fn.call_args[1]['reason'] is cause.reason
     assert fn.call_args[1]['body'] is cause.body
     assert fn.call_args[1]['spec'] == cause.body['spec']
     assert fn.call_args[1]['meta'] == cause.body['metadata']

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.reactor.causation import CREATE, UPDATE, DELETE
+from kopf.reactor.causation import Reason
 from kopf.reactor.handling import subregistry_var
 from kopf.reactor.registries import SimpleRegistry, GlobalRegistry
 from kopf.structs.resources import Resource
@@ -10,7 +10,7 @@ from kopf.structs.resources import Resource
 def test_on_create_minimal(mocker):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, event=CREATE)
+    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
 
     @kopf.on.create('group', 'version', 'plural')
     def fn(**_):
@@ -19,7 +19,7 @@ def test_on_create_minimal(mocker):
     handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event == CREATE
+    assert handlers[0].reason == Reason.CREATE
     assert handlers[0].field is None
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
@@ -29,7 +29,7 @@ def test_on_create_minimal(mocker):
 def test_on_update_minimal(mocker):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, event=UPDATE)
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
 
     @kopf.on.update('group', 'version', 'plural')
     def fn(**_):
@@ -38,7 +38,7 @@ def test_on_update_minimal(mocker):
     handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event == UPDATE
+    assert handlers[0].reason == Reason.UPDATE
     assert handlers[0].field is None
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
@@ -48,7 +48,7 @@ def test_on_update_minimal(mocker):
 def test_on_delete_minimal(mocker):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, event=DELETE)
+    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
 
     @kopf.on.delete('group', 'version', 'plural')
     def fn(**_):
@@ -57,7 +57,7 @@ def test_on_delete_minimal(mocker):
     handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event == DELETE
+    assert handlers[0].reason == Reason.DELETE
     assert handlers[0].field is None
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
@@ -68,7 +68,7 @@ def test_on_field_minimal(mocker):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, event=UPDATE, diff=diff)
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield')
     def fn(**_):
@@ -77,7 +77,7 @@ def test_on_field_minimal(mocker):
     handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event is None
+    assert handlers[0].reason is None
     assert handlers[0].field == ('field', 'subfield')
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
@@ -94,7 +94,7 @@ def test_on_field_fails_without_field():
 def test_on_create_with_all_kwargs(mocker):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, event=CREATE)
+    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.create('group', 'version', 'plural',
@@ -107,7 +107,7 @@ def test_on_create_with_all_kwargs(mocker):
     handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event == CREATE
+    assert handlers[0].reason == Reason.CREATE
     assert handlers[0].field is None
     assert handlers[0].id == 'id'
     assert handlers[0].timeout == 123
@@ -118,7 +118,7 @@ def test_on_create_with_all_kwargs(mocker):
 def test_on_update_with_all_kwargs(mocker):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, event=UPDATE)
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.update('group', 'version', 'plural',
@@ -131,7 +131,7 @@ def test_on_update_with_all_kwargs(mocker):
     handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event == UPDATE
+    assert handlers[0].reason == Reason.UPDATE
     assert handlers[0].field is None
     assert handlers[0].id == 'id'
     assert handlers[0].timeout == 123
@@ -146,7 +146,7 @@ def test_on_update_with_all_kwargs(mocker):
 def test_on_delete_with_all_kwargs(mocker, optional):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, event=DELETE)
+    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.delete('group', 'version', 'plural',
@@ -159,7 +159,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event == DELETE
+    assert handlers[0].reason == Reason.DELETE
     assert handlers[0].field is None
     assert handlers[0].id == 'id'
     assert handlers[0].timeout == 123
@@ -171,7 +171,7 @@ def test_on_field_with_all_kwargs(mocker):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, event=UPDATE, diff=diff)
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
@@ -184,7 +184,7 @@ def test_on_field_with_all_kwargs(mocker):
     handlers = registry.get_cause_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
-    assert handlers[0].event is None
+    assert handlers[0].reason is None
     assert handlers[0].field ==('field', 'subfield')
     assert handlers[0].id == 'id/field.subfield'
     assert handlers[0].timeout == 123
@@ -193,7 +193,7 @@ def test_on_field_with_all_kwargs(mocker):
 
 
 def test_subhandler_declaratively(mocker):
-    cause = mocker.MagicMock(event=UPDATE, diff=None)
+    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
 
     registry = SimpleRegistry()
     subregistry_var.set(registry)
@@ -208,7 +208,7 @@ def test_subhandler_declaratively(mocker):
 
 
 def test_subhandler_imperatively(mocker):
-    cause = mocker.MagicMock(event=UPDATE, diff=None)
+    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
 
     registry = SimpleRegistry()
     subregistry_var.set(registry)

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -34,7 +34,7 @@ def register_fn(registry, resource):
 ])
 def cause_no_diff(request, resource):
     body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
-    return Mock(resource=resource, event='some-event', diff=request.param, body=body)
+    return Mock(resource=resource, reason='some-reason', diff=request.param, body=body)
 
 
 @pytest.fixture(params=[
@@ -43,7 +43,7 @@ def cause_no_diff(request, resource):
 def cause_with_diff(resource):
     body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
     diff = [('op', ('some-field',), 'old', 'new')]
-    return Mock(resource=resource, event='some-event', diff=diff, body=body)
+    return Mock(resource=resource, reason='some-reason', diff=diff, body=body)
 
 
 @pytest.fixture(params=[
@@ -53,7 +53,7 @@ def cause_with_diff(resource):
 ])
 def cause_any_diff(resource, request):
     body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
-    return Mock(resource=resource, event='some-event', diff=request.param, body=body)
+    return Mock(resource=resource, reason='some-reason', diff=request.param, body=body)
 
 
 #
@@ -61,19 +61,19 @@ def cause_any_diff(resource, request):
 #
 
 def test_catchall_handlers_without_field_found(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event=None, field=None)
+    register_fn(some_fn, reason=None, field=None)
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_found(cause_with_diff, registry, register_fn):
-    register_fn(some_fn, event=None, field='some-field')
+    register_fn(some_fn, reason=None, field='some-field')
     handlers = registry.get_cause_handlers(cause_with_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
-    register_fn(some_fn, event=None, field='some-field')
+    register_fn(some_fn, reason=None, field='some-field')
     handlers = registry.get_cause_handlers(cause_no_diff)
     assert not handlers
 
@@ -83,8 +83,8 @@ def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_satisfied(registry, register_fn, resource, labels):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'labels': labels}})
-    register_fn(some_fn, event=None, field=None, labels={'somelabel': 'somevalue'})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
     handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -95,8 +95,8 @@ def test_catchall_handlers_with_labels_satisfied(registry, register_fn, resource
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_labels_not_satisfied(registry, register_fn, resource, labels):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'labels': labels}})
-    register_fn(some_fn, event=None, field=None, labels={'somelabel': 'somevalue'})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
     handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -106,8 +106,8 @@ def test_catchall_handlers_with_labels_not_satisfied(registry, register_fn, reso
     pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_exist(registry, register_fn, resource, labels):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'labels': labels}})
-    register_fn(some_fn, event=None, field=None, labels={'somelabel': None})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
     handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -117,8 +117,8 @@ def test_catchall_handlers_with_labels_exist(registry, register_fn, resource, la
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_labels_not_exist(registry, register_fn, resource, labels):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'labels': labels}})
-    register_fn(some_fn, event=None, field=None, labels={'somelabel': None})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
     handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -131,8 +131,8 @@ def test_catchall_handlers_with_labels_not_exist(registry, register_fn, resource
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_without_labels(registry, register_fn, resource, labels):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'labels': labels}})
-    register_fn(some_fn, event=None, field=None, labels=None)
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels=None)
     handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -142,8 +142,8 @@ def test_catchall_handlers_without_labels(registry, register_fn, resource, label
     pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_with_annotations_satisfied(registry, register_fn, resource, annotations):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'annotations': annotations}})
-    register_fn(some_fn, event=None, field=None, annotations={'someannotation': 'somevalue'})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
     handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -154,8 +154,8 @@ def test_catchall_handlers_with_annotations_satisfied(registry, register_fn, res
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_annotations_not_satisfied(registry, register_fn, resource, annotations):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'annotations': annotations}})
-    register_fn(some_fn, event=None, field=None, annotations={'someannotation': 'somevalue'})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
     handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -165,8 +165,8 @@ def test_catchall_handlers_with_annotations_not_satisfied(registry, register_fn,
     pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_exist(registry, register_fn, resource, annotations):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'annotations': annotations}})
-    register_fn(some_fn, event=None, field=None, annotations={'someannotation': None})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
     handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -176,8 +176,8 @@ def test_catchall_handlers_with_annotations_exist(registry, register_fn, resourc
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_annotations_not_exist(registry, register_fn, resource, annotations):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'annotations': annotations}})
-    register_fn(some_fn, event=None, field=None, annotations={'someannotation': None})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
     handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -190,8 +190,8 @@ def test_catchall_handlers_with_annotations_not_exist(registry, register_fn, res
     pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_without_annotations(registry, register_fn, resource, annotations):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'annotations': annotations}})
-    register_fn(some_fn, event=None, field=None, annotations=None)
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations=None)
     handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -203,8 +203,8 @@ def test_catchall_handlers_without_annotations(registry, register_fn, resource, 
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_satisfied(registry, register_fn, resource, labels, annotations):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'labels': labels, 'annotations': annotations}})
-    register_fn(some_fn, event=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels, 'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
     handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -217,92 +217,92 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(registry, regis
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_not_satisfied(registry, register_fn, resource, labels):
-    cause = Mock(resource=resource, event='some-event', diff=None, body={'metadata': {'labels': labels}})
-    register_fn(some_fn, event=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
     handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
 
 #
-# Relevant handlers are those with event == 'some-event' (but not 'another-event').
+# Relevant handlers are those with event == 'some-reason' (but not 'another-reason').
 # In the per-field handlers, also with field == 'some-field' (not 'another-field').
 # In the label filtered handlers, the relevant handlers are those that ask for 'somelabel'.
 # In the annotation filtered handlers, the relevant handlers are those that ask for 'someannotation'.
 #
 
 def test_relevant_handlers_without_field_found(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='some-event')
+    register_fn(some_fn, reason='some-reason')
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_found(cause_with_diff, registry, register_fn):
-    register_fn(some_fn, event='some-event', field='some-field')
+    register_fn(some_fn, reason='some-reason', field='some-field')
     handlers = registry.get_cause_handlers(cause_with_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
-    register_fn(some_fn, event='some-event', field='some-field')
+    register_fn(some_fn, reason='some-reason', field='some-field')
     handlers = registry.get_cause_handlers(cause_no_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='some-event', labels={'somelabel': None})
+    register_fn(some_fn, reason='some-reason', labels={'somelabel': None})
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='some-event', labels={'otherlabel': None})
+    register_fn(some_fn, reason='some-reason', labels={'otherlabel': None})
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='some-event', annotations={'someannotation': None})
+    register_fn(some_fn, reason='some-reason', annotations={'someannotation': None})
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='some-event', annotations={'otherannotation': None})
+    register_fn(some_fn, reason='some-reason', annotations={'otherannotation': None})
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_without_field_ignored(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='another-event')
+    register_fn(some_fn, reason='another-reason')
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_field_ignored(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='another-event', field='another-field')
+    register_fn(some_fn, reason='another-reason', field='another-field')
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 def test_irrelevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='another-event', labels={'somelabel': None})
+    register_fn(some_fn, reason='another-reason', labels={'somelabel': None})
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='another-event', labels={'otherlabel': None})
+    register_fn(some_fn, reason='another-reason', labels={'otherlabel': None})
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='another-event', annotations={'someannotation': None})
+    register_fn(some_fn, reason='another-reason', annotations={'someannotation': None})
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
-    register_fn(some_fn, event='another-event', annotations={'otherannotation': None})
+    register_fn(some_fn, reason='another-reason', annotations={'otherannotation': None})
     handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
@@ -313,40 +313,40 @@ def test_irrelevant_handlers_with_annotations_not_satisfied(cause_any_diff, regi
 #
 
 def test_order_persisted_a(cause_with_diff, registry, register_fn):
-    register_fn(functools.partial(some_fn, 1), event=None)
-    register_fn(functools.partial(some_fn, 2), event='some-event')
-    register_fn(functools.partial(some_fn, 3), event='filtered-out-event')
-    register_fn(functools.partial(some_fn, 4), event=None, field='filtered-out-field')
-    register_fn(functools.partial(some_fn, 5), event=None, field='some-field')
+    register_fn(functools.partial(some_fn, 1), reason=None)
+    register_fn(functools.partial(some_fn, 2), reason='some-reason')
+    register_fn(functools.partial(some_fn, 3), reason='filtered-out-reason')
+    register_fn(functools.partial(some_fn, 4), reason=None, field='filtered-out-reason')
+    register_fn(functools.partial(some_fn, 5), reason=None, field='some-field')
 
     handlers = registry.get_cause_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
     assert len(handlers) == 3
-    assert handlers[0].event is None
+    assert handlers[0].reason is None
     assert handlers[0].field is None
-    assert handlers[1].event == 'some-event'
+    assert handlers[1].reason == 'some-reason'
     assert handlers[1].field is None
-    assert handlers[2].event is None
+    assert handlers[2].reason is None
     assert handlers[2].field == ('some-field',)
 
 
 def test_order_persisted_b(cause_with_diff, registry, register_fn):
-    register_fn(functools.partial(some_fn, 1), event=None, field='some-field')
-    register_fn(functools.partial(some_fn, 2), event=None, field='filtered-out-field')
-    register_fn(functools.partial(some_fn, 3), event='filtered-out-event')
-    register_fn(functools.partial(some_fn, 4), event='some-event')
-    register_fn(functools.partial(some_fn, 5), event=None)
+    register_fn(functools.partial(some_fn, 1), reason=None, field='some-field')
+    register_fn(functools.partial(some_fn, 2), reason=None, field='filtered-out-field')
+    register_fn(functools.partial(some_fn, 3), reason='filtered-out-reason')
+    register_fn(functools.partial(some_fn, 4), reason='some-reason')
+    register_fn(functools.partial(some_fn, 5), reason=None)
 
     handlers = registry.get_cause_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
     assert len(handlers) == 3
-    assert handlers[0].event is None
+    assert handlers[0].reason is None
     assert handlers[0].field == ('some-field',)
-    assert handlers[1].event == 'some-event'
+    assert handlers[1].reason == 'some-reason'
     assert handlers[1].field is None
-    assert handlers[2].event is None
+    assert handlers[2].reason is None
     assert handlers[2].field is None
 
 #
@@ -355,8 +355,8 @@ def test_order_persisted_b(cause_with_diff, registry, register_fn):
 #
 
 def test_deduplicated(cause_with_diff, registry, register_fn):
-    register_fn(some_fn, event=None, id='a')
-    register_fn(some_fn, event=None, id='b')
+    register_fn(some_fn, reason=None, id='a')
+    register_fn(some_fn, reason=None, id='b')
 
     handlers = registry.get_cause_handlers(cause_with_diff)
 


### PR DESCRIPTION
Rename `cause.event` to `cause.reason` for clarity in terminology.

> Issue : #194

## Description

Originally, in the early stages of Kopf development, one of the cause's fields was named as `event`, when it actually represented a _reason_ of the reaction, or a _trigger_ for this reaction, or what is the detected kind of change.

Over time, this produced confusion, as there are already 2 _events_ present: the watching-events (streaming) and the `kind: Event` resources (logging) -- both are taken from the Kubernetes's terminology and cannot be avoided.

More on that, when the event-handlers were added, it created inconsistency for the `event` kwarg between the event-handlers and the cause-handlers: in the latter ones, it was a _reason_ of the change, while in the former ones, it was the raw event dict being processed.

The terminology conflict became obvious (and troublesome) after the type annotations were added across the code in #200, and with the coming PR of the terminology fixes for causation and handling routines (#???). For example, in a [handler function protocol](https://github.com/zalando-incubator/kopf/blob/e1c995720a7b4be584a948ca1513397f8a89fd5f/kopf/reactor/registries.py#L40):

```python
class HandlerFn(Protocol):
    def __call__(
            self,
            *args: Any,
            type: str,
            event: Union[str, bodies.Event],  # <<<
            body: bodies.Body,
            meta: bodies.Meta,
            spec: bodies.Spec,
```

In this PR, this specific terminology conflict is resolved: the field `cause.event` is renamed to `cause.reason` in all places it is met: in causes, in handlers, in kwargs, etc.

The legacy `event` kwarg/property is kept for backward-compatibility (with a warning). It will be removed indefinitely later (perhaps, on the next major release, with all other deprecated things).

_This PR is only a part of the terminology alignment sequence, extracted to make the review easier._

---

As a continuation of the type-hinting task (#200), the reason is also converted to an enum (str-enum, specifically: making it comparable with the strings as it was for the previous constants).


## Types of Changes

- Refactor/improvements

**There are no behaviour changes.**