### PR TITLE
Refactoring [3/3]: proper OOP for registries

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -46,6 +46,8 @@ from kopf.reactor.lifecycles import (
 )
 from kopf.reactor.registries import (
     ResourceRegistry,
+    ResourceWatchingRegistry,
+    ResourceChangingRegistry,
     OperatorRegistry,
     get_default_registry,
     set_default_registry,
@@ -95,6 +97,8 @@ __all__ = [
     'SimpleRegistry',  # deprecated
     'GlobalRegistry',  # deprecated
     'ResourceRegistry',
+    'ResourceWatchingRegistry',
+    'ResourceChangingRegistry',
     'OperatorRegistry',
     'get_default_registry',
     'set_default_registry',

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -45,7 +45,6 @@ from kopf.reactor.lifecycles import (
     set_default_lifecycle,
 )
 from kopf.reactor.registries import (
-    BaseRegistry,
     ResourceRegistry,
     OperatorRegistry,
     get_default_registry,
@@ -70,11 +69,14 @@ from kopf.toolkits.hierarchies import (
     append_owner_reference,
     remove_owner_reference,
 )
+from kopf.toolkits.legacy_registries import (
+    BaseRegistry,
+    SimpleRegistry,
+    GlobalRegistry,
+)
 
 HandlerFatalError = PermanentError  # a backward-compatibility alias
 HandlerRetryError = TemporaryError  # a backward-compatibility alias
-SimpleRegistry = ResourceRegistry  # a backward-compatibility alias
-GlobalRegistry = OperatorRegistry  # a backward-compatibility alias
 
 __all__ = [
     'on', 'lifecycles', 'register', 'execute',
@@ -89,9 +91,11 @@ __all__ = [
     'PermanentError', 'HandlerFatalError',
     'TemporaryError', 'HandlerRetryError',
     'HandlerTimeoutError',
-    'BaseRegistry',
-    'ResourceRegistry', 'SimpleRegistry',
-    'OperatorRegistry', 'GlobalRegistry',
+    'BaseRegistry',  # deprecated
+    'SimpleRegistry',  # deprecated
+    'GlobalRegistry',  # deprecated
+    'ResourceRegistry',
+    'OperatorRegistry',
     'get_default_registry',
     'set_default_registry',
 ]

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -34,11 +34,10 @@ def resume(
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
-        actual_registry.register_resource_changing_handler(
+        return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, initial=True, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
-        return fn
     return decorator
 
 
@@ -54,11 +53,10 @@ def create(
     """ ``@kopf.on.create()`` handler for the object creation. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
-        actual_registry.register_resource_changing_handler(
+        return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
-        return fn
     return decorator
 
 
@@ -74,11 +72,10 @@ def update(
     """ ``@kopf.on.update()`` handler for the object update or change. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
-        actual_registry.register_resource_changing_handler(
+        return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
-        return fn
     return decorator
 
 
@@ -95,12 +92,11 @@ def delete(
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
-        actual_registry.register_resource_changing_handler(
+        return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.DELETE, id=id, timeout=timeout,
             fn=fn, requires_finalizer=bool(not optional),
             labels=labels, annotations=annotations)
-        return fn
     return decorator
 
 
@@ -117,11 +113,10 @@ def field(
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
-        actual_registry.register_resource_changing_handler(
+        return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id, timeout=timeout,
             fn=fn, labels=labels, annotations=annotations)
-        return fn
     return decorator
 
 
@@ -136,10 +131,9 @@ def event(
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
-        actual_registry.register_resource_watching_handler(
+        return actual_registry.register_resource_watching_handler(
             group=group, version=version, plural=plural,
             id=id, fn=fn, labels=labels, annotations=annotations)
-        return fn
     return decorator
 
 
@@ -182,8 +176,7 @@ def this(
     """
     actual_registry = registry if registry is not None else handling.subregistry_var.get()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
-        actual_registry.register(id=id, fn=fn, timeout=timeout)
-        return fn
+        return actual_registry.register(id=id, fn=fn, timeout=timeout)
     return decorator
 
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -149,7 +149,7 @@ def this(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.ResourceRegistry] = None,
+        registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> ResourceHandlerDecorator:
     """
     ``@kopf.on.this()`` decorator for the dynamically generated sub-handlers.
@@ -192,7 +192,7 @@ def register(
         *,
         id: Optional[str] = None,
         timeout: Optional[float] = None,
-        registry: Optional[registries.ResourceRegistry] = None,
+        registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> registries.ResourceHandlerFn:
     """
     Register a function as a sub-handler of the currently executed handler.

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -1,0 +1,195 @@
+"""
+Backward-compatibility of a semi-public interface of the legacy registries.
+
+Originally, these registries were part of the public interface (exported
+via ``kopf`` top-level package), but later replaced by other registries
+with an incompatible class hierarchy and method signatures.
+"""
+import abc
+import warnings
+from typing import Any, Union, Sequence, Iterator
+
+from kopf.reactor import causation
+from kopf.reactor import registries
+from kopf.structs import bodies
+from kopf.structs import patches
+from kopf.structs import resources as resources_
+
+AnyCause = Union[causation.ResourceWatchingCause, causation.ResourceChangingCause]
+
+
+class BaseRegistry(metaclass=abc.ABCMeta):
+    """
+    .. deprecated: 1.0
+
+        Removed in the new class hierarchy.
+    """
+
+    @abc.abstractmethod
+    def get_event_handlers(
+            self,
+            resource: resources_.Resource,
+            event: bodies.Event,
+    ) -> Sequence[registries.ResourceHandler]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_cause_handlers(
+            self,
+            cause: causation.ResourceChangingCause,
+    ) -> Sequence[registries.ResourceHandler]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def iter_event_handlers(
+            self,
+            resource: resources_.Resource,
+            event: bodies.Event,
+    ) -> Iterator[registries.ResourceHandler]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def iter_cause_handlers(
+            self,
+            cause: causation.ResourceChangingCause,
+    ) -> Iterator[registries.ResourceHandler]:
+        raise NotImplementedError
+
+
+class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
+    """
+    .. deprecated: 1.0
+
+        Replaced with `ResourceWatchingRegistry` and `ResourceChangingRegistry`.
+    """
+
+    def iter_handlers(
+            self,
+            cause: AnyCause,
+    ) -> Iterator[registries.ResourceHandler]:
+        raise NotImplementedError("A dummy method to avoid new ABC restrictions "
+                                  "in an old legacy registry. Should not be used.")
+
+    def get_event_handlers(
+            self,
+            resource: resources_.Resource,
+            event: bodies.Event,
+    ) -> Sequence[registries.ResourceHandler]:
+        warnings.warn("SimpleRegistry.get_event_handlers() is deprecated; use "
+                      "ResourceWatchingRegistry.get_handlers().", DeprecationWarning)
+        return list(registries._deduplicated(self.iter_event_handlers(
+            resource=resource, event=event)))
+
+    def get_cause_handlers(
+            self,
+            cause: causation.ResourceChangingCause,
+    ) -> Sequence[registries.ResourceHandler]:
+        warnings.warn("SimpleRegistry.get_cause_handlers() is deprecated; use "
+                      "ResourceChangingRegistry.get_handlers().", DeprecationWarning)
+        return list(registries._deduplicated(self.iter_cause_handlers(cause=cause)))
+
+    def iter_event_handlers(
+            self,
+            resource: resources_.Resource,
+            event: bodies.Event,
+    ) -> Iterator[registries.ResourceHandler]:
+        warnings.warn("SimpleRegistry.iter_event_handlers() is deprecated; use "
+                      "ResourceWatchingRegistry.iter_handlers().", DeprecationWarning)
+
+        for handler in self._handlers:
+            if registries.match(handler=handler, body=event['object'], ignore_fields=True):
+                yield handler
+
+    def iter_cause_handlers(
+            self,
+            cause: causation.ResourceChangingCause,
+    ) -> Iterator[registries.ResourceHandler]:
+        warnings.warn("SimpleRegistry.iter_cause_handlers() is deprecated; use "
+                      "ResourceChangingRegistry.iter_handlers().", DeprecationWarning)
+
+        changed_fields = frozenset(field for _, field, _, _ in cause.diff or [])
+        for handler in self._handlers:
+            if handler.reason is None or handler.reason == cause.reason:
+                if handler.initial and not cause.initial:
+                    pass  # ignore initial handlers in non-initial causes.
+                elif registries.match(handler=handler, body=cause.body,
+                                      changed_fields=changed_fields):
+                    yield handler
+
+
+class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
+    """
+    .. deprecated: 1.0
+
+        Replaced with `MultiRegistry`.
+    """
+
+    def register_event_handler(self, *args: Any, **kwargs: Any) -> Any:
+        warnings.warn("GlobalRegistry.register_event_handler() is deprecated; use "
+                      "OperatorRegistry.register_resource_watching_handler().", DeprecationWarning)
+        return self.register_resource_watching_handler(*args, **kwargs)
+
+    def register_cause_handler(self, *args: Any, **kwargs: Any) -> Any:
+        warnings.warn("GlobalRegistry.register_cause_handler() is deprecated; use "
+                      "OperatorRegistry.register_resource_changing_handler().", DeprecationWarning)
+        return self.register_resource_changing_handler(*args, **kwargs)
+
+    def has_event_handlers(self, *args: Any, **kwargs: Any) -> Any:
+        warnings.warn("GlobalRegistry.has_event_handlers() is deprecated; use "
+                      "OperatorRegistry.has_resource_watching_handlers().", DeprecationWarning)
+        return self.has_resource_watching_handlers(*args, **kwargs)
+
+    def has_cause_handlers(self, *args: Any, **kwargs: Any) -> Any:
+        warnings.warn("GlobalRegistry.has_cause_handlers() is deprecated; use "
+                      "OperatorRegistry.has_resource_changing_handlers().", DeprecationWarning)
+        return self.has_resource_changing_handlers(*args, **kwargs)
+
+    def get_event_handlers(
+            self,
+            resource: resources_.Resource,
+            event: bodies.Event,
+    ) -> Sequence[registries.ResourceHandler]:
+        warnings.warn("GlobalRegistry.get_event_handlers() is deprecated; use "
+                      "OperatorRegistry.get_resource_watching_handlers().", DeprecationWarning)
+        cause = _create_watching_cause(resource=resource, event=event)
+        return self.get_resource_watching_handlers(cause=cause)
+
+    def get_cause_handlers(
+            self,
+            cause: causation.ResourceChangingCause,
+    ) -> Sequence[registries.ResourceHandler]:
+        warnings.warn("GlobalRegistry.get_cause_handlers() is deprecated; use "
+                      "OperatorRegistry.get_resource_changing_handlers().", DeprecationWarning)
+        return self.get_resource_changing_handlers(cause=cause)
+
+    def iter_event_handlers(
+            self,
+            resource: resources_.Resource,
+            event: bodies.Event,
+    ) -> Iterator[registries.ResourceHandler]:
+        warnings.warn("GlobalRegistry.iter_event_handlers() is deprecated; use "
+                      "OperatorRegistry.iter_resource_watching_handlers().", DeprecationWarning)
+        cause = _create_watching_cause(resource=resource, event=event)
+        yield from self.iter_resource_watching_handlers(cause=cause)
+
+    def iter_cause_handlers(
+            self,
+            cause: causation.ResourceChangingCause,
+    ) -> Iterator[registries.ResourceHandler]:
+        warnings.warn("GlobalRegistry.iter_cause_handlers() is deprecated; use "
+                      "OperatorRegistry.iter_resource_changing_handlers().", DeprecationWarning)
+        yield from self.iter_resource_changing_handlers(cause=cause)
+
+
+def _create_watching_cause(
+        resource: resources_.Resource,
+        event: bodies.Event,
+) -> causation.ResourceWatchingCause:
+    return causation.detect_resource_watching_cause(
+        resource=resource,
+        event=event,
+        patch=patches.Patch(),  # unused
+        type=event['type'],  # unused
+        body=event['object'],  # unused
+        raw=event,  # unused
+    )

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -63,12 +63,13 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
         Replaced with `ResourceWatchingRegistry` and `ResourceChangingRegistry`.
     """
 
+    # A dummy to avoid ABCMeta restrictions, and for rudimentary class testing.
+    # Yield/return everything unconditionally -- it was not used previously anyway.
     def iter_handlers(
             self,
             cause: AnyCause,
     ) -> Iterator[registries.ResourceHandler]:
-        raise NotImplementedError("A dummy method to avoid new ABC restrictions "
-                                  "in an old legacy registry. Should not be used.")
+        yield from self._handlers
 
     def get_event_handlers(
             self,

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -17,6 +17,7 @@ def test_all_args(mocker):
     initial = mocker.Mock()
     labels = mocker.Mock()
     annotations = mocker.Mock()
+    requires_finalizer = mocker.Mock()
     handler = ResourceHandler(
         fn=fn,
         id=id,
@@ -26,6 +27,7 @@ def test_all_args(mocker):
         initial=initial,
         labels=labels,
         annotations=annotations,
+        requires_finalizer=requires_finalizer,
     )
     assert handler.fn is fn
     assert handler.id is id
@@ -36,3 +38,4 @@ def test_all_args(mocker):
     assert handler.initial is initial
     assert handler.labels is labels
     assert handler.annotations is annotations
+    assert handler.requires_finalizer is requires_finalizer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def clear_default_registry():
     Ensure that the tests have a fresh new global (not re-used) registry.
     """
     old_registry = kopf.get_default_registry()
-    new_registry = kopf.OperatorRegistry()
+    new_registry = type(old_registry)()  # i.e. OperatorRegistry/GlobalRegistry
     kopf.set_default_registry(new_registry)
     try:
         yield new_registry

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from kopf import ResourceWatchingRegistry, ResourceChangingRegistry, OperatorRegistry
+from kopf import SimpleRegistry, GlobalRegistry  # deprecated, but tested
+
+
+@pytest.fixture(params=[
+    pytest.param(ResourceWatchingRegistry, id='resource-watching-registry'),
+    pytest.param(ResourceChangingRegistry, id='resource-changing-registry'),
+    pytest.param(SimpleRegistry, id='simple-registry'),  # deprecated
+])
+def resource_registry_cls(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    pytest.param(OperatorRegistry, id='operator-registry'),
+    pytest.param(GlobalRegistry, id='global-registry'),  # deprecated
+])
+def operator_registry_cls(request):
+    return request.param

--- a/tests/registries/legacy/test_legacy_creation.py
+++ b/tests/registries/legacy/test_legacy_creation.py
@@ -1,0 +1,24 @@
+from kopf import BaseRegistry, SimpleRegistry, GlobalRegistry
+
+
+def test_creation_of_simple_no_prefix():
+    registry = SimpleRegistry()
+    assert isinstance(registry, BaseRegistry)
+    assert isinstance(registry, SimpleRegistry)
+    assert registry.prefix is None
+
+
+def test_creation_of_simple_with_prefix_argument():
+    registry = SimpleRegistry('hello')
+    assert registry.prefix == 'hello'
+
+
+def test_creation_of_simple_with_prefix_keyword():
+    registry = SimpleRegistry(prefix='hello')
+    assert registry.prefix == 'hello'
+
+
+def test_creation_of_global():
+    registry = GlobalRegistry()
+    assert isinstance(registry, BaseRegistry)
+    assert isinstance(registry, GlobalRegistry)

--- a/tests/registries/legacy/test_legacy_decorators.py
+++ b/tests/registries/legacy/test_legacy_decorators.py
@@ -1,0 +1,222 @@
+import pytest
+
+import kopf
+from kopf import SimpleRegistry, GlobalRegistry
+from kopf.reactor.causation import Reason
+from kopf.reactor.handling import subregistry_var
+from kopf.structs.resources import Resource
+
+
+def test_on_create_minimal(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+
+    @kopf.on.create('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].reason == Reason.CREATE
+    assert handlers[0].field is None
+    assert handlers[0].timeout is None
+    assert handlers[0].labels is None
+    assert handlers[0].annotations is None
+
+
+def test_on_update_minimal(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+
+    @kopf.on.update('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].reason == Reason.UPDATE
+    assert handlers[0].field is None
+    assert handlers[0].timeout is None
+    assert handlers[0].labels is None
+    assert handlers[0].annotations is None
+
+
+def test_on_delete_minimal(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+
+    @kopf.on.delete('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].reason == Reason.DELETE
+    assert handlers[0].field is None
+    assert handlers[0].timeout is None
+    assert handlers[0].labels is None
+    assert handlers[0].annotations is None
+
+
+def test_on_field_minimal(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    diff = [('op', ('field', 'subfield'), 'old', 'new')]
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+
+    @kopf.on.field('group', 'version', 'plural', 'field.subfield')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].reason is None
+    assert handlers[0].field == ('field', 'subfield')
+    assert handlers[0].timeout is None
+    assert handlers[0].labels is None
+    assert handlers[0].annotations is None
+
+
+def test_on_field_fails_without_field():
+    with pytest.raises(TypeError):
+        @kopf.on.field('group', 'version', 'plural')
+        def fn(**_):
+            pass
+
+
+def test_on_create_with_all_kwargs(mocker):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.create('group', 'version', 'plural',
+                    id='id', timeout=123, registry=registry,
+                    labels={'somelabel': 'somevalue'},
+                    annotations={'someanno': 'somevalue'})
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].reason == Reason.CREATE
+    assert handlers[0].field is None
+    assert handlers[0].id == 'id'
+    assert handlers[0].timeout == 123
+    assert handlers[0].labels == {'somelabel': 'somevalue'}
+    assert handlers[0].annotations == {'someanno': 'somevalue'}
+
+
+def test_on_update_with_all_kwargs(mocker):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.update('group', 'version', 'plural',
+                    id='id', timeout=123, registry=registry,
+                    labels={'somelabel': 'somevalue'},
+                    annotations={'someanno': 'somevalue'})
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].reason == Reason.UPDATE
+    assert handlers[0].field is None
+    assert handlers[0].id == 'id'
+    assert handlers[0].timeout == 123
+    assert handlers[0].labels == {'somelabel': 'somevalue'}
+    assert handlers[0].annotations == {'someanno': 'somevalue'}
+
+
+@pytest.mark.parametrize('optional', [
+    pytest.param(True, id='optional'),
+    pytest.param(False, id='mandatory'),
+])
+def test_on_delete_with_all_kwargs(mocker, optional):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.delete('group', 'version', 'plural',
+                    id='id', timeout=123, registry=registry, optional=optional,
+                    labels={'somelabel': 'somevalue'},
+                    annotations={'someanno': 'somevalue'})
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].reason == Reason.DELETE
+    assert handlers[0].field is None
+    assert handlers[0].id == 'id'
+    assert handlers[0].timeout == 123
+    assert handlers[0].labels == {'somelabel': 'somevalue'}
+    assert handlers[0].annotations == {'someanno': 'somevalue'}
+
+
+def test_on_field_with_all_kwargs(mocker):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+    diff = [('op', ('field', 'subfield'), 'old', 'new')]
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.field('group', 'version', 'plural', 'field.subfield',
+                   id='id', timeout=123, registry=registry,
+                   labels={'somelabel': 'somevalue'},
+                   annotations={'someanno': 'somevalue'})
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].reason is None
+    assert handlers[0].field ==('field', 'subfield')
+    assert handlers[0].id == 'id/field.subfield'
+    assert handlers[0].timeout == 123
+    assert handlers[0].labels == {'somelabel': 'somevalue'}
+    assert handlers[0].annotations == {'someanno': 'somevalue'}
+
+
+def test_subhandler_declaratively(mocker):
+    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
+
+    registry = SimpleRegistry()
+    subregistry_var.set(registry)
+
+    @kopf.on.this()
+    def fn(**_):
+        pass
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+
+
+def test_subhandler_imperatively(mocker):
+    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
+
+    registry = SimpleRegistry()
+    subregistry_var.set(registry)
+
+    def fn(**_):
+        pass
+    kopf.register(fn)
+
+    handlers = registry.get_cause_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn

--- a/tests/registries/legacy/test_legacy_default_registry.py
+++ b/tests/registries/legacy/test_legacy_default_registry.py
@@ -1,0 +1,13 @@
+import kopf
+
+
+def test_getting_default_registry():
+    registry = kopf.get_default_registry()
+    assert isinstance(registry, kopf.GlobalRegistry)
+
+
+def test_setting_default_registry():
+    registry_expected = kopf.GlobalRegistry()
+    kopf.set_default_registry(registry_expected)
+    registry_actual = kopf.get_default_registry()
+    assert registry_actual is registry_expected

--- a/tests/registries/legacy/test_legacy_global_registry.py
+++ b/tests/registries/legacy/test_legacy_global_registry.py
@@ -1,0 +1,25 @@
+import collections
+
+from kopf import GlobalRegistry
+from kopf.structs.resources import Resource
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn():
+    pass
+
+
+def test_resources():
+    registry = GlobalRegistry()
+    registry.register_cause_handler('group1', 'version1', 'plural1', some_fn)
+    registry.register_cause_handler('group2', 'version2', 'plural2', some_fn)
+
+    resources = registry.resources
+
+    assert isinstance(resources, collections.abc.Collection)
+    assert len(resources) == 2
+
+    resource1 = Resource('group1', 'version1', 'plural1')
+    resource2 = Resource('group2', 'version2', 'plural2')
+    assert resource1 in resources
+    assert resource2 in resources

--- a/tests/registries/legacy/test_legacy_handler_matching.py
+++ b/tests/registries/legacy/test_legacy_handler_matching.py
@@ -1,0 +1,364 @@
+import functools
+from unittest.mock import Mock
+
+import pytest
+
+from kopf import SimpleRegistry, GlobalRegistry
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn(x=None):
+    pass
+
+
+@pytest.fixture(params=[
+    pytest.param(SimpleRegistry, id='in-simple-registry'),
+    pytest.param(GlobalRegistry, id='in-global-registry'),
+])
+def registry(request):
+    return request.param()
+
+
+@pytest.fixture()
+def register_fn(registry, resource):
+    if isinstance(registry, SimpleRegistry):
+        return registry.register
+    if isinstance(registry, GlobalRegistry):
+        return functools.partial(registry.register_cause_handler, resource.group, resource.version, resource.plural)
+    raise Exception(f"Unsupported registry type: {registry}")
+
+
+@pytest.fixture(params=[
+    pytest.param(None, id='without-diff'),
+    pytest.param([], id='with-empty-diff'),
+])
+def cause_no_diff(request, resource):
+    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
+    return Mock(resource=resource, reason='some-reason', diff=request.param, body=body)
+
+
+@pytest.fixture(params=[
+    pytest.param([('op', ('some-field',), 'old', 'new')], id='with-field-diff'),
+])
+def cause_with_diff(resource):
+    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
+    diff = [('op', ('some-field',), 'old', 'new')]
+    return Mock(resource=resource, reason='some-reason', diff=diff, body=body)
+
+
+@pytest.fixture(params=[
+    pytest.param(None, id='without-diff'),
+    pytest.param([], id='with-empty-diff'),
+    pytest.param([('op', ('some-field',), 'old', 'new')], id='with-field-diff'),
+])
+def cause_any_diff(resource, request):
+    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
+    return Mock(resource=resource, reason='some-reason', diff=request.param, body=body)
+
+
+#
+# "Catch-all" handlers are those with event == None.
+#
+
+def test_catchall_handlers_without_field_found(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason=None, field=None)
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert handlers
+
+
+def test_catchall_handlers_with_field_found(cause_with_diff, registry, register_fn):
+    register_fn(some_fn, reason=None, field='some-field')
+    handlers = registry.get_cause_handlers(cause_with_diff)
+    assert handlers
+
+
+def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
+    register_fn(some_fn, reason=None, field='some-field')
+    handlers = registry.get_cause_handlers(cause_no_diff)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_with_labels_satisfied(registry, register_fn, resource, labels):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
+    handlers = registry.get_cause_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_labels_not_satisfied(registry, register_fn, resource, labels):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
+    handlers = registry.get_cause_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_labels_exist(registry, register_fn, resource, labels):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
+    handlers = registry.get_cause_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_labels_not_exist(registry, register_fn, resource, labels):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
+    handlers = registry.get_cause_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_without_labels(registry, register_fn, resource, labels):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels=None)
+    handlers = registry.get_cause_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+])
+def test_catchall_handlers_with_annotations_satisfied(registry, register_fn, resource, annotations):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
+    handlers = registry.get_cause_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_annotations_not_satisfied(registry, register_fn, resource, annotations):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
+    handlers = registry.get_cause_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_annotations_exist(registry, register_fn, resource, annotations):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
+    handlers = registry.get_cause_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_annotations_not_exist(registry, register_fn, resource, annotations):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
+    handlers = registry.get_cause_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+])
+def test_catchall_handlers_without_annotations(registry, register_fn, resource, annotations):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, annotations=None)
+    handlers = registry.get_cause_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels, annotations', [
+    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue'}, id='with-label-annotation'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue'}, id='with-extra-label-annotation'),
+    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-label-extra-annotation'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
+])
+def test_catchall_handlers_with_labels_and_annotations_satisfied(registry, register_fn, resource, labels, annotations):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels, 'annotations': annotations}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handlers = registry.get_cause_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_with_labels_and_annotations_not_satisfied(registry, register_fn, resource, labels):
+    cause = Mock(resource=resource, reason='some-reason', diff=None, body={'metadata': {'labels': labels}})
+    register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handlers = registry.get_cause_handlers(cause)
+    assert not handlers
+
+
+#
+# Relevant handlers are those with event == 'some-reason' (but not 'another-reason').
+# In the per-field handlers, also with field == 'some-field' (not 'another-field').
+# In the label filtered handlers, the relevant handlers are those that ask for 'somelabel'.
+# In the annotation filtered handlers, the relevant handlers are those that ask for 'someannotation'.
+#
+
+def test_relevant_handlers_without_field_found(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='some-reason')
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert handlers
+
+
+def test_relevant_handlers_with_field_found(cause_with_diff, registry, register_fn):
+    register_fn(some_fn, reason='some-reason', field='some-field')
+    handlers = registry.get_cause_handlers(cause_with_diff)
+    assert handlers
+
+
+def test_relevant_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
+    register_fn(some_fn, reason='some-reason', field='some-field')
+    handlers = registry.get_cause_handlers(cause_no_diff)
+    assert not handlers
+
+
+def test_relevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='some-reason', labels={'somelabel': None})
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert handlers
+
+
+def test_relevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='some-reason', labels={'otherlabel': None})
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert not handlers
+
+
+def test_relevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='some-reason', annotations={'someannotation': None})
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert handlers
+
+
+def test_relevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='some-reason', annotations={'otherannotation': None})
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert not handlers
+
+
+def test_irrelevant_handlers_without_field_ignored(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='another-reason')
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert not handlers
+
+
+def test_irrelevant_handlers_with_field_ignored(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='another-reason', field='another-field')
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert not handlers
+
+def test_irrelevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='another-reason', labels={'somelabel': None})
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert not handlers
+
+
+def test_irrelevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='another-reason', labels={'otherlabel': None})
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert not handlers
+
+
+def test_irrelevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='another-reason', annotations={'someannotation': None})
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert not handlers
+
+
+def test_irrelevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
+    register_fn(some_fn, reason='another-reason', annotations={'otherannotation': None})
+    handlers = registry.get_cause_handlers(cause_any_diff)
+    assert not handlers
+
+
+#
+# The handlers must be returned in order of registration,
+# even if they are mixed with-/without- * -event/-field handlers.
+#
+
+def test_order_persisted_a(cause_with_diff, registry, register_fn):
+    register_fn(functools.partial(some_fn, 1), reason=None)
+    register_fn(functools.partial(some_fn, 2), reason='some-reason')
+    register_fn(functools.partial(some_fn, 3), reason='filtered-out-reason')
+    register_fn(functools.partial(some_fn, 4), reason=None, field='filtered-out-reason')
+    register_fn(functools.partial(some_fn, 5), reason=None, field='some-field')
+
+    handlers = registry.get_cause_handlers(cause_with_diff)
+
+    # Order must be preserved -- same as registered.
+    assert len(handlers) == 3
+    assert handlers[0].reason is None
+    assert handlers[0].field is None
+    assert handlers[1].reason == 'some-reason'
+    assert handlers[1].field is None
+    assert handlers[2].reason is None
+    assert handlers[2].field == ('some-field',)
+
+
+def test_order_persisted_b(cause_with_diff, registry, register_fn):
+    register_fn(functools.partial(some_fn, 1), reason=None, field='some-field')
+    register_fn(functools.partial(some_fn, 2), reason=None, field='filtered-out-field')
+    register_fn(functools.partial(some_fn, 3), reason='filtered-out-reason')
+    register_fn(functools.partial(some_fn, 4), reason='some-reason')
+    register_fn(functools.partial(some_fn, 5), reason=None)
+
+    handlers = registry.get_cause_handlers(cause_with_diff)
+
+    # Order must be preserved -- same as registered.
+    assert len(handlers) == 3
+    assert handlers[0].reason is None
+    assert handlers[0].field == ('some-field',)
+    assert handlers[1].reason == 'some-reason'
+    assert handlers[1].field is None
+    assert handlers[2].reason is None
+    assert handlers[2].field is None
+
+#
+# Same function should not be returned twice for the same event/cause.
+# Only actual for the cases when the event/cause can match multiple handlers.
+#
+
+def test_deduplicated(cause_with_diff, registry, register_fn):
+    register_fn(some_fn, reason=None, id='a')
+    register_fn(some_fn, reason=None, id='b')
+
+    handlers = registry.get_cause_handlers(cause_with_diff)
+
+    assert len(handlers) == 1
+    assert handlers[0].id == 'a'  # the first found one is returned

--- a/tests/registries/legacy/test_legacy_id_detection.py
+++ b/tests/registries/legacy/test_legacy_id_detection.py
@@ -1,0 +1,144 @@
+import functools
+
+import pytest
+
+from kopf import SimpleRegistry
+from kopf.reactor.registries import get_callable_id
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn():
+    pass
+
+
+@pytest.fixture(params=[
+    'some-field.sub-field',
+    ['some-field', 'sub-field'],
+    ('some-field', 'sub-field'),
+], ids=['str', 'list', 'tuple'])
+def field(request):
+    return request.param
+
+
+def test_id_of_simple_function():
+    fn_id = get_callable_id(some_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_single_partial():
+    partial_fn = functools.partial(some_fn)
+
+    fn_id = get_callable_id(partial_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_double_partial():
+    partial1_fn = functools.partial(some_fn)
+    partial2_fn = functools.partial(partial1_fn)
+
+    fn_id = get_callable_id(partial2_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_single_wrapper():
+
+    @functools.wraps(some_fn)
+    def wrapped_fn():
+        pass
+
+    fn_id = get_callable_id(wrapped_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_double_wrapper():
+
+    @functools.wraps(some_fn)
+    def wrapped1_fn():
+        pass
+
+    @functools.wraps(wrapped1_fn)
+    def wrapped2_fn():
+        pass
+
+    fn_id = get_callable_id(wrapped2_fn)
+    assert fn_id == 'some_fn'
+
+
+def test_id_of_lambda():
+    some_lambda = lambda: None
+
+    fn_id = get_callable_id(some_lambda)
+    assert fn_id.startswith(f'lambda:{__file__}:')
+
+
+def test_with_no_hints(mocker):
+    get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+
+    registry = SimpleRegistry()
+    registry.register(some_fn)
+    handlers = registry.get_cause_handlers(mocker.MagicMock())
+
+    assert get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-id'
+
+
+def test_with_prefix(mocker):
+    get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+
+    registry = SimpleRegistry(prefix='some-prefix')
+    registry.register(some_fn)
+    handlers = registry.get_cause_handlers(mocker.MagicMock())
+
+    assert get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-prefix/some-id'
+
+
+def test_with_suffix(mocker, field):
+    get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+    diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
+
+    registry = SimpleRegistry()
+    registry.register(some_fn, field=field)
+    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+
+    assert get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-id/some-field.sub-field'
+
+
+def test_with_prefix_and_suffix(mocker, field):
+    get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+    diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
+
+    registry = SimpleRegistry(prefix='some-prefix')
+    registry.register(some_fn, field=field)
+    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+
+    assert get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-prefix/some-id/some-field.sub-field'
+
+
+def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
+    get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+    diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
+
+    registry = SimpleRegistry(prefix='some-prefix')
+    registry.register(some_fn, id='explicit-id', field=field)
+    handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+
+    assert not get_fn_id.called
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+    assert handlers[0].id == 'some-prefix/explicit-id/some-field.sub-field'

--- a/tests/registries/legacy/test_legacy_registering.py
+++ b/tests/registries/legacy/test_legacy_registering.py
@@ -1,0 +1,85 @@
+import collections.abc
+
+from kopf import SimpleRegistry, GlobalRegistry
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn():
+    pass
+
+
+def test_simple_registry_via_iter(mocker):
+    cause = mocker.Mock(event=None, diff=None)
+
+    registry = SimpleRegistry()
+    iterator = registry.iter_cause_handlers(cause)
+
+    assert isinstance(iterator, collections.abc.Iterator)
+    assert not isinstance(iterator, collections.abc.Collection)
+    assert not isinstance(iterator, collections.abc.Container)
+    assert not isinstance(iterator, (list, tuple))
+
+    handlers = list(iterator)
+    assert not handlers
+
+
+def test_simple_registry_via_list(mocker):
+    cause = mocker.Mock(event=None, diff=None)
+
+    registry = SimpleRegistry()
+    handlers = registry.get_cause_handlers(cause)
+
+    assert isinstance(handlers, collections.abc.Iterable)
+    assert isinstance(handlers, collections.abc.Container)
+    assert isinstance(handlers, collections.abc.Collection)
+    assert not handlers
+
+
+def test_simple_registry_with_minimal_signature(mocker):
+    cause = mocker.Mock(event=None, diff=None)
+
+    registry = SimpleRegistry()
+    registry.register(some_fn)
+    handlers = registry.get_cause_handlers(cause)
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+
+
+def test_global_registry_via_iter(mocker, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = GlobalRegistry()
+    iterator = registry.iter_cause_handlers(cause)
+
+    assert isinstance(iterator, collections.abc.Iterator)
+    assert not isinstance(iterator, collections.abc.Collection)
+    assert not isinstance(iterator, collections.abc.Container)
+    assert not isinstance(iterator, (list, tuple))
+
+    handlers = list(iterator)
+    assert not handlers
+
+
+def test_global_registry_via_list(mocker, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = GlobalRegistry()
+    handlers = registry.get_cause_handlers(cause)
+
+    assert isinstance(handlers, collections.abc.Iterable)
+    assert isinstance(handlers, collections.abc.Container)
+    assert isinstance(handlers, collections.abc.Collection)
+    assert not handlers
+
+
+def test_global_registry_with_minimal_signature(mocker, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = GlobalRegistry()
+    registry.register_cause_handler(resource.group, resource.version, resource.plural, some_fn)
+    handlers = registry.get_cause_handlers(cause)
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+

--- a/tests/registries/legacy/test_legacy_requires_finalizer.py
+++ b/tests/registries/legacy/test_legacy_requires_finalizer.py
@@ -1,0 +1,159 @@
+import pytest
+
+import kopf
+from kopf import GlobalRegistry
+from kopf.structs.resources import Resource
+
+OBJECT_BODY = {
+    'apiVersion': 'group/version',
+    'kind': 'singular',
+    'metadata': {
+        'name': 'test',
+        'labels': {
+            'key': 'value',
+        },
+        'annotations': {
+            'key': 'value',
+        }
+    }
+}
+
+
+@pytest.mark.parametrize('optional, expected', [
+    pytest.param(True, False, id='optional'),
+    pytest.param(False, True, id='mandatory'),
+])
+def test_requires_finalizer_deletion_handler(optional, expected):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+
+    @kopf.on.delete('group', 'version', 'plural',
+                    registry=registry, optional=optional)
+    def fn(**_):
+        pass
+
+    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    assert requires_finalizer == expected
+
+
+@pytest.mark.parametrize('optional, expected', [
+    pytest.param(True, False, id='optional'),
+    pytest.param(False, True, id='mandatory'),
+])
+def test_requires_finalizer_multiple_handlers(optional, expected):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+
+    @kopf.on.create('group', 'version', 'plural',
+                    registry=registry)
+    def fn1(**_):
+        pass
+
+    @kopf.on.delete('group', 'version', 'plural',
+                    registry=registry, optional=optional)
+    def fn2(**_):
+        pass
+
+    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    assert requires_finalizer == expected
+
+
+def test_requires_finalizer_no_deletion_handler():
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+
+    @kopf.on.create('group', 'version', 'plural',
+                    registry=registry)
+    def fn1(**_):
+        pass
+
+    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    assert requires_finalizer is False
+
+
+@pytest.mark.parametrize('optional, expected', [
+    pytest.param(True, False, id='optional'),
+    pytest.param(False, True, id='mandatory'),
+])
+@pytest.mark.parametrize('labels', [
+    pytest.param({'key': 'value'}, id='value-matches'),
+    pytest.param({'key': None}, id='key-exists'),
+])
+def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, expected):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+
+    @kopf.on.delete('group', 'version', 'plural',
+                    labels=labels,
+                    registry=registry, optional=optional)
+    def fn(**_):
+        pass
+
+    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    assert requires_finalizer == expected
+
+
+@pytest.mark.parametrize('optional, expected', [
+    pytest.param(True, False, id='optional'),
+    pytest.param(False, False, id='mandatory'),
+])
+@pytest.mark.parametrize('labels', [
+    pytest.param({'key': 'othervalue'}, id='value-mismatch'),
+    pytest.param({'otherkey': None}, id='key-doesnt-exist'),
+])
+def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional, expected):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+
+    @kopf.on.delete('group', 'version', 'plural',
+                    labels=labels,
+                    registry=registry, optional=optional)
+    def fn(**_):
+        pass
+
+    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    assert requires_finalizer == expected
+
+
+@pytest.mark.parametrize('optional, expected', [
+    pytest.param(True, False, id='optional'),
+    pytest.param(False, True, id='mandatory'),
+])
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'key': 'value'}, id='value-matches'),
+    pytest.param({'key': None}, id='key-exists'),
+])
+def test_requires_finalizer_deletion_handler_matches_annotations(annotations, optional, expected):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+
+    @kopf.on.delete('group', 'version', 'plural',
+                    annotations=annotations,
+                    registry=registry, optional=optional)
+    def fn(**_):
+        pass
+
+    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    assert requires_finalizer == expected
+
+
+@pytest.mark.parametrize('optional, expected', [
+    pytest.param(True, False, id='optional'),
+    pytest.param(False, False, id='mandatory'),
+])
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'key': 'othervalue'}, id='value-mismatch'),
+    pytest.param({'otherkey': None}, id='key-doesnt-exist'),
+])
+def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations, optional, expected):
+    registry = GlobalRegistry()
+    resource = Resource('group', 'version', 'plural')
+
+    @kopf.on.delete('group', 'version', 'plural',
+                    annotations=annotations,
+                    registry=registry, optional=optional)
+    def fn(**_):
+        pass
+
+    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    assert requires_finalizer == expected

--- a/tests/registries/test_creation.py
+++ b/tests/registries/test_creation.py
@@ -1,22 +1,23 @@
 from kopf import ResourceRegistry, OperatorRegistry
 
 
-def test_creation_of_simple_no_prefix():
-    registry = ResourceRegistry()
+def test_resource_registry_with_no_prefix(resource_registry_cls):
+    registry = resource_registry_cls()
     assert isinstance(registry, ResourceRegistry)
     assert registry.prefix is None
 
 
-def test_creation_of_simple_with_prefix_argument():
-    registry = ResourceRegistry('hello')
+def test_resource_registry_with_prefix_argument(resource_registry_cls):
+    registry = resource_registry_cls('hello')
     assert registry.prefix == 'hello'
 
 
-def test_creation_of_simple_with_prefix_keyword():
-    registry = ResourceRegistry(prefix='hello')
+def test_resource_registry_with_prefix_keyword(resource_registry_cls):
+    registry = resource_registry_cls(prefix='hello')
     assert registry.prefix == 'hello'
 
 
-def test_creation_of_global():
-    registry = OperatorRegistry()
+def test_operator_registry(operator_registry_cls):
+    registry = operator_registry_cls()
     assert isinstance(registry, OperatorRegistry)
+    assert not isinstance(registry, ResourceRegistry)

--- a/tests/registries/test_creation.py
+++ b/tests/registries/test_creation.py
@@ -1,9 +1,8 @@
-from kopf import BaseRegistry, ResourceRegistry, OperatorRegistry
+from kopf import ResourceRegistry, OperatorRegistry
 
 
 def test_creation_of_simple_no_prefix():
     registry = ResourceRegistry()
-    assert isinstance(registry, BaseRegistry)
     assert isinstance(registry, ResourceRegistry)
     assert registry.prefix is None
 
@@ -20,5 +19,4 @@ def test_creation_of_simple_with_prefix_keyword():
 
 def test_creation_of_global():
     registry = OperatorRegistry()
-    assert isinstance(registry, BaseRegistry)
     assert isinstance(registry, OperatorRegistry)

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -3,7 +3,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import Reason
 from kopf.reactor.handling import subregistry_var
-from kopf.reactor.registries import ResourceRegistry, OperatorRegistry
+from kopf.reactor.registries import ResourceRegistry, OperatorRegistry, ResourceChangingRegistry
 from kopf.structs.resources import Resource
 
 
@@ -195,14 +195,14 @@ def test_on_field_with_all_kwargs(mocker):
 def test_subhandler_declaratively(mocker):
     cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
 
-    registry = ResourceRegistry()
+    registry = ResourceChangingRegistry()
     subregistry_var.set(registry)
 
     @kopf.on.this()
     def fn(**_):
         pass
 
-    handlers = registry.get_resource_changing_handlers(cause)
+    handlers = registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
 
@@ -210,13 +210,13 @@ def test_subhandler_declaratively(mocker):
 def test_subhandler_imperatively(mocker):
     cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
 
-    registry = ResourceRegistry()
+    registry = ResourceChangingRegistry()
     subregistry_var.set(registry)
 
     def fn(**_):
         pass
     kopf.register(fn)
 
-    handlers = registry.get_resource_changing_handlers(cause)
+    handlers = registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -12,7 +12,7 @@ def some_fn(x=None):
 
 
 @pytest.fixture(params=[
-    pytest.param(ResourceRegistry, id='in-simple-registry'),
+    # pytest.param(ResourceRegistry, id='in-simple-registry'),
     pytest.param(OperatorRegistry, id='in-global-registry'),
 ])
 def registry(request):
@@ -21,8 +21,8 @@ def registry(request):
 
 @pytest.fixture()
 def register_fn(registry, resource):
-    if isinstance(registry, ResourceRegistry):
-        return registry.register
+    # if isinstance(registry, ResourceRegistry):
+    #     return registry.register
     if isinstance(registry, OperatorRegistry):
         return functools.partial(registry.register_resource_changing_handler, resource.group, resource.version, resource.plural)
     raise Exception(f"Unsupported registry type: {registry}")

--- a/tests/registries/test_id_detection.py
+++ b/tests/registries/test_id_detection.py
@@ -2,7 +2,6 @@ import functools
 
 import pytest
 
-from kopf import ResourceRegistry
 from kopf.reactor.registries import get_callable_id
 
 
@@ -71,12 +70,14 @@ def test_id_of_lambda():
     assert fn_id.startswith(f'lambda:{__file__}:')
 
 
-def test_with_no_hints(mocker):
+def test_with_no_hints(
+        mocker, resource_registry_cls):
+
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
 
-    registry = ResourceRegistry()
+    registry = resource_registry_cls()
     registry.register(some_fn)
-    handlers = registry.get_resource_changing_handlers(mocker.MagicMock())
+    handlers = registry.get_handlers(mocker.MagicMock())
 
     assert get_fn_id.called
 
@@ -85,12 +86,14 @@ def test_with_no_hints(mocker):
     assert handlers[0].id == 'some-id'
 
 
-def test_with_prefix(mocker):
+def test_with_prefix(
+        mocker, resource_registry_cls):
+
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
 
-    registry = ResourceRegistry(prefix='some-prefix')
+    registry = resource_registry_cls(prefix='some-prefix')
     registry.register(some_fn)
-    handlers = registry.get_resource_changing_handlers(mocker.MagicMock())
+    handlers = registry.get_handlers(mocker.MagicMock())
 
     assert get_fn_id.called
 
@@ -99,13 +102,15 @@ def test_with_prefix(mocker):
     assert handlers[0].id == 'some-prefix/some-id'
 
 
-def test_with_suffix(mocker, field):
+def test_with_suffix(
+        mocker, field, resource_registry_cls):
+
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
-    registry = ResourceRegistry()
+    registry = resource_registry_cls()
     registry.register(some_fn, field=field)
-    handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -114,13 +119,15 @@ def test_with_suffix(mocker, field):
     assert handlers[0].id == 'some-id/some-field.sub-field'
 
 
-def test_with_prefix_and_suffix(mocker, field):
+def test_with_prefix_and_suffix(
+        mocker, field, resource_registry_cls):
+
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
-    registry = ResourceRegistry(prefix='some-prefix')
+    registry = resource_registry_cls(prefix='some-prefix')
     registry.register(some_fn, field=field)
-    handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
 
     assert get_fn_id.called
 
@@ -129,13 +136,15 @@ def test_with_prefix_and_suffix(mocker, field):
     assert handlers[0].id == 'some-prefix/some-id/some-field.sub-field'
 
 
-def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
+def test_with_explicit_id_and_prefix_and_suffix(
+        mocker, field, resource_registry_cls):
+
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
 
-    registry = ResourceRegistry(prefix='some-prefix')
+    registry = resource_registry_cls(prefix='some-prefix')
     registry.register(some_fn, id='explicit-id', field=field)
-    handlers = registry.get_resource_changing_handlers(mocker.MagicMock(diff=diff))
+    handlers = registry.get_handlers(mocker.MagicMock(diff=diff))
 
     assert not get_fn_id.called
 

--- a/tests/registries/test_operator_resources.py
+++ b/tests/registries/test_operator_resources.py
@@ -11,8 +11,10 @@ def some_fn():
 
 def test_resources():
     registry = OperatorRegistry()
-    registry.register_resource_changing_handler('group1', 'version1', 'plural1', some_fn)
+    registry.register_resource_watching_handler('group1', 'version1', 'plural1', some_fn)
     registry.register_resource_changing_handler('group2', 'version2', 'plural2', some_fn)
+    registry.register_resource_watching_handler('group2', 'version2', 'plural2', some_fn)
+    registry.register_resource_changing_handler('group1', 'version1', 'plural1', some_fn)
 
     resources = registry.resources
 

--- a/tests/registries/test_registering.py
+++ b/tests/registries/test_registering.py
@@ -1,18 +1,16 @@
 import collections.abc
 
-from kopf import ResourceRegistry, OperatorRegistry
-
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.
 def some_fn():
     pass
 
 
-def test_simple_registry_via_iter(mocker):
+def test_resource_registry_via_iter(mocker, resource_registry_cls):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = ResourceRegistry()
-    iterator = registry.iter_resource_changing_handlers(cause)
+    registry = resource_registry_cls()
+    iterator = registry.iter_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -23,11 +21,11 @@ def test_simple_registry_via_iter(mocker):
     assert not handlers
 
 
-def test_simple_registry_via_list(mocker):
+def test_resource_registry_via_list(mocker, resource_registry_cls):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = ResourceRegistry()
-    handlers = registry.get_resource_changing_handlers(cause)
+    registry = resource_registry_cls()
+    handlers = registry.get_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -35,21 +33,38 @@ def test_simple_registry_via_list(mocker):
     assert not handlers
 
 
-def test_simple_registry_with_minimal_signature(mocker):
+def test_resource_registry_with_minimal_signature(mocker, resource_registry_cls):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = ResourceRegistry()
+    registry = resource_registry_cls()
     registry.register(some_fn)
-    handlers = registry.get_resource_changing_handlers(cause)
+    handlers = registry.get_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn
 
 
-def test_global_registry_via_iter(mocker, resource):
+def test_operator_registry_with_resource_watching_via_iter(
+        mocker, operator_registry_cls, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
-    registry = OperatorRegistry()
+    registry = operator_registry_cls()
+    iterator = registry.iter_resource_watching_handlers(cause)
+
+    assert isinstance(iterator, collections.abc.Iterator)
+    assert not isinstance(iterator, collections.abc.Collection)
+    assert not isinstance(iterator, collections.abc.Container)
+    assert not isinstance(iterator, (list, tuple))
+
+    handlers = list(iterator)
+    assert not handlers
+
+
+def test_operator_registry_with_resource_changing_via_iter(
+        mocker, operator_registry_cls, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = operator_registry_cls()
     iterator = registry.iter_resource_changing_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
@@ -61,10 +76,24 @@ def test_global_registry_via_iter(mocker, resource):
     assert not handlers
 
 
-def test_global_registry_via_list(mocker, resource):
+def test_operator_registry_with_resource_watching_via_list(
+        mocker, operator_registry_cls, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
-    registry = OperatorRegistry()
+    registry = operator_registry_cls()
+    handlers = registry.get_resource_watching_handlers(cause)
+
+    assert isinstance(handlers, collections.abc.Iterable)
+    assert isinstance(handlers, collections.abc.Container)
+    assert isinstance(handlers, collections.abc.Collection)
+    assert not handlers
+
+
+def test_operator_registry_with_resource_changing_via_list(
+        mocker, operator_registry_cls, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = operator_registry_cls()
     handlers = registry.get_resource_changing_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -73,13 +102,25 @@ def test_global_registry_via_list(mocker, resource):
     assert not handlers
 
 
-def test_global_registry_with_minimal_signature(mocker, resource):
+def test_operator_registry_with_resource_watching_with_minimal_signature(
+        mocker, operator_registry_cls, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
 
-    registry = OperatorRegistry()
+    registry = operator_registry_cls()
+    registry.register_resource_watching_handler(resource.group, resource.version, resource.plural, some_fn)
+    handlers = registry.get_resource_watching_handlers(cause)
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
+
+
+def test_operator_registry_with_resource_changing_with_minimal_signature(
+        mocker, operator_registry_cls, resource):
+    cause = mocker.Mock(resource=resource, event=None, diff=None)
+
+    registry = operator_registry_cls()
     registry.register_resource_changing_handler(resource.group, resource.version, resource.plural, some_fn)
     handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn
-


### PR DESCRIPTION
Code refactoring (part 3 of 3): bring proper OOP to registries.

> Issue : preparation for #59 #187 #142
> Preceded: #209 (part 1/3), #210 (part 2/3).

## Description

Bring registries to the proper OOP implementation, with inheritance and polymorphism. For histroic reasons and quick-prorotyping, they were initially implemented with different methods of the same class; now, it is done via different classes with one method overridden.

The ex-`GlobalRegistry` (now, the `OperatorRegistry`) is excluded from the registries hierarchy, since it shares 0 methods with other registies, and is implemented as a *composite* of specialised registries. The code now clearly annotates which registries are expected where — they are NOT interchangeable anymore.

The unit-tests for the old registry classes signatures are restored from the old code _(unmodified, so not worth reviewing in `/tests/registries/legacy/`)_ to ensure the interfaces are maintained. Those legacy registries are extracted as a toolkit — since they are not used internally anymore, but could be used by the users: `SimpleRegistry` & `GlobalRegistry` were exposed as part of the public interfaces, and we want to keep them so for some until (until big cleanup).

In addition, few little implementation changes are done there.

There **could be** behavioral changes (unintended).


## Types of Changes

- Refactor/improvements
