### PR TITLE
Speed up e2e tests and make them exiting gracefully

### DIFF
--- a/examples/03-exceptions/example.py
+++ b/examples/03-exceptions/example.py
@@ -3,7 +3,7 @@ import time
 import kopf
 
 E2E_TRACEBACKS = True
-E2E_CREATION_TIME_LIMIT = 3.5
+E2E_CREATION_STOP_WORDS = ['Third failure, the final one']
 E2E_SUCCESS_COUNTS = {}
 E2E_FAILURE_COUNTS = {'create_fn': 1}
 

--- a/examples/03-exceptions/example.py
+++ b/examples/03-exceptions/example.py
@@ -3,7 +3,7 @@ import time
 import kopf
 
 E2E_TRACEBACKS = True
-E2E_CREATE_TIME = 3.5
+E2E_CREATION_TIME_LIMIT = 3.5
 E2E_SUCCESS_COUNTS = {}
 E2E_FAILURE_COUNTS = {'create_fn': 1}
 

--- a/examples/99-all-at-once/example.py
+++ b/examples/99-all-at-once/example.py
@@ -9,8 +9,8 @@ import pykube
 import yaml
 
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
-E2E_CREATE_TIME = 5
-E2E_DELETE_TIME = 1
+E2E_CREATION_TIME_LIMIT = 5
+E2E_DELETION_TIME_LIMIT = 1
 E2E_SUCCESS_COUNTS = {'create_1': 1, 'create_2': 1, 'create_pod': 1, 'delete': 1}
 E2E_FAILURE_COUNTS = {}
 E2E_TRACEBACKS = True

--- a/examples/99-all-at-once/example.py
+++ b/examples/99-all-at-once/example.py
@@ -9,8 +9,8 @@ import pykube
 import yaml
 
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
-E2E_CREATION_TIME_LIMIT = 5
-E2E_DELETION_TIME_LIMIT = 1
+E2E_CREATION_STOP_WORDS = ['All handlers succeeded for creation']
+E2E_DELETION_STOP_WORDS = ['Deleted, really deleted']
 E2E_SUCCESS_COUNTS = {'create_1': 1, 'create_2': 1, 'create_pod': 1, 'delete': 1}
 E2E_FAILURE_COUNTS = {}
 E2E_TRACEBACKS = True

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import functools
 from typing import Any, Optional, Callable, List
 
@@ -9,6 +10,13 @@ from kopf.clients import auth
 from kopf.engines import peering
 from kopf.reactor import running
 from kopf.utilities import loaders
+
+
+@dataclasses.dataclass()
+class CLIControls:
+    """ `KopfRunner` controls, which are impossible to pass via CLI. """
+    stop_flag: Optional[running.Flag] = None
+    ready_flag: Optional[running.Flag] = None
 
 
 def cli_login() -> None:
@@ -50,7 +58,9 @@ def main() -> None:
 @click.option('-p', '--priority', type=int, default=0)
 @click.option('-m', '--module', 'modules', multiple=True)
 @click.argument('paths', nargs=-1)
+@click.make_pass_decorator(CLIControls, ensure=True)
 def run(
+        __controls: CLIControls,
         paths: List[str],
         modules: List[str],
         peering_name: Optional[str],
@@ -69,6 +79,8 @@ def run(
         namespace=namespace,
         priority=priority,
         peering_name=peering_name,
+        stop_flag=__controls.stop_flag,
+        ready_flag=__controls.ready_flag,
     )
 
 

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -36,6 +36,8 @@ def run(
         priority: int = 0,
         peering_name: Optional[str] = None,
         namespace: Optional[str] = None,
+        stop_flag: Optional[Flag] = None,
+        ready_flag: Optional[Flag] = None,
 ) -> None:
     """
     Run the whole operator synchronously.
@@ -51,6 +53,8 @@ def run(
             namespace=namespace,
             priority=priority,
             peering_name=peering_name,
+            stop_flag=stop_flag,
+            ready_flag=ready_flag,
         ))
     except asyncio.CancelledError:
         pass

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -13,7 +13,7 @@ assert examples  # if empty, it is just the detection failed
 examples = [path for path in examples if not glob.glob((os.path.join(path, 'test*.py')))]
 
 
-@pytest.fixture(params=examples)
+@pytest.fixture(params=examples, ids=[os.path.basename(path.rstrip('/')) for path in examples])
 def exampledir(request):
     return pathlib.Path(request.param)
 


### PR DESCRIPTION

> Issue : #13 #59 

## Description

Improve e2e tests to wait for the stop-words in the logs instead of just waiting for the time. It was quite common that the e2e tests do not fit into the empirically guessed timings, so the timings had to be increased far above what was normally needed — thus slowing the e2e tests.

This became even more important for the tests that contain the artificial delays, such as sleep, temporary errors with delays, or arbitrary exceptions with the default retry delay (even if mocked).

Now, they default delay is 10 seconds, but the tests continue as soon as they see the specially defined stop-words for each stage (creation, deletion; later: startup, cleanup).

In addition, the `KopfRunner` was improved to stop the background operator gracefully instead of the forced cancellation (which had no graceful period).

## Types of Changes

- Refactor/improvements
