### PR TITLE
Refactoring [2/3]: code moves and extractions

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -165,7 +165,7 @@ async def resource_handler(
 
 async def handle_resource_watching_cause(
         lifecycle: lifecycles.LifeCycleFn,
-        registry: registries.BaseRegistry,
+        registry: registries.OperatorRegistry,
         cause: causation.ResourceWatchingCause,
 ) -> None:
     """
@@ -202,7 +202,7 @@ async def handle_resource_watching_cause(
 
 async def handle_resource_changing_cause(
         lifecycle: lifecycles.LifeCycleFn,
-        registry: registries.BaseRegistry,
+        registry: registries.OperatorRegistry,
         cause: causation.ResourceChangingCause,
 ) -> Optional[float]:
     """
@@ -283,7 +283,7 @@ async def execute(
         *,
         fns: Optional[Iterable[invocation.Invokable]] = None,
         handlers: Optional[Iterable[registries.ResourceHandler]] = None,
-        registry: Optional[registries.BaseRegistry] = None,
+        registry: Optional[registries.ResourceRegistry] = None,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
         cause: Optional[causation.BaseCause] = None,
 ) -> None:

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -435,26 +435,6 @@ class OperatorRegistry(BaseRegistry):
         return self.has_resource_changing_handlers(*args, **kwargs)
 
 
-_default_registry: OperatorRegistry = OperatorRegistry()
-
-
-def get_default_registry() -> OperatorRegistry:
-    """
-    Get the default registry to be used by the decorators and the reactor
-    unless the explicit registry is provided to them.
-    """
-    return _default_registry
-
-
-def set_default_registry(registry: OperatorRegistry) -> None:
-    """
-    Set the default registry to be used by the decorators and the reactor
-    unless the explicit registry is provided to them.
-    """
-    global _default_registry
-    _default_registry = registry
-
-
 def get_callable_id(c: Optional[Callable[..., Any]]) -> str:
     """ Get an reasonably good id of any commonly used callable. """
     if c is None:
@@ -526,3 +506,23 @@ def _matches_metadata(
         else:
             continue
     return True
+
+
+_default_registry: OperatorRegistry = OperatorRegistry()
+
+
+def get_default_registry() -> OperatorRegistry:
+    """
+    Get the default registry to be used by the decorators and the reactor
+    unless the explicit registry is provided to them.
+    """
+    return _default_registry
+
+
+def set_default_registry(registry: OperatorRegistry) -> None:
+    """
+    Set the default registry to be used by the decorators and the reactor
+    unless the explicit registry is provided to them.
+    """
+    global _default_registry
+    _default_registry = registry


### PR DESCRIPTION
Code refactoring (part 2 of 3): moving the code pieces around.

> Issue : preparation for #59 #187 #142
> Preceded: #209 (part 1/3)

## Description

This PR is purely **moving** of functions and methods — a part of the code refactoring needed to extend Kopf with the startup/cleanup/(re-)authentication background activities.

Historically, some code pieces were located in strange places. To minimise the size of the meaningful PR, the moves are extracted to this PR.

There are **NO** behavioral changes.

The public interfaces are kept **unmodified**. These are the internal changes only.


## Types of Changes

- Refactor/improvements
