### PR TITLE
Resolve a terminology conflict: event-watching vs state-changing causes

### DIFF
--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -84,8 +84,8 @@ is required for the forward compatibility: the framework can add new keywords
 in the future, and the existing handlers should accept them and not break.
 
 
-Event handlers
-==============
+Event-watching handlers
+=======================
 
 Low-level events can be intercepted and handled silently, without
 storing the handlers' status (errors, retries, successes) on the object.
@@ -114,8 +114,8 @@ and then ignored.
     (re-executable with do duplicating side-effects).
 
 
-Cause handlers
-==============
+State-changing handlers
+=======================
 
 Kopf goes further and beyond: it detects the actual causes of these events,
 i.e. what actually happened to the object:

--- a/examples/08-events/README.md
+++ b/examples/08-events/README.md
@@ -5,7 +5,7 @@ This can be not desired when the objects do not belong to this operator,
 but a probably served by some other operator, and are just watched
 by the current operator, e.g. for their status fields.
 
-Event-handlers can be used as the silent spies on the raw events:
+Event-watching handlers can be used as the silent spies on the raw events:
 they do not store anything on the object, and do not create the k8s-events.
 
 If the event handler fails, the error is logged to the operator's log,

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -34,7 +34,7 @@ def resume(
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_cause_handler(
+        actual_registry.register_state_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, initial=True, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
@@ -54,7 +54,7 @@ def create(
     """ ``@kopf.on.create()`` handler for the object creation. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_cause_handler(
+        actual_registry.register_state_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
@@ -74,7 +74,7 @@ def update(
     """ ``@kopf.on.update()`` handler for the object update or change. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_cause_handler(
+        actual_registry.register_state_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
@@ -95,7 +95,7 @@ def delete(
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_cause_handler(
+        actual_registry.register_state_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.DELETE, id=id, timeout=timeout,
             fn=fn, requires_finalizer=bool(not optional),
@@ -117,7 +117,7 @@ def field(
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_cause_handler(
+        actual_registry.register_state_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
@@ -136,7 +136,7 @@ def event(
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_event_handler(
+        actual_registry.register_event_watching_handler(
             group=group, version=version, plural=plural,
             id=id, fn=fn, labels=labels, annotations=annotations)
         return fn

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -100,7 +100,7 @@ class StateChangingCause:
         return self.reason
 
 
-def detect_cause(
+def detect_state_changing_cause(
         *,
         event: bodies.Event,
         diff: Optional[diffs.Diff] = None,

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -19,10 +19,11 @@ For deletion, the cause is detected when the object is just marked for deletion,
 not when it is actually deleted (as the events notify): so that the handlers
 could execute on the yet-existing object (and its children, if created).
 """
+import dataclasses
 import enum
 import logging
 import warnings
-from typing import Any, NamedTuple, Optional, Union
+from typing import Any, Optional, Union
 
 from kopf.structs import bodies
 from kopf.structs import diffs
@@ -75,7 +76,8 @@ TITLES = {
 }
 
 
-class Cause(NamedTuple):
+@dataclasses.dataclass
+class Cause:
     """
     The cause is what has caused the whole reaction as a chain of handlers.
 
@@ -174,4 +176,4 @@ def enrich_cause(
     Usually, those are the old/new/diff fields, and used when a field-handler
     is invoked (the old/new/diff refer to the field's values only).
     """
-    return cause._replace(**kwargs)
+    return dataclasses.replace(cause, **kwargs)

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -73,7 +73,7 @@ sublifecycle_var: ContextVar[lifecycles.LifeCycleFn] = ContextVar('sublifecycle_
 subregistry_var: ContextVar[registries.SimpleRegistry] = ContextVar('subregistry_var')
 subexecuted_var: ContextVar[bool] = ContextVar('subexecuted_var')
 handler_var: ContextVar[registries.Handler] = ContextVar('handler_var')
-cause_var: ContextVar[causation.Cause] = ContextVar('cause_var')
+cause_var: ContextVar[causation.StateChangingCause] = ContextVar('cause_var')
 
 
 async def custom_object_handler(
@@ -192,7 +192,7 @@ async def handle_event(
 async def handle_cause(
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.BaseRegistry,
-        cause: causation.Cause,
+        cause: causation.StateChangingCause,
 ) -> Optional[float]:
     """
     Handle a detected cause, as part of the bigger handler routine.
@@ -274,7 +274,7 @@ async def execute(
         handlers: Optional[Iterable[registries.Handler]] = None,
         registry: Optional[registries.BaseRegistry] = None,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
-        cause: Optional[causation.Cause] = None,
+        cause: Optional[causation.StateChangingCause] = None,
 ) -> None:
     """
     Execute the handlers in an isolated lifecycle.
@@ -348,7 +348,7 @@ async def execute(
 async def _execute(
         lifecycle: lifecycles.LifeCycleFn,
         handlers: Collection[registries.Handler],
-        cause: causation.Cause,
+        cause: causation.StateChangingCause,
         retry_on_errors: bool = True,
 ) -> None:
     """
@@ -464,7 +464,7 @@ async def _execute(
 async def _call_handler(
         handler: registries.Handler,
         *args: Any,
-        cause: causation.Cause,
+        cause: causation.StateChangingCause,
         lifecycle: lifecycles.LifeCycleFn,
         **kwargs: Any,
 ) -> Any:

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -340,6 +340,11 @@ async def execute(
         subexecuted_var.set(True)
         registry = subregistry_var.get()
 
+    # The sub-handlers are only for upper-level causes, not for lower-level events.
+    if not isinstance(cause, causation.StateChangingCause):
+        raise RuntimeError("Sub-handlers of event-handlers are not supported and have "
+                           "no practical use (there are no retries or state tracking).")
+
     # Execute the real handlers (all or few or one of them, as per the lifecycle).
     # Raises `HandlerChildrenRetry` if the execute should be continued on the next iteration.
     await _execute(
@@ -507,7 +512,7 @@ async def _call_handler(
             **kwargs,
         )
 
-        if not subexecuted_var.get():
+        if not subexecuted_var.get() and isinstance(cause, causation.StateChangingCause):
             await execute()
 
         return result

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -306,11 +306,7 @@ async def execute(
     # Restore the current context as set in the handler execution cycle.
     lifecycle = lifecycle if lifecycle is not None else sublifecycle_var.get()
     cause = cause if cause is not None else cause_var.get()
-    handler: Optional[registries.Handler]
-    try:
-        handler = handler_var.get()
-    except LookupError:
-        handler = None
+    handler: registries.Handler = handler_var.get()
 
     # Validate the inputs; the function signatures cannot put these kind of restrictions, so we do.
     if len([v for v in [fns, handlers, registry] if v is not None]) > 1:

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -23,8 +23,7 @@ Invokable = Union[lifecycles.LifeCycleFn, registries.HandlerFn]
 async def invoke(
         fn: Invokable,
         *args: Any,
-        event: Optional[bodies.Event] = None,
-        cause: Optional[causation.StateChangingCause] = None,
+        cause: Optional[causation.BaseCause] = None,
         **kwargs: Any,
 ) -> Any:
     """
@@ -42,19 +41,21 @@ async def invoke(
     """
 
     # Add aliases for the kwargs, directly linked to the body, or to the assumed defaults.
-    if event is not None:
+    if isinstance(cause, causation.EventWatchingCause):
         kwargs.update(
-            event=event,
-            type=event['type'],
-            body=event['object'],
-            spec=dicts.DictView(event['object'], 'spec'),
-            meta=dicts.DictView(event['object'], 'metadata'),
-            status=dicts.DictView(event['object'], 'status'),
-            uid=event['object'].get('metadata', {}).get('uid'),
-            name=event['object'].get('metadata', {}).get('name'),
-            namespace=event['object'].get('metadata', {}).get('namespace'),
+            event=cause.raw,
+            patch=cause.patch,
+            logger=cause.logger,
+            type=cause.type,
+            body=cause.body,
+            spec=dicts.DictView(cause.body, 'spec'),
+            meta=dicts.DictView(cause.body, 'metadata'),
+            status=dicts.DictView(cause.body, 'status'),
+            uid=cause.body.get('metadata', {}).get('uid'),
+            name=cause.body.get('metadata', {}).get('name'),
+            namespace=cause.body.get('metadata', {}).get('namespace'),
         )
-    if cause is not None:
+    if isinstance(cause, causation.StateChangingCause):
         kwargs.update(
             cause=cause,
             event=cause.reason,  # deprecated; kept for backward-compatibility

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -24,7 +24,7 @@ async def invoke(
         fn: Invokable,
         *args: Any,
         event: Optional[bodies.Event] = None,
-        cause: Optional[causation.Cause] = None,
+        cause: Optional[causation.StateChangingCause] = None,
         **kwargs: Any,
 ) -> Any:
     """

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -141,6 +141,53 @@ class BaseRegistry(metaclass=abc.ABCMeta):
                 seen_ids.add(id(handler.fn))
                 yield handler
 
+    #
+    # Backward-compatibility of a semi-public interface: registries are exposed,
+    # but these methods were not documented or demonstrated, but could be used.
+    #
+
+    def get_cause_handlers(
+            self,
+            cause: causation.StateChangingCause,
+    ) -> Sequence[Handler]:
+        warnings.warn("registry.get_cause_handlers() is deprecated; "
+                      "use registry.get_state_changing_handlers().", DeprecationWarning)
+        return self.get_state_changing_handlers(cause=cause)
+
+    def iter_cause_handlers(
+            self,
+            cause: causation.StateChangingCause,
+    ) -> Iterator[Handler]:
+        warnings.warn("registry.iter_cause_handlers() is deprecated; "
+                      "use registry.iter_state_changing_handlers().", DeprecationWarning)
+        return self.iter_state_changing_handlers(cause=cause)
+
+    def get_event_handlers(
+            self,
+            resource: resources_.Resource,
+            event: bodies.Event,
+    ) -> Sequence[Handler]:
+        warnings.warn("registry.get_event_handlers() is deprecated; "
+                      "use registry.get_event_watching_handlers().", DeprecationWarning)
+        return list(self._deduplicated(self.iter_event_handlers(resource=resource, event=event)))
+
+    def iter_event_handlers(
+            self,
+            resource: resources_.Resource,
+            event: bodies.Event,
+    ) -> Iterator[Handler]:
+        warnings.warn("registry.iter_event_handlers() is deprecated; "
+                      "use registry.iter_event_watching_handlers().", DeprecationWarning)
+        return self.iter_event_watching_handlers(cause=causation.detect_event_watching_cause(
+            resource=resource,
+            event=event,
+            patch=patches.Patch(),          # unused
+            type=event['type'],             # unused
+            body=event['object'],           # unused
+            raw=event,                      # unused
+            logger=logging.Logger('kopf'),  # unused
+        ))
+
 
 class SimpleRegistry(BaseRegistry):
     """
@@ -376,6 +423,31 @@ class GlobalRegistry(BaseRegistry):
         if resource_registry is None:
             return False
         return resource_registry.requires_finalizer(resource, body)
+
+    #
+    # Backward-compatibility of a semi-public interface: registries are exposed,
+    # but these methods were not documented or demonstrated, but could be used.
+    #
+
+    def register_cause_handler(self, *args:Any, **kwargs: Any) -> Any:
+        warnings.warn("registry.register_cause_handler() is deprecated; "
+                      "use registry.register_state_changing_handler().", DeprecationWarning)
+        return self.register_state_changing_handler(*args, **kwargs)
+
+    def register_event_handler(self, *args:Any, **kwargs: Any) -> Any:
+        warnings.warn("registry.register_event_handler() is deprecated; "
+                      "use registry.register_event_watching_handler().", DeprecationWarning)
+        return self.register_event_watching_handler(*args, **kwargs)
+
+    def has_cause_handlers(self, *args:Any, **kwargs: Any) -> Any:
+        warnings.warn("registry.has_cause_handlers() is deprecated; "
+                      "use registry.has_state_changing_handlers().", DeprecationWarning)
+        return self.has_state_changing_handlers(*args, **kwargs)
+
+    def has_event_handlers(self, *args:Any, **kwargs: Any) -> Any:
+        warnings.warn("registry.has_event_handlers() is deprecated; "
+                      "use registry.has_event_watching_handlers().", DeprecationWarning)
+        return self.has_event_watching_handlers(*args, **kwargs)
 
 
 _default_registry: GlobalRegistry = GlobalRegistry()

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -93,16 +93,14 @@ class BaseRegistry(metaclass=abc.ABCMeta):
 
     def get_event_watching_handlers(
             self,
-            resource: resources_.Resource,
-            event: bodies.Event,
+            cause: causation.EventWatchingCause,
     ) -> Sequence[Handler]:
-        return list(self._deduplicated(self.iter_event_watching_handlers(resource=resource, event=event)))
+        return list(self._deduplicated(self.iter_event_watching_handlers(cause=cause)))
 
     @abc.abstractmethod
     def iter_event_watching_handlers(
             self,
-            resource: resources_.Resource,
-            event: bodies.Event,
+            cause: causation.EventWatchingCause,
     ) -> Iterator[Handler]:
         pass
 
@@ -214,11 +212,10 @@ class SimpleRegistry(BaseRegistry):
 
     def iter_event_watching_handlers(
             self,
-            resource: resources_.Resource,
-            event: bodies.Event,
+            cause: causation.EventWatchingCause,
     ) -> Iterator[Handler]:
         for handler in self._handlers:
-            if match(handler=handler, body=event['object']):
+            if match(handler=handler, body=cause.body):
                 yield handler
 
     def iter_extra_fields(
@@ -349,15 +346,14 @@ class GlobalRegistry(BaseRegistry):
 
     def iter_event_watching_handlers(
             self,
-            resource: resources_.Resource,
-            event: bodies.Event,
+            cause: causation.EventWatchingCause,
     ) -> Iterator[Handler]:
         """
         Iterate all handlers for the low-level events.
         """
-        resource_registry = self._event_handlers.get(resource, None)
+        resource_registry = self._event_handlers.get(cause.resource, None)
         if resource_registry is not None:
-            yield from resource_registry.iter_event_watching_handlers(resource=resource, event=event)
+            yield from resource_registry.iter_event_watching_handlers(cause=cause)
 
     def iter_extra_fields(
             self,

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -80,14 +80,14 @@ class BaseRegistry(metaclass=abc.ABCMeta):
 
     def get_cause_handlers(
             self,
-            cause: causation.Cause,
+            cause: causation.StateChangingCause,
     ) -> Sequence[Handler]:
         return list(self._deduplicated(self.iter_cause_handlers(cause=cause)))
 
     @abc.abstractmethod
     def iter_cause_handlers(
             self,
-            cause: causation.Cause,
+            cause: causation.StateChangingCause,
     ) -> Iterator[Handler]:
         pass
 
@@ -202,7 +202,7 @@ class SimpleRegistry(BaseRegistry):
 
     def iter_cause_handlers(
             self,
-            cause: causation.Cause,
+            cause: causation.StateChangingCause,
     ) -> Iterator[Handler]:
         changed_fields = frozenset(field for _, field, _, _ in cause.diff or [])
         for handler in self._handlers:
@@ -338,7 +338,7 @@ class GlobalRegistry(BaseRegistry):
 
     def iter_cause_handlers(
             self,
-            cause: causation.Cause,
+            cause: causation.StateChangingCause,
     ) -> Iterator[Handler]:
         """
         Iterate all handlers that match this cause/event, in the order they were registered (even if mixed).

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -1,11 +1,11 @@
 import pytest
 
-from kopf.reactor.causation import Cause
+from kopf.reactor.causation import StateChangingCause
 
 
 def test_no_args():
     with pytest.raises(TypeError):
-        Cause()
+        StateChangingCause()
 
 
 def test_all_args(mocker):
@@ -18,7 +18,7 @@ def test_all_args(mocker):
     diff = mocker.Mock()
     old = mocker.Mock()
     new = mocker.Mock()
-    cause = Cause(
+    cause = StateChangingCause(
         resource=resource,
         logger=logger,
         reason=reason,
@@ -48,7 +48,7 @@ def test_required_args(mocker):
     initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
-    cause = Cause(
+    cause = StateChangingCause(
         resource=resource,
         logger=logger,
         reason=reason,

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from kopf.reactor.causation import Reason, detect_cause
+from kopf.reactor.causation import Reason, detect_state_changing_cause
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 
@@ -137,7 +137,10 @@ def test_for_gone(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        **kwargs)
     assert cause.reason == Reason.GONE
     check_kwargs(cause, kwargs)
 
@@ -150,7 +153,10 @@ def test_for_free(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        **kwargs)
     assert cause.reason == Reason.FREE
     check_kwargs(cause, kwargs)
 
@@ -163,7 +169,10 @@ def test_for_delete(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        **kwargs)
     assert cause.reason == Reason.DELETE
     check_kwargs(cause, kwargs)
 
@@ -176,7 +185,10 @@ def test_for_acquire(kwargs, event, finalizers, deletion_ts, requires_finalizer)
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        **kwargs)
     assert cause.reason == Reason.ACQUIRE
     check_kwargs(cause, kwargs)
 
@@ -189,7 +201,10 @@ def test_for_release(kwargs, event, finalizers, deletion_ts, requires_finalizer)
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        **kwargs)
     assert cause.reason == Reason.RELEASE
     check_kwargs(cause, kwargs)
 
@@ -205,7 +220,10 @@ def test_for_create(kwargs, event, finalizers, deletion_ts, annotations, content
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        **kwargs)
     assert cause.reason == Reason.CREATE
     check_kwargs(cause, kwargs)
 
@@ -218,7 +236,10 @@ def test_for_create_skip_acquire(kwargs, event, finalizers, deletion_ts, require
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        **kwargs)
     assert cause.reason == Reason.CREATE
     check_kwargs(cause, kwargs)
 
@@ -234,7 +255,10 @@ def test_for_no_op(kwargs, event, finalizers, deletion_ts, annotations, content,
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        **kwargs)
     assert cause.reason == Reason.NOOP
     check_kwargs(cause, kwargs)
 
@@ -250,6 +274,10 @@ def test_for_update(kwargs, event, finalizers, deletion_ts, annotations, content
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_cause(event=event, requires_finalizer=requires_finalizer, diff=True, **kwargs)
+    cause = detect_state_changing_cause(
+        event=event,
+        requires_finalizer=requires_finalizer,
+        diff=True,
+        **kwargs)
     assert cause.reason == Reason.UPDATE
     check_kwargs(cause, kwargs)

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -41,7 +41,7 @@ from unittest.mock import Mock
 import pytest
 
 import kopf
-from kopf.reactor.causation import Cause, Reason
+from kopf.reactor.causation import StateChangingCause, Reason
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
@@ -198,12 +198,12 @@ def cause_mock(mocker, resource):
         new = copy.deepcopy(mock.new) if mock.new is not None else original_new
         old = copy.deepcopy(mock.old) if mock.old is not None else original_old
 
-        # Remove requires_finalizer from kwargs as it shouldn't be passed to the Cause object
+        # Remove requires_finalizer from kwargs as it shouldn't be passed to the cause.
         kwargs.pop('requires_finalizer', None)
 
         # Pass through kwargs: resource, logger, patch, diff, old, new.
         # I.e. everything except what we mock: reason & body.
-        cause = Cause(
+        cause = StateChangingCause(
             reason=reason,
             initial=initial,
             body=body,

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -22,7 +22,7 @@ Therefore, we do not mock/spy/intercept anything within the handling routines
 (except for cause detection), leaving it as the implementation details.
 Specifically, this internal chain of calls happens on every event:
 
-* ``causation.detect_cause()`` -- tested separately in ``/tests/causation/``.
+* ``causation.detect_*_cause()`` -- tested separately in ``/tests/causation/``.
 * ``handle_cause()``
 * ``execute()``
 * ``_execute()``
@@ -222,7 +222,7 @@ def cause_mock(mocker, resource):
         return cause
 
     # Substitute the real cause detector with out own mock-based one.
-    mocker.patch('kopf.reactor.causation.detect_cause', new=new_detect_fn)
+    mocker.patch('kopf.reactor.causation.detect_state_changing_cause', new=new_detect_fn)
 
     # The mock object stores some values later used by the factory substitute.
     mock = mocker.Mock(spec_set=['reason', 'body', 'diff', 'new', 'old'])

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -177,7 +177,7 @@ async def test_release(registry, resource, handlers, cause_mock, caplog, k8s_moc
     cause_mock.body.setdefault('metadata', {})['finalizers'] = [FINALIZER]
 
     # register handlers (no deletion handlers)
-    registry.register_cause_handler(
+    registry.register_state_changing_handler(
         group=resource.group,
         version=resource.version,
         plural=resource.plural,

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -7,8 +7,8 @@ from kopf.reactor.registries import GlobalRegistry
 
 
 async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, assert_logs):
-    detect_cause = mocker.patch('kopf.reactor.causation.detect_cause')
-    handle_cause = mocker.patch('kopf.reactor.handling.handle_cause')
+    detect_state_changing_cause = mocker.patch('kopf.reactor.causation.detect_state_changing_cause')
+    handle_cause = mocker.patch('kopf.reactor.handling.handle_state_changing_cause')
     patch_obj = mocker.patch('kopf.clients.patching.patch_obj')
     asyncio_sleep = mocker.patch('asyncio.sleep')
 
@@ -33,7 +33,7 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
         event_queue=asyncio.Queue(),
     )
 
-    assert not detect_cause.called
+    assert not detect_state_changing_cause.called
     assert not handle_cause.called
     assert not patch_obj.called
     assert not asyncio_sleep.called

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -16,15 +16,15 @@ async def test_skipped_with_no_handlers(
     caplog.set_level(logging.DEBUG)
     cause_mock.reason = cause_type
 
-    assert not registry.has_cause_handlers(resource=resource)  # prerequisite
-    registry.register_cause_handler(
+    assert not registry.has_state_changing_handlers(resource=resource)  # prerequisite
+    registry.register_state_changing_handler(
         group=resource.group,
         version=resource.version,
         plural=resource.plural,
         reason='a-non-existent-cause-type',
         fn=lambda **_: None,
     )
-    assert registry.has_cause_handlers(resource=resource)  # prerequisite
+    assert registry.has_state_changing_handlers(resource=resource)  # prerequisite
 
     await custom_object_handler(
         lifecycle=kopf.lifecycles.all_at_once,

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -5,7 +5,7 @@ import traceback
 import pytest
 from asynctest import MagicMock
 
-from kopf.reactor.causation import Cause, Reason
+from kopf.reactor.causation import StateChangingCause, Reason
 from kopf.reactor.invocation import invoke, is_async_fn
 from kopf.structs.patches import Patch
 
@@ -167,7 +167,7 @@ async def test_special_kwargs_added(fn, resource):
             'status': {'info': 'payload'}}
 
     # Values can be any.
-    cause = Cause(
+    cause = StateChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         resource=resource,
         patch=Patch(),

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -1,8 +1,12 @@
+import logging
+
 import pytest
 
 import kopf
-from kopf.reactor.causation import Cause
+from kopf.reactor.causation import Cause, Reason
 from kopf.reactor.invocation import invoke
+from kopf.structs.bodies import Body
+from kopf.structs.patches import Patch
 
 
 @pytest.mark.parametrize('lifecycle', [
@@ -12,12 +16,20 @@ from kopf.reactor.invocation import invoke
     kopf.lifecycles.shuffled,
     kopf.lifecycles.asap,
 ])
-async def test_protocol_invocation(mocker, lifecycle):
+async def test_protocol_invocation(lifecycle, resource):
     """
     To be sure that all kwargs are accepted properly.
     Especially when the new kwargs are added or an invocation protocol changed.
     """
-    cause = mocker.Mock(spec=Cause)
+    # The values are irrelevant, they can be anything.
+    cause = Cause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        resource=resource,
+        patch=Patch(),
+        body=Body(),
+        initial=False,
+        reason=Reason.NOOP,
+    )
     handlers = []
     selected = await invoke(lifecycle, handlers, cause=cause)
     assert isinstance(selected, (tuple, list))

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import Cause, Reason
+from kopf.reactor.causation import StateChangingCause, Reason
 from kopf.reactor.invocation import invoke
 from kopf.structs.bodies import Body
 from kopf.structs.patches import Patch
@@ -22,7 +22,7 @@ async def test_protocol_invocation(lifecycle, resource):
     Especially when the new kwargs are added or an invocation protocol changed.
     """
     # The values are irrelevant, they can be anything.
-    cause = Cause(
+    cause = StateChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         resource=resource,
         patch=Patch(),

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -16,7 +16,7 @@ def test_on_create_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.CREATE
@@ -35,7 +35,7 @@ def test_on_update_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.UPDATE
@@ -54,7 +54,7 @@ def test_on_delete_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.DELETE
@@ -74,7 +74,7 @@ def test_on_field_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
@@ -104,7 +104,7 @@ def test_on_create_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.CREATE
@@ -128,7 +128,7 @@ def test_on_update_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.UPDATE
@@ -156,7 +156,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.DELETE
@@ -181,7 +181,7 @@ def test_on_field_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
@@ -202,7 +202,7 @@ def test_subhandler_declaratively(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
 
@@ -217,6 +217,6 @@ def test_subhandler_imperatively(mocker):
         pass
     kopf.register(fn)
 
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn

--- a/tests/registries/test_global_registry.py
+++ b/tests/registries/test_global_registry.py
@@ -11,8 +11,8 @@ def some_fn():
 
 def test_resources():
     registry = GlobalRegistry()
-    registry.register_cause_handler('group1', 'version1', 'plural1', some_fn)
-    registry.register_cause_handler('group2', 'version2', 'plural2', some_fn)
+    registry.register_state_changing_handler('group1', 'version1', 'plural1', some_fn)
+    registry.register_state_changing_handler('group2', 'version2', 'plural2', some_fn)
 
     resources = registry.resources
 

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -24,7 +24,7 @@ def register_fn(registry, resource):
     if isinstance(registry, SimpleRegistry):
         return registry.register
     if isinstance(registry, GlobalRegistry):
-        return functools.partial(registry.register_cause_handler, resource.group, resource.version, resource.plural)
+        return functools.partial(registry.register_state_changing_handler, resource.group, resource.version, resource.plural)
     raise Exception(f"Unsupported registry type: {registry}")
 
 
@@ -62,19 +62,19 @@ def cause_any_diff(resource, request):
 
 def test_catchall_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field=None)
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field='some-field')
-    handlers = registry.get_cause_handlers(cause_with_diff)
+    handlers = registry.get_state_changing_handlers(cause_with_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field='some-field')
-    handlers = registry.get_cause_handlers(cause_no_diff)
+    handlers = registry.get_state_changing_handlers(cause_no_diff)
     assert not handlers
 
 
@@ -85,7 +85,7 @@ def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_
 def test_catchall_handlers_with_labels_satisfied(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert handlers
 
 
@@ -97,7 +97,7 @@ def test_catchall_handlers_with_labels_satisfied(registry, register_fn, resource
 def test_catchall_handlers_with_labels_not_satisfied(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert not handlers
 
 
@@ -108,7 +108,7 @@ def test_catchall_handlers_with_labels_not_satisfied(registry, register_fn, reso
 def test_catchall_handlers_with_labels_exist(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert handlers
 
 
@@ -119,7 +119,7 @@ def test_catchall_handlers_with_labels_exist(registry, register_fn, resource, la
 def test_catchall_handlers_with_labels_not_exist(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert not handlers
 
 
@@ -133,7 +133,7 @@ def test_catchall_handlers_with_labels_not_exist(registry, register_fn, resource
 def test_catchall_handlers_without_labels(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels=None)
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert handlers
 
 
@@ -144,7 +144,7 @@ def test_catchall_handlers_without_labels(registry, register_fn, resource, label
 def test_catchall_handlers_with_annotations_satisfied(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert handlers
 
 
@@ -156,7 +156,7 @@ def test_catchall_handlers_with_annotations_satisfied(registry, register_fn, res
 def test_catchall_handlers_with_annotations_not_satisfied(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert not handlers
 
 
@@ -167,7 +167,7 @@ def test_catchall_handlers_with_annotations_not_satisfied(registry, register_fn,
 def test_catchall_handlers_with_annotations_exist(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert handlers
 
 
@@ -178,7 +178,7 @@ def test_catchall_handlers_with_annotations_exist(registry, register_fn, resourc
 def test_catchall_handlers_with_annotations_not_exist(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert not handlers
 
 
@@ -192,7 +192,7 @@ def test_catchall_handlers_with_annotations_not_exist(registry, register_fn, res
 def test_catchall_handlers_without_annotations(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations=None)
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert handlers
 
 
@@ -205,7 +205,7 @@ def test_catchall_handlers_without_annotations(registry, register_fn, resource, 
 def test_catchall_handlers_with_labels_and_annotations_satisfied(registry, register_fn, resource, labels, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels, 'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert handlers
 
 
@@ -219,7 +219,7 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(registry, regis
 def test_catchall_handlers_with_labels_and_annotations_not_satisfied(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
     assert not handlers
 
 
@@ -232,78 +232,78 @@ def test_catchall_handlers_with_labels_and_annotations_not_satisfied(registry, r
 
 def test_relevant_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason')
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', field='some-field')
-    handlers = registry.get_cause_handlers(cause_with_diff)
+    handlers = registry.get_state_changing_handlers(cause_with_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', field='some-field')
-    handlers = registry.get_cause_handlers(cause_no_diff)
+    handlers = registry.get_state_changing_handlers(cause_no_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', labels={'somelabel': None})
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', labels={'otherlabel': None})
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', annotations={'someannotation': None})
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', annotations={'otherannotation': None})
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_without_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason')
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', field='another-field')
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert not handlers
 
 def test_irrelevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', labels={'somelabel': None})
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', labels={'otherlabel': None})
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', annotations={'someannotation': None})
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', annotations={'otherannotation': None})
-    handlers = registry.get_cause_handlers(cause_any_diff)
+    handlers = registry.get_state_changing_handlers(cause_any_diff)
     assert not handlers
 
 
@@ -319,7 +319,7 @@ def test_order_persisted_a(cause_with_diff, registry, register_fn):
     register_fn(functools.partial(some_fn, 4), reason=None, field='filtered-out-reason')
     register_fn(functools.partial(some_fn, 5), reason=None, field='some-field')
 
-    handlers = registry.get_cause_handlers(cause_with_diff)
+    handlers = registry.get_state_changing_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
     assert len(handlers) == 3
@@ -338,7 +338,7 @@ def test_order_persisted_b(cause_with_diff, registry, register_fn):
     register_fn(functools.partial(some_fn, 4), reason='some-reason')
     register_fn(functools.partial(some_fn, 5), reason=None)
 
-    handlers = registry.get_cause_handlers(cause_with_diff)
+    handlers = registry.get_state_changing_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
     assert len(handlers) == 3
@@ -358,7 +358,7 @@ def test_deduplicated(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason=None, id='a')
     register_fn(some_fn, reason=None, id='b')
 
-    handlers = registry.get_cause_handlers(cause_with_diff)
+    handlers = registry.get_state_changing_handlers(cause_with_diff)
 
     assert len(handlers) == 1
     assert handlers[0].id == 'a'  # the first found one is returned

--- a/tests/registries/test_id_detection.py
+++ b/tests/registries/test_id_detection.py
@@ -76,7 +76,7 @@ def test_with_no_hints(mocker):
 
     registry = SimpleRegistry()
     registry.register(some_fn)
-    handlers = registry.get_cause_handlers(mocker.MagicMock())
+    handlers = registry.get_state_changing_handlers(mocker.MagicMock())
 
     assert get_fn_id.called
 
@@ -90,7 +90,7 @@ def test_with_prefix(mocker):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn)
-    handlers = registry.get_cause_handlers(mocker.MagicMock())
+    handlers = registry.get_state_changing_handlers(mocker.MagicMock())
 
     assert get_fn_id.called
 
@@ -105,7 +105,7 @@ def test_with_suffix(mocker, field):
 
     registry = SimpleRegistry()
     registry.register(some_fn, field=field)
-    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_state_changing_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -120,7 +120,7 @@ def test_with_prefix_and_suffix(mocker, field):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn, field=field)
-    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_state_changing_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -135,7 +135,7 @@ def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn, id='explicit-id', field=field)
-    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_state_changing_handlers(mocker.MagicMock(diff=diff))
 
     assert not get_fn_id.called
 

--- a/tests/registries/test_registering.py
+++ b/tests/registries/test_registering.py
@@ -12,7 +12,7 @@ def test_simple_registry_via_iter(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
     registry = SimpleRegistry()
-    iterator = registry.iter_cause_handlers(cause)
+    iterator = registry.iter_state_changing_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -27,7 +27,7 @@ def test_simple_registry_via_list(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
     registry = SimpleRegistry()
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -40,7 +40,7 @@ def test_simple_registry_with_minimal_signature(mocker):
 
     registry = SimpleRegistry()
     registry.register(some_fn)
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn
@@ -50,7 +50,7 @@ def test_global_registry_via_iter(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    iterator = registry.iter_cause_handlers(cause)
+    iterator = registry.iter_state_changing_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -65,7 +65,7 @@ def test_global_registry_via_list(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    handlers = registry.get_cause_handlers(cause)
+    handlers = registry.get_state_changing_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -77,8 +77,8 @@ def test_global_registry_with_minimal_signature(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    registry.register_cause_handler(resource.group, resource.version, resource.plural, some_fn)
-    handlers = registry.get_cause_handlers(cause)
+    registry.register_state_changing_handler(resource.group, resource.version, resource.plural, some_fn)
+    handlers = registry.get_state_changing_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn


### PR DESCRIPTION
Fix the terminology mess between the event-watching and state-changing causes & reactions.

> Issue : #194


## Description

Since the event-handlers were introduced, there was a terminology chaos in the framework. Specifically, the "event-handling" routines had different signatures than the "cause-handling" routines, despite doing exactly the same, in almost the same way. This became very obvious during the throughout type annotation in #200.

This PR changes the internal terminology both for causation and for handling of such different causes:

* All **ex-"event-handling"** routines were renamed to **"event-watching"** causes and routines -- as they trigger the reaction directly from the _event watching_ streams.
* The **ex-"cause-handling"** routines were renamed to **"state-changing"** causes and routines -- as they trigger the reaction based on the detected changes of the object's state according to the framework's logic; or to no reaction if the state is not changed, regardless of the streamed events.

Internally, the causes are also converted to a more suitable data structures: [dataclasses](https://docs.python.org/3/library/dataclasses.html) (Python 3.7+). This allows their inheritance, unlike with the namedtuples.

The legacy methods and properties are left in place for backward-compatibility of semi-public interfaces: the registries were exposed to the users, so they could be used; but these specific methods were not documented and were used mostly internally (but this cannot be guaranteed).

_Actual purpose: This PR is extracted from the following PR with the auto-guessed implicit owners for hierarchy building: it will require identifying the current object in a similar way in all kind of handlers, regardless of their nature -- hence, they all should have a "cause" with the same core properties._


## Types of Changes

- Refactor/improvements

**There are no behaviour changes in theory.** In practice, some semi-public methods could be broken: they are untested, but they are also not supposed to be used externally, and are not used internally.
