### PR TITLE
Refactoring [1/3]: renames for better terminology

### DIFF
--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -83,7 +83,7 @@ in :mod:`contextvars` containers with values isolated per-loop and per-task.
 
     import kopf
 
-    registry = kopf.GlobalRegistry()
+    registry = kopf.OperatorRegistry()
 
     @kopf.on.create('zalando.org', 'v1', 'kopfexamples', registry=registry)
     def create_fn(**_):

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -46,7 +46,7 @@ from kopf.reactor.lifecycles import (
 )
 from kopf.reactor.registries import (
     BaseRegistry,
-    SimpleRegistry,
+    ResourceRegistry,
     GlobalRegistry,
     get_default_registry,
     set_default_registry,
@@ -73,6 +73,7 @@ from kopf.toolkits.hierarchies import (
 
 HandlerFatalError = PermanentError  # a backward-compatibility alias
 HandlerRetryError = TemporaryError  # a backward-compatibility alias
+SimpleRegistry = ResourceRegistry  # a backward-compatibility alias
 
 __all__ = [
     'on', 'lifecycles', 'register', 'execute',
@@ -88,7 +89,7 @@ __all__ = [
     'TemporaryError', 'HandlerRetryError',
     'HandlerTimeoutError',
     'BaseRegistry',
-    'SimpleRegistry',
+    'ResourceRegistry', 'SimpleRegistry',
     'GlobalRegistry',
     'get_default_registry',
     'set_default_registry',

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -47,7 +47,7 @@ from kopf.reactor.lifecycles import (
 from kopf.reactor.registries import (
     BaseRegistry,
     ResourceRegistry,
-    GlobalRegistry,
+    OperatorRegistry,
     get_default_registry,
     set_default_registry,
 )
@@ -74,6 +74,7 @@ from kopf.toolkits.hierarchies import (
 HandlerFatalError = PermanentError  # a backward-compatibility alias
 HandlerRetryError = TemporaryError  # a backward-compatibility alias
 SimpleRegistry = ResourceRegistry  # a backward-compatibility alias
+GlobalRegistry = OperatorRegistry  # a backward-compatibility alias
 
 __all__ = [
     'on', 'lifecycles', 'register', 'execute',
@@ -90,7 +91,7 @@ __all__ = [
     'HandlerTimeoutError',
     'BaseRegistry',
     'ResourceRegistry', 'SimpleRegistry',
-    'GlobalRegistry',
+    'OperatorRegistry', 'GlobalRegistry',
     'get_default_registry',
     'set_default_registry',
 ]

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -27,7 +27,7 @@ def resume(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
 ) -> ResourceHandlerDecorator:
@@ -47,7 +47,7 @@ def create(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
 ) -> ResourceHandlerDecorator:
@@ -67,7 +67,7 @@ def update(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
 ) -> ResourceHandlerDecorator:
@@ -87,7 +87,7 @@ def delete(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         optional: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -110,7 +110,7 @@ def field(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
 ) -> ResourceHandlerDecorator:
@@ -129,7 +129,7 @@ def event(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
 ) -> ResourceHandlerDecorator:

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -34,7 +34,7 @@ def resume(
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_state_changing_handler(
+        actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, initial=True, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
@@ -54,7 +54,7 @@ def create(
     """ ``@kopf.on.create()`` handler for the object creation. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_state_changing_handler(
+        actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
@@ -74,7 +74,7 @@ def update(
     """ ``@kopf.on.update()`` handler for the object update or change. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_state_changing_handler(
+        actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
@@ -95,7 +95,7 @@ def delete(
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_state_changing_handler(
+        actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.DELETE, id=id, timeout=timeout,
             fn=fn, requires_finalizer=bool(not optional),
@@ -117,7 +117,7 @@ def field(
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_state_changing_handler(
+        actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
@@ -136,7 +136,7 @@ def event(
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
-        actual_registry.register_event_watching_handler(
+        actual_registry.register_resource_watching_handler(
             group=group, version=version, plural=plural,
             id=id, fn=fn, labels=labels, annotations=annotations)
         return fn

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -19,7 +19,7 @@ from kopf.reactor import handling
 from kopf.reactor import registries
 from kopf.structs import bodies
 
-HandlerDecorator = Callable[[registries.HandlerFn], registries.HandlerFn]
+ResourceHandlerDecorator = Callable[[registries.ResourceHandlerFn], registries.ResourceHandlerFn]
 
 
 def resume(
@@ -30,10 +30,10 @@ def resume(
         registry: Optional[registries.GlobalRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-) -> HandlerDecorator:
+) -> ResourceHandlerDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
+    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, initial=True, id=id, timeout=timeout,
@@ -50,10 +50,10 @@ def create(
         registry: Optional[registries.GlobalRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-) -> HandlerDecorator:
+) -> ResourceHandlerDecorator:
     """ ``@kopf.on.create()`` handler for the object creation. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
+    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id, timeout=timeout,
@@ -70,10 +70,10 @@ def update(
         registry: Optional[registries.GlobalRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-) -> HandlerDecorator:
+) -> ResourceHandlerDecorator:
     """ ``@kopf.on.update()`` handler for the object update or change. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
+    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id, timeout=timeout,
@@ -91,10 +91,10 @@ def delete(
         optional: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-) -> HandlerDecorator:
+) -> ResourceHandlerDecorator:
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
+    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.DELETE, id=id, timeout=timeout,
@@ -113,10 +113,10 @@ def field(
         registry: Optional[registries.GlobalRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-) -> HandlerDecorator:
+) -> ResourceHandlerDecorator:
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
+    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id, timeout=timeout,
@@ -132,10 +132,10 @@ def event(
         registry: Optional[registries.GlobalRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-) -> HandlerDecorator:
+) -> ResourceHandlerDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
+    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         actual_registry.register_resource_watching_handler(
             group=group, version=version, plural=plural,
             id=id, fn=fn, labels=labels, annotations=annotations)
@@ -149,8 +149,8 @@ def this(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.SimpleRegistry] = None,
-) -> HandlerDecorator:
+        registry: Optional[registries.ResourceRegistry] = None,
+) -> ResourceHandlerDecorator:
     """
     ``@kopf.on.this()`` decorator for the dynamically generated sub-handlers.
 
@@ -181,19 +181,19 @@ def this(
     create function will have its own value, not the latest in the for-cycle.
     """
     actual_registry = registry if registry is not None else handling.subregistry_var.get()
-    def decorator(fn: registries.HandlerFn) -> registries.HandlerFn:
+    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         actual_registry.register(id=id, fn=fn, timeout=timeout)
         return fn
     return decorator
 
 
 def register(
-        fn: registries.HandlerFn,
+        fn: registries.ResourceHandlerFn,
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.SimpleRegistry] = None,
-) -> registries.HandlerFn:
+        registry: Optional[registries.ResourceRegistry] = None,
+) -> registries.ResourceHandlerFn:
     """
     Register a function as a sub-handler of the currently executed handler.
 

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -78,7 +78,7 @@ cause_var: ContextVar[causation.BaseCause] = ContextVar('cause_var')
 
 async def resource_handler(
         lifecycle: lifecycles.LifeCycleFn,
-        registry: registries.GlobalRegistry,
+        registry: registries.OperatorRegistry,
         resource: resources.Resource,
         event: bodies.Event,
         freeze: asyncio.Event,

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -76,7 +76,7 @@ handler_var: ContextVar[registries.Handler] = ContextVar('handler_var')
 cause_var: ContextVar[causation.BaseCause] = ContextVar('cause_var')
 
 
-async def custom_object_handler(
+async def resource_handler(
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.GlobalRegistry,
         resource: resources.Resource,

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -17,7 +17,7 @@ from kopf.reactor import lifecycles
 from kopf.reactor import registries
 from kopf.structs import dicts
 
-Invokable = Union[lifecycles.LifeCycleFn, registries.HandlerFn]
+Invokable = Union[lifecycles.LifeCycleFn, registries.ResourceHandlerFn]
 
 
 @contextlib.contextmanager

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -59,7 +59,7 @@ async def invoke(
     """
 
     # Add aliases for the kwargs, directly linked to the body, or to the assumed defaults.
-    if isinstance(cause, causation.EventWatchingCause):
+    if isinstance(cause, causation.ResourceWatchingCause):
         kwargs.update(
             event=cause.raw,
             patch=cause.patch,
@@ -73,7 +73,7 @@ async def invoke(
             name=cause.body.get('metadata', {}).get('name'),
             namespace=cause.body.get('metadata', {}).get('namespace'),
         )
-    if isinstance(cause, causation.StateChangingCause):
+    if isinstance(cause, causation.ResourceChangingCause):
         kwargs.update(
             cause=cause,
             event=cause.reason,  # deprecated; kept for backward-compatibility

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -8,7 +8,6 @@ and return the list of handlers in the order and amount to be executed.
 The default behaviour of the framework is the most simplistic:
 execute in the order they are registered, one by one.
 """
-
 import logging
 import random
 from typing import Sequence, Any, Optional
@@ -21,7 +20,7 @@ from kopf.structs import bodies
 
 logger = logging.getLogger(__name__)
 
-Handlers = Sequence[registries.Handler]
+Handlers = Sequence[registries.ResourceHandler]
 
 
 class LifeCycleFn(Protocol):

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -309,7 +309,7 @@ def get_callable_id(c: ResourceHandlerFn) -> str:
         raise ValueError(f"Cannot get id of {c!r}.")
 
 
-class GlobalRegistry(BaseRegistry):
+class OperatorRegistry(BaseRegistry):
     """
     A global registry is used for handling of the multiple resources.
     It is usually populated by the `@kopf.on...` decorators.
@@ -455,10 +455,10 @@ class GlobalRegistry(BaseRegistry):
         return self.has_resource_watching_handlers(*args, **kwargs)
 
 
-_default_registry: GlobalRegistry = GlobalRegistry()
+_default_registry: OperatorRegistry = OperatorRegistry()
 
 
-def get_default_registry() -> GlobalRegistry:
+def get_default_registry() -> OperatorRegistry:
     """
     Get the default registry to be used by the decorators and the reactor
     unless the explicit registry is provided to them.
@@ -466,7 +466,7 @@ def get_default_registry() -> GlobalRegistry:
     return _default_registry
 
 
-def set_default_registry(registry: GlobalRegistry) -> None:
+def set_default_registry(registry: OperatorRegistry) -> None:
     """
     Set the default registry to be used by the decorators and the reactor
     unless the explicit registry is provided to them.

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 def run(
         loop: Optional[asyncio.AbstractEventLoop] = None,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         standalone: bool = False,
         priority: int = 0,
         peering_name: Optional[str] = None,
@@ -58,7 +58,7 @@ def run(
 
 async def operator(
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         standalone: bool = False,
         priority: int = 0,
         peering_name: Optional[str] = None,
@@ -90,7 +90,7 @@ async def operator(
 
 async def spawn_tasks(
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
-        registry: Optional[registries.GlobalRegistry] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
         standalone: bool = False,
         priority: int = 0,
         peering_name: Optional[str] = None,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -153,7 +153,7 @@ async def spawn_tasks(
             loop.create_task(_root_task_checker(f"watcher of {resource.name}", queueing.watcher(
                 namespace=namespace,
                 resource=resource,
-                handler=functools.partial(handling.custom_object_handler,
+                handler=functools.partial(handling.resource_handler,
                                           lifecycle=lifecycle,
                                           registry=registry,
                                           resource=resource,

--- a/kopf/reactor/state.py
+++ b/kopf/reactor/state.py
@@ -62,7 +62,7 @@ from kopf.structs import patches
 def is_started(
         *,
         body: bodies.Body,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
 ) -> bool:
     progress = body.get('status', {}).get('kopf', {}).get('progress', {})
     return handler.id in progress
@@ -71,7 +71,7 @@ def is_started(
 def is_sleeping(
         *,
         body: bodies.Body,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
 ) -> bool:
     ts = get_awake_time(body=body, handler=handler)
     finished = is_finished(body=body, handler=handler)
@@ -81,7 +81,7 @@ def is_sleeping(
 def is_awakened(
         *,
         body: bodies.Body,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
 ) -> bool:
     finished = is_finished(body=body, handler=handler)
     sleeping = is_sleeping(body=body, handler=handler)
@@ -91,7 +91,7 @@ def is_awakened(
 def is_finished(
         *,
         body: bodies.Body,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
 ) -> bool:
     progress = body.get('status', {}).get('kopf', {}).get('progress', {})
     success = progress.get(handler.id, {}).get('success', None)
@@ -103,7 +103,7 @@ def get_start_time(
         *,
         body: bodies.Body,
         patch: patches.Patch,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
 ) -> Optional[datetime.datetime]:
     progress = patch.get('status', {}).get('kopf', {}).get('progress', {})
     new_value = progress.get(handler.id, {}).get('started', None)
@@ -116,7 +116,7 @@ def get_start_time(
 def get_awake_time(
         *,
         body: bodies.Body,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
 ) -> Optional[datetime.datetime]:
     progress = body.get('status', {}).get('kopf', {}).get('progress', {})
     value = progress.get(handler.id, {}).get('delayed', None)
@@ -126,7 +126,7 @@ def get_awake_time(
 def get_retry_count(
         *,
         body: bodies.Body,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
 ) -> int:
     progress = body.get('status', {}).get('kopf', {}).get('progress', {})
     return progress.get(handler.id, {}).get('retries', None) or 0
@@ -136,7 +136,7 @@ def set_start_time(
         *,
         body: bodies.Body,
         patch: patches.Patch,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
 ) -> None:
     progress = patch.setdefault('status', {}).setdefault('kopf', {}).setdefault('progress', {})
     progress.setdefault(handler.id, {}).update({
@@ -148,7 +148,7 @@ def set_awake_time(
         *,
         body: bodies.Body,
         patch: patches.Patch,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
         delay: Optional[float] = None,
 ) -> None:
     ts_str: Optional[str]
@@ -167,7 +167,7 @@ def set_retry_time(
         *,
         body: bodies.Body,
         patch: patches.Patch,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
         delay: Optional[float] = None,
 ) -> None:
     retry = get_retry_count(body=body, handler=handler)
@@ -182,7 +182,7 @@ def store_failure(
         *,
         body: bodies.Body,
         patch: patches.Patch,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
         exc: BaseException,
 ) -> None:
     retry = get_retry_count(body=body, handler=handler)
@@ -199,7 +199,7 @@ def store_success(
         *,
         body: bodies.Body,
         patch: patches.Patch,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
         result: Any = None,
 ) -> None:
     retry = get_retry_count(body=body, handler=handler)
@@ -216,7 +216,7 @@ def store_success(
 def store_result(
         *,
         patch: patches.Patch,
-        handler: registries.Handler,
+        handler: registries.ResourceHandler,
         result: Any = None,
 ) -> None:
     if result is None:

--- a/kopf/structs/lastseen.py
+++ b/kopf/structs/lastseen.py
@@ -26,7 +26,7 @@ LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 """ The annotation name for the last stored state of the resource. """
 
 
-def get_state(
+def get_essence(
         body: bodies.Body,
         extra_fields: Optional[Iterable[dicts.FieldSpec]] = None,
 ) -> bodies.BodyEssence:
@@ -98,12 +98,12 @@ def get_essential_diffs(
         body: bodies.Body,
         extra_fields: Optional[Iterable[dicts.FieldSpec]] = None,
 ) -> Tuple[Optional[bodies.BodyEssence], Optional[bodies.BodyEssence], diffs.Diff]:
-    old: Optional[bodies.BodyEssence] = retreive_essence(body)
-    new: Optional[bodies.BodyEssence] = get_state(body, extra_fields=extra_fields)
+    old: Optional[bodies.BodyEssence] = retrieve_essence(body)
+    new: Optional[bodies.BodyEssence] = get_essence(body, extra_fields=extra_fields)
     return old, new, diffs.diff(old, new)
 
 
-def retreive_essence(
+def retrieve_essence(
         body: bodies.Body,
 ) -> Optional[bodies.BodyEssence]:
     if not has_essence_stored(body):
@@ -119,5 +119,5 @@ def refresh_essence(
         patch: patches.Patch,
         extra_fields: Optional[Iterable[dicts.FieldSpec]] = None,
 ) -> None:
-    state = get_state(body, extra_fields=extra_fields)
+    state = get_essence(body, extra_fields=extra_fields)
     patch.setdefault('metadata', {}).setdefault('annotations', {})[LAST_SEEN_ANNOTATION] = json.dumps(state)

--- a/tests/basic-structs/test_cause.py
+++ b/tests/basic-structs/test_cause.py
@@ -1,11 +1,11 @@
 import pytest
 
-from kopf.reactor.causation import StateChangingCause
+from kopf.reactor.causation import ResourceChangingCause
 
 
 def test_no_args():
     with pytest.raises(TypeError):
-        StateChangingCause()
+        ResourceChangingCause()
 
 
 def test_all_args(mocker):
@@ -18,7 +18,7 @@ def test_all_args(mocker):
     diff = mocker.Mock()
     old = mocker.Mock()
     new = mocker.Mock()
-    cause = StateChangingCause(
+    cause = ResourceChangingCause(
         resource=resource,
         logger=logger,
         reason=reason,
@@ -48,7 +48,7 @@ def test_required_args(mocker):
     initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
-    cause = StateChangingCause(
+    cause = ResourceChangingCause(
         resource=resource,
         logger=logger,
         reason=reason,

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -1,11 +1,11 @@
 import pytest
 
-from kopf.reactor.registries import Handler
+from kopf.reactor.registries import ResourceHandler
 
 
 def test_no_args():
     with pytest.raises(TypeError):
-        Handler()
+        ResourceHandler()
 
 
 def test_all_args(mocker):
@@ -17,7 +17,7 @@ def test_all_args(mocker):
     initial = mocker.Mock()
     labels = mocker.Mock()
     annotations = mocker.Mock()
-    handler = Handler(
+    handler = ResourceHandler(
         fn=fn,
         id=id,
         reason=reason,

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from kopf.reactor.causation import Reason, detect_state_changing_cause
+from kopf.reactor.causation import Reason, detect_resource_changing_cause
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 
@@ -137,7 +137,7 @@ def test_for_gone(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         **kwargs)
@@ -153,7 +153,7 @@ def test_for_free(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         **kwargs)
@@ -169,7 +169,7 @@ def test_for_delete(kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         **kwargs)
@@ -185,7 +185,7 @@ def test_for_acquire(kwargs, event, finalizers, deletion_ts, requires_finalizer)
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         **kwargs)
@@ -201,7 +201,7 @@ def test_for_release(kwargs, event, finalizers, deletion_ts, requires_finalizer)
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         **kwargs)
@@ -220,7 +220,7 @@ def test_for_create(kwargs, event, finalizers, deletion_ts, annotations, content
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         **kwargs)
@@ -236,7 +236,7 @@ def test_for_create_skip_acquire(kwargs, event, finalizers, deletion_ts, require
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         **kwargs)
@@ -255,7 +255,7 @@ def test_for_no_op(kwargs, event, finalizers, deletion_ts, annotations, content,
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         **kwargs)
@@ -274,7 +274,7 @@ def test_for_update(kwargs, event, finalizers, deletion_ts, annotations, content
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_state_changing_cause(
+    cause = detect_resource_changing_cause(
         event=event,
         requires_finalizer=requires_finalizer,
         diff=True,

--- a/tests/cli/test_preloading.py
+++ b/tests/cli/test_preloading.py
@@ -16,7 +16,7 @@ def test_one_file(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._cause_handlers[resource]._handlers
+    handlers = registry._resource_changing_handlers[resource]._handlers
     assert len(handlers) == 1
     assert handlers[0].id == 'create_fn'
 
@@ -28,7 +28,7 @@ def test_two_files(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._cause_handlers[resource]._handlers
+    handlers = registry._resource_changing_handlers[resource]._handlers
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'
@@ -41,7 +41,7 @@ def test_one_module(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._cause_handlers[resource]._handlers
+    handlers = registry._resource_changing_handlers[resource]._handlers
     assert len(handlers) == 1
     assert handlers[0].id == 'create_fn'
 
@@ -53,7 +53,7 @@ def test_two_modules(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._cause_handlers[resource]._handlers
+    handlers = registry._resource_changing_handlers[resource]._handlers
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'
@@ -66,7 +66,7 @@ def test_mixed_sources(invoke, login, real_run):
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
     resource = list(registry.resources)[0]
-    handlers = registry._cause_handlers[resource]._handlers
+    handlers = registry._resource_changing_handlers[resource]._handlers
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def clear_default_registry():
     Ensure that the tests have a fresh new global (not re-used) registry.
     """
     old_registry = kopf.get_default_registry()
-    new_registry = kopf.GlobalRegistry()
+    new_registry = kopf.OperatorRegistry()
     kopf.set_default_registry(new_registry)
     try:
         yield new_registry

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -41,7 +41,7 @@ from unittest.mock import Mock
 import pytest
 
 import kopf
-from kopf.reactor.causation import StateChangingCause, Reason
+from kopf.reactor.causation import ResourceChangingCause, Reason
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
@@ -192,7 +192,7 @@ def cause_mock(mocker, resource):
 
         # Pass through kwargs: resource, logger, patch, diff, old, new.
         # I.e. everything except what we mock: reason & body.
-        cause = StateChangingCause(
+        cause = ResourceChangingCause(
             reason=reason,
             initial=initial,
             body=body,
@@ -211,7 +211,7 @@ def cause_mock(mocker, resource):
         return cause
 
     # Substitute the real cause detector with out own mock-based one.
-    mocker.patch('kopf.reactor.causation.detect_state_changing_cause', new=new_detect_fn)
+    mocker.patch('kopf.reactor.causation.detect_resource_changing_cause', new=new_detect_fn)
 
     # The mock object stores some values later used by the factory substitute.
     mock = mocker.Mock(spec_set=['reason', 'body', 'diff', 'new', 'old'])

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -3,7 +3,7 @@ import logging
 
 import kopf
 from kopf.reactor.causation import Reason
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 
@@ -14,7 +14,7 @@ async def test_acquire(registry, handlers, resource, cause_mock,
     cause_mock.reason = Reason.ACQUIRE
 
     event_queue = asyncio.Queue()
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -50,7 +50,7 @@ async def test_create(registry, handlers, resource, cause_mock,
     cause_mock.reason = Reason.CREATE
 
     event_queue = asyncio.Queue()
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -93,7 +93,7 @@ async def test_update(registry, handlers, resource, cause_mock,
     cause_mock.reason = Reason.UPDATE
 
     event_queue = asyncio.Queue()
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -136,7 +136,7 @@ async def test_delete(registry, handlers, resource, cause_mock,
     cause_mock.reason = Reason.DELETE
 
     event_queue = asyncio.Queue()
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -187,7 +187,7 @@ async def test_release(registry, resource, handlers, cause_mock, caplog, k8s_moc
     )
 
     event_queue = asyncio.Queue()
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -227,7 +227,7 @@ async def test_gone(registry, handlers, resource, cause_mock,
     cause_mock.reason = Reason.GONE
 
     event_queue = asyncio.Queue()
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -257,7 +257,7 @@ async def test_free(registry, handlers, resource, cause_mock,
     cause_mock.reason = Reason.FREE
 
     event_queue = asyncio.Queue()
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -287,7 +287,7 @@ async def test_noop(registry, handlers, resource, cause_mock,
     cause_mock.reason = Reason.NOOP
 
     event_queue = asyncio.Queue()
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -177,7 +177,7 @@ async def test_release(registry, resource, handlers, cause_mock, caplog, k8s_moc
     cause_mock.body.setdefault('metadata', {})['finalizers'] = [FINALIZER]
 
     # register handlers (no deletion handlers)
-    registry.register_state_changing_handler(
+    registry.register_resource_changing_handler(
         group=resource.group,
         version=resource.version,
         plural=resource.plural,

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import ALL_REASONS, HANDLER_REASONS
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)
@@ -13,7 +13,7 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
                                      logstream, cause_type, cause_mock):
     cause_mock.reason = cause_type
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -42,7 +42,7 @@ async def test_diffs_logged_if_present(registry, resource, handlers, cause_type,
     cause_mock.new = object()  # checked for `not None`
     cause_mock.old = object()  # checked for `not None`
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -64,7 +64,7 @@ async def test_diffs_not_logged_if_absent(registry, resource, handlers, cause_ty
     cause_mock.reason = cause_type
     cause_mock.diff = None  # same as the default, but for clarity
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -8,7 +8,7 @@ import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import TemporaryError
 from kopf.reactor.handling import WAITING_KEEPALIVE_INTERVAL
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 from kopf.structs.finalizers import FINALIZER
 
 
@@ -29,7 +29,7 @@ async def test_delayed_handlers_progress(
     cause_mock.reason = cause_reason
 
     with freezegun.freeze_time(now):
-        await custom_object_handler(
+        await resource_handler(
             lifecycle=kopf.lifecycles.all_at_once,
             registry=registry,
             resource=resource,
@@ -80,7 +80,7 @@ async def test_delayed_handlers_sleep(
     cause_mock.body.setdefault('metadata', {})['finalizers'] = [FINALIZER]
 
     with freezegun.freeze_time(now):
-        await custom_object_handler(
+        await resource_handler(
             lifecycle=kopf.lifecycles.all_at_once,
             registry=registry,
             resource=resource,

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -6,7 +6,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import PermanentError, TemporaryError
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
@@ -23,7 +23,7 @@ async def test_fatal_error_stops_handler(
     handlers.delete_mock.side_effect = PermanentError("oops")
     handlers.resume_mock.side_effect = PermanentError("oops")
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,
@@ -65,7 +65,7 @@ async def test_retry_error_delays_handler(
     handlers.delete_mock.side_effect = TemporaryError("oops")
     handlers.resume_mock.side_effect = TemporaryError("oops")
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,
@@ -108,7 +108,7 @@ async def test_arbitrary_error_delays_handler(
     handlers.delete_mock.side_effect = Exception("oops")
     handlers.resume_mock.side_effect = Exception("oops")
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import ALL_REASONS
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)
@@ -15,7 +15,7 @@ async def test_handlers_called_always(
     caplog.set_level(logging.DEBUG)
     cause_mock.reason = cause_type
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -50,7 +50,7 @@ async def test_errors_are_ignored(
     cause_mock.reason = cause_type
     handlers.event_mock.side_effect = Exception("oops")
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -7,8 +7,8 @@ from kopf.reactor.registries import GlobalRegistry
 
 
 async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, assert_logs):
-    detect_state_changing_cause = mocker.patch('kopf.reactor.causation.detect_state_changing_cause')
-    handle_cause = mocker.patch('kopf.reactor.handling.handle_state_changing_cause')
+    detect_cause = mocker.patch('kopf.reactor.causation.detect_resource_changing_cause')
+    handle_cause = mocker.patch('kopf.reactor.handling.handle_resource_changing_cause')
     patch_obj = mocker.patch('kopf.clients.patching.patch_obj')
     asyncio_sleep = mocker.patch('asyncio.sleep')
 
@@ -33,7 +33,7 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
         event_queue=asyncio.Queue(),
     )
 
-    assert not detect_state_changing_cause.called
+    assert not detect_cause.called
     assert not handle_cause.called
     assert not patch_obj.called
     assert not asyncio_sleep.called

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -3,7 +3,7 @@ import logging
 
 import kopf
 from kopf.reactor.handling import resource_handler
-from kopf.reactor.registries import GlobalRegistry
+from kopf.reactor.registries import OperatorRegistry
 
 
 async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, assert_logs):
@@ -15,7 +15,7 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
     # Nothing of these is actually used, but we need to feed something.
     # Except for namespace+name, which are used for the logger prefixes.
     lifecycle = kopf.lifecycles.all_at_once
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     event = {'object': {'metadata': {'namespace': 'ns1', 'name': 'name1'}}}
 
     # This is what makes it frozen.

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 import kopf
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 from kopf.reactor.registries import GlobalRegistry
 
 
@@ -23,7 +23,7 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
     freeze.set()
 
     caplog.set_level(logging.DEBUG)
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=lifecycle,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -4,7 +4,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 
 
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
@@ -16,7 +16,7 @@ async def test_1st_step_stores_progress_by_patching(
 
     cause_mock.reason = cause_type
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.asap,
         registry=registry,
         resource=resource,
@@ -62,7 +62,7 @@ async def test_2nd_step_finishes_the_handlers(
         }}}
     })
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 
 
@@ -26,7 +26,7 @@ async def test_skipped_with_no_handlers(
     )
     assert registry.has_state_changing_handlers(resource=resource)  # prerequisite
 
-    await custom_object_handler(
+    await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -16,15 +16,15 @@ async def test_skipped_with_no_handlers(
     caplog.set_level(logging.DEBUG)
     cause_mock.reason = cause_type
 
-    assert not registry.has_state_changing_handlers(resource=resource)  # prerequisite
-    registry.register_state_changing_handler(
+    assert not registry.has_resource_changing_handlers(resource=resource)  # prerequisite
+    registry.register_resource_changing_handler(
         group=resource.group,
         version=resource.version,
         plural=resource.plural,
         reason='a-non-existent-cause-type',
         fn=lambda **_: None,
     )
-    assert registry.has_state_changing_handlers(resource=resource)  # prerequisite
+    assert registry.has_resource_changing_handlers(resource=resource)  # prerequisite
 
     await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,

--- a/tests/handling/test_timeouts.py
+++ b/tests/handling/test_timeouts.py
@@ -6,7 +6,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS
-from kopf.reactor.handling import custom_object_handler
+from kopf.reactor.handling import resource_handler
 
 
 # The timeout is hard-coded in conftest.py:handlers().
@@ -32,7 +32,7 @@ async def test_timed_out_handler_fails(
     })
 
     with freezegun.freeze_time(now):
-        await custom_object_handler(
+        await resource_handler(
             lifecycle=kopf.lifecycles.one_by_one,
             registry=registry,
             resource=resource,

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import Reason, StateChangingCause, EventWatchingCause
+from kopf.reactor.causation import Reason, ResourceChangingCause, ResourceWatchingCause
 from kopf.reactor.handling import cause_var
 from kopf.reactor.invocation import context
 from kopf.structs.bodies import Body, Meta, Labels, Event
@@ -30,7 +30,7 @@ OWNER = Body(
 @pytest.fixture(params=['state-changing-cause', 'event-watching-cause'])
 def owner(request, resource):
     if request.param == 'state-changing-cause':
-        cause = StateChangingCause(
+        cause = ResourceChangingCause(
             logger=logging.getLogger('kopf.test.fake.logger'),
             resource=resource,
             patch=Patch(),
@@ -41,7 +41,7 @@ def owner(request, resource):
         with context([(cause_var, cause)]):
             yield
     elif request.param == 'event-watching-cause':
-        cause = EventWatchingCause(
+        cause = ResourceWatchingCause(
             logger=logging.getLogger('kopf.test.fake.logger'),
             resource=resource,
             patch=Patch(),

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -5,7 +5,7 @@ import traceback
 import pytest
 from asynctest import MagicMock
 
-from kopf.reactor.causation import StateChangingCause, Reason
+from kopf.reactor.causation import ResourceChangingCause, Reason
 from kopf.reactor.invocation import invoke, is_async_fn
 from kopf.structs.patches import Patch
 
@@ -167,7 +167,7 @@ async def test_special_kwargs_added(fn, resource):
             'status': {'info': 'payload'}}
 
     # Values can be any.
-    cause = StateChangingCause(
+    cause = ResourceChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         resource=resource,
         patch=Patch(),

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import StateChangingCause, Reason
+from kopf.reactor.causation import ResourceChangingCause, Reason
 from kopf.reactor.invocation import invoke
 from kopf.structs.bodies import Body
 from kopf.structs.patches import Patch
@@ -22,7 +22,7 @@ async def test_protocol_invocation(lifecycle, resource):
     Especially when the new kwargs are added or an invocation protocol changed.
     """
     # The values are irrelevant, they can be anything.
-    cause = StateChangingCause(
+    cause = ResourceChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         resource=resource,
         patch=Patch(),

--- a/tests/registries/test_creation.py
+++ b/tests/registries/test_creation.py
@@ -1,20 +1,20 @@
-from kopf import BaseRegistry, SimpleRegistry, GlobalRegistry
+from kopf import BaseRegistry, ResourceRegistry, GlobalRegistry
 
 
 def test_creation_of_simple_no_prefix():
-    registry = SimpleRegistry()
+    registry = ResourceRegistry()
     assert isinstance(registry, BaseRegistry)
-    assert isinstance(registry, SimpleRegistry)
+    assert isinstance(registry, ResourceRegistry)
     assert registry.prefix is None
 
 
 def test_creation_of_simple_with_prefix_argument():
-    registry = SimpleRegistry('hello')
+    registry = ResourceRegistry('hello')
     assert registry.prefix == 'hello'
 
 
 def test_creation_of_simple_with_prefix_keyword():
-    registry = SimpleRegistry(prefix='hello')
+    registry = ResourceRegistry(prefix='hello')
     assert registry.prefix == 'hello'
 
 

--- a/tests/registries/test_creation.py
+++ b/tests/registries/test_creation.py
@@ -1,4 +1,4 @@
-from kopf import BaseRegistry, ResourceRegistry, GlobalRegistry
+from kopf import BaseRegistry, ResourceRegistry, OperatorRegistry
 
 
 def test_creation_of_simple_no_prefix():
@@ -19,6 +19,6 @@ def test_creation_of_simple_with_prefix_keyword():
 
 
 def test_creation_of_global():
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     assert isinstance(registry, BaseRegistry)
-    assert isinstance(registry, GlobalRegistry)
+    assert isinstance(registry, OperatorRegistry)

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -3,7 +3,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import Reason
 from kopf.reactor.handling import subregistry_var
-from kopf.reactor.registries import SimpleRegistry, GlobalRegistry
+from kopf.reactor.registries import ResourceRegistry, GlobalRegistry
 from kopf.structs.resources import Resource
 
 
@@ -195,7 +195,7 @@ def test_on_field_with_all_kwargs(mocker):
 def test_subhandler_declaratively(mocker):
     cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
 
-    registry = SimpleRegistry()
+    registry = ResourceRegistry()
     subregistry_var.set(registry)
 
     @kopf.on.this()
@@ -210,7 +210,7 @@ def test_subhandler_declaratively(mocker):
 def test_subhandler_imperatively(mocker):
     cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
 
-    registry = SimpleRegistry()
+    registry = ResourceRegistry()
     subregistry_var.set(registry)
 
     def fn(**_):

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -3,7 +3,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import Reason
 from kopf.reactor.handling import subregistry_var
-from kopf.reactor.registries import ResourceRegistry, GlobalRegistry
+from kopf.reactor.registries import ResourceRegistry, OperatorRegistry
 from kopf.structs.resources import Resource
 
 
@@ -92,7 +92,7 @@ def test_on_field_fails_without_field():
 
 
 def test_on_create_with_all_kwargs(mocker):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
@@ -116,7 +116,7 @@ def test_on_create_with_all_kwargs(mocker):
 
 
 def test_on_update_with_all_kwargs(mocker):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
@@ -144,7 +144,7 @@ def test_on_update_with_all_kwargs(mocker):
     pytest.param(False, id='mandatory'),
 ])
 def test_on_delete_with_all_kwargs(mocker, optional):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
@@ -168,7 +168,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
 
 
 def test_on_field_with_all_kwargs(mocker):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -16,7 +16,7 @@ def test_on_create_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.CREATE
@@ -35,7 +35,7 @@ def test_on_update_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.UPDATE
@@ -54,7 +54,7 @@ def test_on_delete_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.DELETE
@@ -74,7 +74,7 @@ def test_on_field_minimal(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
@@ -104,7 +104,7 @@ def test_on_create_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.CREATE
@@ -128,7 +128,7 @@ def test_on_update_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.UPDATE
@@ -156,7 +156,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.DELETE
@@ -181,7 +181,7 @@ def test_on_field_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
@@ -202,7 +202,7 @@ def test_subhandler_declaratively(mocker):
     def fn(**_):
         pass
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
 
@@ -217,6 +217,6 @@ def test_subhandler_imperatively(mocker):
         pass
     kopf.register(fn)
 
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn

--- a/tests/registries/test_default_registry.py
+++ b/tests/registries/test_default_registry.py
@@ -3,11 +3,11 @@ import kopf
 
 def test_getting_default_registry():
     registry = kopf.get_default_registry()
-    assert isinstance(registry, kopf.GlobalRegistry)
+    assert isinstance(registry, kopf.OperatorRegistry)
 
 
 def test_setting_default_registry():
-    registry_expected = kopf.GlobalRegistry()
+    registry_expected = kopf.OperatorRegistry()
     kopf.set_default_registry(registry_expected)
     registry_actual = kopf.get_default_registry()
     assert registry_actual is registry_expected

--- a/tests/registries/test_global_registry.py
+++ b/tests/registries/test_global_registry.py
@@ -11,8 +11,8 @@ def some_fn():
 
 def test_resources():
     registry = GlobalRegistry()
-    registry.register_state_changing_handler('group1', 'version1', 'plural1', some_fn)
-    registry.register_state_changing_handler('group2', 'version2', 'plural2', some_fn)
+    registry.register_resource_changing_handler('group1', 'version1', 'plural1', some_fn)
+    registry.register_resource_changing_handler('group2', 'version2', 'plural2', some_fn)
 
     resources = registry.resources
 

--- a/tests/registries/test_global_registry.py
+++ b/tests/registries/test_global_registry.py
@@ -1,6 +1,6 @@
 import collections
 
-from kopf.reactor.registries import GlobalRegistry
+from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.resources import Resource
 
 
@@ -10,7 +10,7 @@ def some_fn():
 
 
 def test_resources():
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     registry.register_resource_changing_handler('group1', 'version1', 'plural1', some_fn)
     registry.register_resource_changing_handler('group2', 'version2', 'plural2', some_fn)
 

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from kopf import ResourceRegistry, GlobalRegistry
+from kopf import ResourceRegistry, OperatorRegistry
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.
@@ -13,7 +13,7 @@ def some_fn(x=None):
 
 @pytest.fixture(params=[
     pytest.param(ResourceRegistry, id='in-simple-registry'),
-    pytest.param(GlobalRegistry, id='in-global-registry'),
+    pytest.param(OperatorRegistry, id='in-global-registry'),
 ])
 def registry(request):
     return request.param()
@@ -23,7 +23,7 @@ def registry(request):
 def register_fn(registry, resource):
     if isinstance(registry, ResourceRegistry):
         return registry.register
-    if isinstance(registry, GlobalRegistry):
+    if isinstance(registry, OperatorRegistry):
         return functools.partial(registry.register_resource_changing_handler, resource.group, resource.version, resource.plural)
     raise Exception(f"Unsupported registry type: {registry}")
 

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from kopf import SimpleRegistry, GlobalRegistry
+from kopf import ResourceRegistry, GlobalRegistry
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.
@@ -12,7 +12,7 @@ def some_fn(x=None):
 
 
 @pytest.fixture(params=[
-    pytest.param(SimpleRegistry, id='in-simple-registry'),
+    pytest.param(ResourceRegistry, id='in-simple-registry'),
     pytest.param(GlobalRegistry, id='in-global-registry'),
 ])
 def registry(request):
@@ -21,7 +21,7 @@ def registry(request):
 
 @pytest.fixture()
 def register_fn(registry, resource):
-    if isinstance(registry, SimpleRegistry):
+    if isinstance(registry, ResourceRegistry):
         return registry.register
     if isinstance(registry, GlobalRegistry):
         return functools.partial(registry.register_resource_changing_handler, resource.group, resource.version, resource.plural)

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -24,7 +24,7 @@ def register_fn(registry, resource):
     if isinstance(registry, SimpleRegistry):
         return registry.register
     if isinstance(registry, GlobalRegistry):
-        return functools.partial(registry.register_state_changing_handler, resource.group, resource.version, resource.plural)
+        return functools.partial(registry.register_resource_changing_handler, resource.group, resource.version, resource.plural)
     raise Exception(f"Unsupported registry type: {registry}")
 
 
@@ -62,19 +62,19 @@ def cause_any_diff(resource, request):
 
 def test_catchall_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field=None)
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field='some-field')
-    handlers = registry.get_state_changing_handlers(cause_with_diff)
+    handlers = registry.get_resource_changing_handlers(cause_with_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field='some-field')
-    handlers = registry.get_state_changing_handlers(cause_no_diff)
+    handlers = registry.get_resource_changing_handlers(cause_no_diff)
     assert not handlers
 
 
@@ -85,7 +85,7 @@ def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_
 def test_catchall_handlers_with_labels_satisfied(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
 
@@ -97,7 +97,7 @@ def test_catchall_handlers_with_labels_satisfied(registry, register_fn, resource
 def test_catchall_handlers_with_labels_not_satisfied(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
 
@@ -108,7 +108,7 @@ def test_catchall_handlers_with_labels_not_satisfied(registry, register_fn, reso
 def test_catchall_handlers_with_labels_exist(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
 
@@ -119,7 +119,7 @@ def test_catchall_handlers_with_labels_exist(registry, register_fn, resource, la
 def test_catchall_handlers_with_labels_not_exist(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
 
@@ -133,7 +133,7 @@ def test_catchall_handlers_with_labels_not_exist(registry, register_fn, resource
 def test_catchall_handlers_without_labels(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels=None)
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
 
@@ -144,7 +144,7 @@ def test_catchall_handlers_without_labels(registry, register_fn, resource, label
 def test_catchall_handlers_with_annotations_satisfied(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
 
@@ -156,7 +156,7 @@ def test_catchall_handlers_with_annotations_satisfied(registry, register_fn, res
 def test_catchall_handlers_with_annotations_not_satisfied(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
 
@@ -167,7 +167,7 @@ def test_catchall_handlers_with_annotations_not_satisfied(registry, register_fn,
 def test_catchall_handlers_with_annotations_exist(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
 
@@ -178,7 +178,7 @@ def test_catchall_handlers_with_annotations_exist(registry, register_fn, resourc
 def test_catchall_handlers_with_annotations_not_exist(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
 
@@ -192,7 +192,7 @@ def test_catchall_handlers_with_annotations_not_exist(registry, register_fn, res
 def test_catchall_handlers_without_annotations(registry, register_fn, resource, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations=None)
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
 
@@ -205,7 +205,7 @@ def test_catchall_handlers_without_annotations(registry, register_fn, resource, 
 def test_catchall_handlers_with_labels_and_annotations_satisfied(registry, register_fn, resource, labels, annotations):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels, 'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
 
@@ -219,7 +219,7 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(registry, regis
 def test_catchall_handlers_with_labels_and_annotations_not_satisfied(registry, register_fn, resource, labels):
     cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
 
@@ -232,78 +232,78 @@ def test_catchall_handlers_with_labels_and_annotations_not_satisfied(registry, r
 
 def test_relevant_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason')
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', field='some-field')
-    handlers = registry.get_state_changing_handlers(cause_with_diff)
+    handlers = registry.get_resource_changing_handlers(cause_with_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', field='some-field')
-    handlers = registry.get_state_changing_handlers(cause_no_diff)
+    handlers = registry.get_resource_changing_handlers(cause_no_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', labels={'somelabel': None})
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', labels={'otherlabel': None})
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', annotations={'someannotation': None})
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', annotations={'otherannotation': None})
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_without_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason')
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', field='another-field')
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 def test_irrelevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', labels={'somelabel': None})
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', labels={'otherlabel': None})
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', annotations={'someannotation': None})
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', annotations={'otherannotation': None})
-    handlers = registry.get_state_changing_handlers(cause_any_diff)
+    handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
@@ -319,7 +319,7 @@ def test_order_persisted_a(cause_with_diff, registry, register_fn):
     register_fn(functools.partial(some_fn, 4), reason=None, field='filtered-out-reason')
     register_fn(functools.partial(some_fn, 5), reason=None, field='some-field')
 
-    handlers = registry.get_state_changing_handlers(cause_with_diff)
+    handlers = registry.get_resource_changing_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
     assert len(handlers) == 3
@@ -338,7 +338,7 @@ def test_order_persisted_b(cause_with_diff, registry, register_fn):
     register_fn(functools.partial(some_fn, 4), reason='some-reason')
     register_fn(functools.partial(some_fn, 5), reason=None)
 
-    handlers = registry.get_state_changing_handlers(cause_with_diff)
+    handlers = registry.get_resource_changing_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
     assert len(handlers) == 3
@@ -358,7 +358,7 @@ def test_deduplicated(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason=None, id='a')
     register_fn(some_fn, reason=None, id='b')
 
-    handlers = registry.get_state_changing_handlers(cause_with_diff)
+    handlers = registry.get_resource_changing_handlers(cause_with_diff)
 
     assert len(handlers) == 1
     assert handlers[0].id == 'a'  # the first found one is returned

--- a/tests/registries/test_id_detection.py
+++ b/tests/registries/test_id_detection.py
@@ -2,7 +2,7 @@ import functools
 
 import pytest
 
-from kopf import SimpleRegistry
+from kopf import ResourceRegistry
 from kopf.reactor.registries import get_callable_id
 
 
@@ -74,7 +74,7 @@ def test_id_of_lambda():
 def test_with_no_hints(mocker):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
 
-    registry = SimpleRegistry()
+    registry = ResourceRegistry()
     registry.register(some_fn)
     handlers = registry.get_resource_changing_handlers(mocker.MagicMock())
 
@@ -88,7 +88,7 @@ def test_with_no_hints(mocker):
 def test_with_prefix(mocker):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
 
-    registry = SimpleRegistry(prefix='some-prefix')
+    registry = ResourceRegistry(prefix='some-prefix')
     registry.register(some_fn)
     handlers = registry.get_resource_changing_handlers(mocker.MagicMock())
 
@@ -103,7 +103,7 @@ def test_with_suffix(mocker, field):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
-    registry = SimpleRegistry()
+    registry = ResourceRegistry()
     registry.register(some_fn, field=field)
     handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
 
@@ -118,7 +118,7 @@ def test_with_prefix_and_suffix(mocker, field):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
-    registry = SimpleRegistry(prefix='some-prefix')
+    registry = ResourceRegistry(prefix='some-prefix')
     registry.register(some_fn, field=field)
     handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
 
@@ -133,7 +133,7 @@ def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
-    registry = SimpleRegistry(prefix='some-prefix')
+    registry = ResourceRegistry(prefix='some-prefix')
     registry.register(some_fn, id='explicit-id', field=field)
     handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
 

--- a/tests/registries/test_id_detection.py
+++ b/tests/registries/test_id_detection.py
@@ -76,7 +76,7 @@ def test_with_no_hints(mocker):
 
     registry = SimpleRegistry()
     registry.register(some_fn)
-    handlers = registry.get_state_changing_handlers(mocker.MagicMock())
+    handlers = registry.get_resource_changing_handlers(mocker.MagicMock())
 
     assert get_fn_id.called
 
@@ -90,7 +90,7 @@ def test_with_prefix(mocker):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn)
-    handlers = registry.get_state_changing_handlers(mocker.MagicMock())
+    handlers = registry.get_resource_changing_handlers(mocker.MagicMock())
 
     assert get_fn_id.called
 
@@ -105,7 +105,7 @@ def test_with_suffix(mocker, field):
 
     registry = SimpleRegistry()
     registry.register(some_fn, field=field)
-    handlers = registry.get_state_changing_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -120,7 +120,7 @@ def test_with_prefix_and_suffix(mocker, field):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn, field=field)
-    handlers = registry.get_state_changing_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -135,7 +135,7 @@ def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
 
     registry = SimpleRegistry(prefix='some-prefix')
     registry.register(some_fn, id='explicit-id', field=field)
-    handlers = registry.get_state_changing_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
 
     assert not get_fn_id.called
 

--- a/tests/registries/test_registering.py
+++ b/tests/registries/test_registering.py
@@ -1,6 +1,6 @@
 import collections.abc
 
-from kopf import SimpleRegistry, GlobalRegistry
+from kopf import ResourceRegistry, GlobalRegistry
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.
@@ -11,7 +11,7 @@ def some_fn():
 def test_simple_registry_via_iter(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = SimpleRegistry()
+    registry = ResourceRegistry()
     iterator = registry.iter_resource_changing_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
@@ -26,7 +26,7 @@ def test_simple_registry_via_iter(mocker):
 def test_simple_registry_via_list(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = SimpleRegistry()
+    registry = ResourceRegistry()
     handlers = registry.get_resource_changing_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -38,7 +38,7 @@ def test_simple_registry_via_list(mocker):
 def test_simple_registry_with_minimal_signature(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = SimpleRegistry()
+    registry = ResourceRegistry()
     registry.register(some_fn)
     handlers = registry.get_resource_changing_handlers(cause)
 

--- a/tests/registries/test_registering.py
+++ b/tests/registries/test_registering.py
@@ -1,6 +1,6 @@
 import collections.abc
 
-from kopf import ResourceRegistry, GlobalRegistry
+from kopf import ResourceRegistry, OperatorRegistry
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.
@@ -49,7 +49,7 @@ def test_simple_registry_with_minimal_signature(mocker):
 def test_global_registry_via_iter(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     iterator = registry.iter_resource_changing_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
@@ -64,7 +64,7 @@ def test_global_registry_via_iter(mocker, resource):
 def test_global_registry_via_list(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     handlers = registry.get_resource_changing_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -76,7 +76,7 @@ def test_global_registry_via_list(mocker, resource):
 def test_global_registry_with_minimal_signature(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     registry.register_resource_changing_handler(resource.group, resource.version, resource.plural, some_fn)
     handlers = registry.get_resource_changing_handlers(cause)
 

--- a/tests/registries/test_registering.py
+++ b/tests/registries/test_registering.py
@@ -12,7 +12,7 @@ def test_simple_registry_via_iter(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
     registry = SimpleRegistry()
-    iterator = registry.iter_state_changing_handlers(cause)
+    iterator = registry.iter_resource_changing_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -27,7 +27,7 @@ def test_simple_registry_via_list(mocker):
     cause = mocker.Mock(event=None, diff=None)
 
     registry = SimpleRegistry()
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -40,7 +40,7 @@ def test_simple_registry_with_minimal_signature(mocker):
 
     registry = SimpleRegistry()
     registry.register(some_fn)
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn
@@ -50,7 +50,7 @@ def test_global_registry_via_iter(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    iterator = registry.iter_state_changing_handlers(cause)
+    iterator = registry.iter_resource_changing_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -65,7 +65,7 @@ def test_global_registry_via_list(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    handlers = registry.get_state_changing_handlers(cause)
+    handlers = registry.get_resource_changing_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -77,8 +77,8 @@ def test_global_registry_with_minimal_signature(mocker, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
     registry = GlobalRegistry()
-    registry.register_state_changing_handler(resource.group, resource.version, resource.plural, some_fn)
-    handlers = registry.get_state_changing_handlers(cause)
+    registry.register_resource_changing_handler(resource.group, resource.version, resource.plural, some_fn)
+    handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn

--- a/tests/registries/test_requires_finalizer.py
+++ b/tests/registries/test_requires_finalizer.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.reactor.registries import GlobalRegistry
+from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.resources import Resource
 
 OBJECT_BODY = {
@@ -24,7 +24,7 @@ OBJECT_BODY = {
     pytest.param(False, True, id='mandatory'),
 ])
 def test_requires_finalizer_deletion_handler(optional, expected):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
 
     @kopf.on.delete('group', 'version', 'plural',
@@ -41,7 +41,7 @@ def test_requires_finalizer_deletion_handler(optional, expected):
     pytest.param(False, True, id='mandatory'),
 ])
 def test_requires_finalizer_multiple_handlers(optional, expected):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
 
     @kopf.on.create('group', 'version', 'plural',
@@ -59,7 +59,7 @@ def test_requires_finalizer_multiple_handlers(optional, expected):
 
 
 def test_requires_finalizer_no_deletion_handler():
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
 
     @kopf.on.create('group', 'version', 'plural',
@@ -80,7 +80,7 @@ def test_requires_finalizer_no_deletion_handler():
     pytest.param({'key': None}, id='key-exists'),
 ])
 def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, expected):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
 
     @kopf.on.delete('group', 'version', 'plural',
@@ -102,7 +102,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
     pytest.param({'otherkey': None}, id='key-doesnt-exist'),
 ])
 def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional, expected):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
 
     @kopf.on.delete('group', 'version', 'plural',
@@ -124,7 +124,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
     pytest.param({'key': None}, id='key-exists'),
 ])
 def test_requires_finalizer_deletion_handler_matches_annotations(annotations, optional, expected):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
 
     @kopf.on.delete('group', 'version', 'plural',
@@ -146,7 +146,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
     pytest.param({'otherkey': None}, id='key-doesnt-exist'),
 ])
 def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations, optional, expected):
-    registry = GlobalRegistry()
+    registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
 
     @kopf.on.delete('group', 'version', 'plural',


### PR DESCRIPTION
Code refactoring (part 1 of 3): terminology fixes and look-ahead alignments.

> Issue : preparation for #59 #187 #142

## Description

This PR is purely for **renaming** the classes and methods _(massive, but simple)_ — a part of the code refactoring needed to extend Kopf with the startup/cleanup/(re-)authentication background activities.

Adding "activities" requires some terminology corrections, specifically naming the "resource"-related causes/handlers/registries as such.

Now: they exist as the only possible form of causes/handlers/registries. Adding the activity-specialised classes/methods in addition to generic-looking but resource-specialised classes/methods will create a confusion.

Briefly:

* `custom_object_handler` -> `resource_handler` (to be paired with `activity_handler`).
* `SimpleRegistry` -> `ResourceRegistry` (to be paired with `ActivityRegistry`)
* `GlobalRegistry` -> `OperatorRegistry` (for the legacy method extraction & deprecation later).
* `..._event_watching_...` -> `..._resource_watching_...` (causes, handlers, registries).
* `..._state_changing_...` -> `..._resource_changing_...` (causes, handlers, registries).
* `get_state` -> `get_essence` (a leftover from #200: the "state" word is reserved for the reactor's state persistance, and should not be used for the resources' minified bodies (now: "essence")).

There are **NO** behavioral changes. The public interfaces are kept **unmodified**. These are the internal changes only.

Some of these renames were introduced in #202, and never were released yet (despite merged to master), so it is safe to rename it again without breaking the public interfaces of any Kopf version.


## Types of Changes

- Refactor/improvements
