### PR TITLE
Fix the tests for the new pytest-mock package structure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ urllib3<1.25
 
 # Everything needed to develop (test, debug) the framework.
 pytest-asyncio
-pytest-mock
+pytest-mock>=1.11.1
 pytest-cov
 pytest
 asynctest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,8 @@ def pytest_collection_modifyitems(config, items):
 # Substitute the regular mock with the async-aware mock in the `mocker` fixture.
 @pytest.fixture(scope='session', autouse=True)
 def enforce_asyncio_mocker():
-    pytest_mock._get_mock_module = lambda config: asynctest
+    pytest_mock.plugin._get_mock_module = lambda config: asynctest
+    pytest_mock._get_mock_module = pytest_mock.plugin._get_mock_module
 
 
 @pytest.fixture()


### PR DESCRIPTION
A replay of #199 (already in master), but started from the supposed 0.22 release point — in order to not have the hanging branches for the releases, and to stream all hotfix branches/tags into master.