### PR TITLE
Fix mypy's recommendations for `__exit__` results

### DIFF
--- a/kopf/toolkits/runner.py
+++ b/kopf/toolkits/runner.py
@@ -6,6 +6,7 @@ import types
 from typing import cast, Any, Optional, Tuple, Type, TYPE_CHECKING
 
 import click.testing
+from typing_extensions import Literal
 
 from kopf import cli
 
@@ -81,7 +82,7 @@ class KopfRunner(_AbstractKopfRunner):
             exc_type: Optional[Type[BaseException]],
             exc_val: Optional[BaseException],
             exc_tb: Optional[types.TracebackType],
-    ) -> Optional[bool]:
+    ) -> Literal[False]:
 
         # A coroutine that is injected into the loop to cancel everything in it.
         # Cancellations are caught in `run`, so that it exits gracefully.


### PR DESCRIPTION
Fix the mypy strict-mode error for context manager result.

> Issue : #200 

## Description

The new mypy 0.740 started to fail on `__exit__` result type (0.730 was fine with this):

```
$ mypy kopf --strict --pretty
kopf/toolkits/runner.py:79: error: "bool" is invalid as return type for "__exit__" that always returns False
        def __exit__(
        ^
kopf/toolkits/runner.py:79: note: Use "typing_extensions.Literal[False]" as the return type or change it to "None"
kopf/toolkits/runner.py:79: note: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
```

Sample CI: https://travis-ci.org/nolar/kopf/jobs/601269875

This PR does as recommended — annotate that it is literally `False`, not just any boolean.

## Types of Changes

- Refactor/improvements
