### PR TITLE
Assume the current object as an implicit owner for hierarchies

### DIFF
--- a/docs/hierarchies.rst
+++ b/docs/hierarchies.rst
@@ -39,8 +39,8 @@ Owner references
 Kubernetes natively supports the owner references, when one object (child)
 can be marked as "owned" by one or more other objects (owners or parents).
 
-if the owner is deleted, its children will be deleted too, automatically,
-and not additional handlers are needed.
+If the owner is deleted, its children will be deleted too, automatically,
+and no additional handlers are needed.
 
 To mark an object or objects as owned by another object::
 
@@ -49,6 +49,11 @@ To mark an object or objects as owned by another object::
 To unmark::
 
     kopf.remove_owner_reference(objs, owner=owner)
+
+The currently handled object is the owner by default (if not specified)::
+
+    kopf.append_owner_reference(objs)
+    kopf.remove_owner_reference(objs)
 
 .. seealso::
     :doc:`walkthrough/deletion`.
@@ -79,5 +84,5 @@ Adopting
 
 All of the above can be done in one call::
 
-    kopf.adopt(obj, owner=owner)
-    kopf.adopt([obj1, obj2], owner=owner)
+    kopf.adopt(obj)
+    kopf.adopt([obj1, obj2])

--- a/docs/walkthrough/deletion.rst
+++ b/docs/walkthrough/deletion.rst
@@ -40,7 +40,7 @@ Let's extend the creation handler:
     import yaml
 
     @kopf.on.create('zalando.org', 'v1', 'ephemeralvolumeclaims')
-    def create_fn(meta, body, spec, namespace, logger, **kwargs):
+    def create_fn(meta, spec, namespace, logger, **kwargs):
 
         name = meta.get('name')
         size = spec.get('size')
@@ -52,7 +52,7 @@ Let's extend the creation handler:
         text = tmpl.format(name=name, size=size)
         data = yaml.safe_load(text)
 
-        kopf.adopt(data, owner=body)
+        kopf.adopt(data)
 
         api = kubernetes.client.CoreV1Api()
         obj = api.create_namespaced_persistent_volume_claim(

--- a/docs/walkthrough/updates.rst
+++ b/docs/walkthrough/updates.rst
@@ -43,7 +43,7 @@ with one additional line:
         text = tmpl.format(size=size, name=name)
         data = yaml.safe_load(text)
 
-        kopf.adopt(data, owner=body)
+        kopf.adopt(data)
 
         api = kubernetes.client.CoreV1Api()
         obj = api.create_namespaced_persistent_volume_claim(

--- a/examples/02-children/example.py
+++ b/examples/02-children/example.py
@@ -4,7 +4,7 @@ import yaml
 
 
 @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
-def create_fn(body, spec, **kwargs):
+def create_fn(spec, **kwargs):
 
     # Render the pod yaml with some spec fields used in the template.
     doc = yaml.safe_load(f"""
@@ -25,7 +25,7 @@ def create_fn(body, spec, **kwargs):
     """)
 
     # Make it our child: assign the namespace, name, labels, owner references, etc.
-    kopf.adopt(doc, owner=body)
+    kopf.adopt(doc)
 
     # Actually create an object by requesting the Kubernetes API.
     api = kubernetes.client.CoreV1Api()

--- a/examples/99-all-at-once/example.py
+++ b/examples/99-all-at-once/example.py
@@ -68,7 +68,7 @@ def wait_for_something():
 
 
 @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
-def create_pod(body, **kwargs):
+def create_pod(**kwargs):
 
     # Render the pod yaml with some spec fields used in the template.
     pod_data = yaml.safe_load(f"""
@@ -82,7 +82,7 @@ def create_pod(body, **kwargs):
     """)
 
     # Make it our child: assign the namespace, name, labels, owner references, etc.
-    kopf.adopt(pod_data, owner=body)
+    kopf.adopt(pod_data)
     kopf.label(pod_data, {'application': 'kopf-example-10'})
 
     # Actually create an object by requesting the Kubernetes API.

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -9,13 +9,12 @@ import asyncio
 import contextlib
 import contextvars
 import functools
-from typing import Optional, Any, Union, List, Iterable, Tuple
+from typing import Optional, Any, Union, List, Iterable, Iterator, Tuple
 
 from kopf import config
 from kopf.reactor import causation
 from kopf.reactor import lifecycles
 from kopf.reactor import registries
-from kopf.structs import bodies
 from kopf.structs import dicts
 
 Invokable = Union[lifecycles.LifeCycleFn, registries.HandlerFn]
@@ -23,12 +22,12 @@ Invokable = Union[lifecycles.LifeCycleFn, registries.HandlerFn]
 
 @contextlib.contextmanager
 def context(
-        values: Iterable[Tuple[contextvars.ContextVar, Any]],
-) -> None:
+        values: Iterable[Tuple[contextvars.ContextVar[Any], Any]],
+) -> Iterator[None]:
     """
     A context manager to set the context variables temporarily.
     """
-    tokens: List[Tuple[contextvars.ContextVar, contextvars.Token]] = []
+    tokens: List[Tuple[contextvars.ContextVar[Any], contextvars.Token[Any]]] = []
     try:
         for var, val in values:
             token = var.set(val)

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -1,0 +1,111 @@
+import logging
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import Reason, StateChangingCause, EventWatchingCause
+from kopf.reactor.handling import cause_var
+from kopf.reactor.invocation import context
+from kopf.structs.bodies import Body, Meta, Labels, Event
+from kopf.structs.patches import Patch
+
+OWNER_API_VERSION = 'owner-api-version'
+OWNER_NAMESPACE = 'owner-namespace'
+OWNER_KIND = 'OwnerKind'
+OWNER_NAME = 'owner-name'
+OWNER_UID = 'owner-uid'
+OWNER_LABELS: Labels = {'label-1': 'value-1', 'label-2': 'value-2'}
+OWNER = Body(
+    apiVersion=OWNER_API_VERSION,
+    kind=OWNER_KIND,
+    metadata=Meta(
+        namespace=OWNER_NAMESPACE,
+        name=OWNER_NAME,
+        uid=OWNER_UID,
+        labels=OWNER_LABELS,
+    ),
+)
+
+
+@pytest.fixture(params=['state-changing-cause', 'event-watching-cause'])
+def owner(request, resource):
+    if request.param == 'state-changing-cause':
+        cause = StateChangingCause(
+            logger=logging.getLogger('kopf.test.fake.logger'),
+            resource=resource,
+            patch=Patch(),
+            body=OWNER,
+            initial=False,
+            reason=Reason.NOOP,
+        )
+        with context([(cause_var, cause)]):
+            yield
+    elif request.param == 'event-watching-cause':
+        cause = EventWatchingCause(
+            logger=logging.getLogger('kopf.test.fake.logger'),
+            resource=resource,
+            patch=Patch(),
+            body=OWNER,
+            type='irrelevant',
+            raw=Event(type='irrelevant', object=OWNER),
+        )
+        with context([(cause_var, cause)]):
+            yield
+    else:
+        raise RuntimeError(f"Wrong param for `owner` fixture: {request.param!r}")
+
+
+def test_when_unset_for_owner_references_appending():
+    with pytest.raises(LookupError) as e:
+        kopf.append_owner_reference([])
+    assert 'Owner must be set explicitly' in str(e.value)
+
+
+def test_when_unset_for_owner_references_removal():
+    with pytest.raises(LookupError) as e:
+        kopf.remove_owner_reference([])
+    assert 'Owner must be set explicitly' in str(e.value)
+
+
+def test_when_unset_for_name_harmonization():
+    with pytest.raises(LookupError) as e:
+        kopf.harmonize_naming([])
+    assert 'Owner must be set explicitly' in str(e.value)
+
+
+def test_when_unset_for_namespace_adjustment():
+    with pytest.raises(LookupError) as e:
+        kopf.adjust_namespace([])
+    assert 'Owner must be set explicitly' in str(e.value)
+
+
+def test_when_unset_for_adopting():
+    with pytest.raises(LookupError) as e:
+        kopf.adopt([])
+    assert 'Owner must be set explicitly' in str(e.value)
+
+
+def test_when_set_for_name_harmonization(owner):
+    obj = {}
+    kopf.harmonize_naming(obj)
+    assert obj['metadata']['generateName'].startswith(OWNER_NAME)
+
+
+def test_when_set_for_namespace_adjustment(owner):
+    obj = {}
+    kopf.adjust_namespace(obj)
+    assert obj['metadata']['namespace'] == OWNER_NAMESPACE
+
+
+def test_when_set_for_owner_references_appending(owner):
+    obj = {}
+    kopf.append_owner_reference(obj)
+    assert obj['metadata']['ownerReferences']
+    assert obj['metadata']['ownerReferences'][0]['uid'] == OWNER_UID
+
+
+def test_when_set_for_owner_references_removal(owner):
+    obj = {}
+    kopf.append_owner_reference(obj)  # assumed to work, tested above
+    kopf.remove_owner_reference(obj)  # this one is being tested here
+    assert not obj['metadata']['ownerReferences']


### PR DESCRIPTION
Assume the currently handled object as the default owner when adopting.

> Issue: closes #56

## Description

Simplify the usage of hierarchy management functions to make `owner` optional. If not specified, the currently handler object is assumed to be the owner, or the source of name prefix and namespace.

This is not done for labels, as I am not sure that `kopf.label(obj)` semantically implies the label transfer from the currently handled object. The labelling remains explicit.


## Types of Changes

- New feature (non-breaking change which adds functionality)


## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
