### PR TITLE
Convert client wrappers to coroutines, use thread pools for actual calls

### DIFF
--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -42,7 +42,7 @@ async def patch_obj(
             body['metadata']['namespace'] = namespace
 
     api = auth.get_pykube_api()
-    cls = classes._make_cls(resource=resource)
+    cls = await classes._make_cls(resource=resource)
     obj = cls(api, body)
 
     # The handler could delete its own object, so we have nothing to patch. It is okay, ignore.

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -131,7 +131,7 @@ async def spawn_tasks(
     ])
 
     # Monitor the peers, unless explicitly disabled.
-    ourselves: Optional[peering.Peer] = peering.Peer.detect(
+    ourselves: Optional[peering.Peer] = await peering.Peer.detect(
         id=peering.detect_own_id(), priority=priority,
         standalone=standalone, namespace=namespace, name=peering_name,
     )

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -4,11 +4,11 @@ import requests
 from kopf.clients.fetching import list_objs_rv
 
 
-def test_when_successful_clustered(req_mock, resource):
+async def test_when_successful_clustered(req_mock, resource):
     result = {'items': [{}, {}]}
     req_mock.get.return_value.json.return_value = result
 
-    items, resource_version = list_objs_rv(resource=resource, namespace=None)
+    items, resource_version = await list_objs_rv(resource=resource, namespace=None)
     assert items == result['items']
 
     assert req_mock.get.called
@@ -19,11 +19,11 @@ def test_when_successful_clustered(req_mock, resource):
     assert 'namespaces/' not in url
 
 
-def test_when_successful_namespaced(req_mock, resource):
+async def test_when_successful_namespaced(req_mock, resource):
     result = {'items': [{}, {}]}
     req_mock.get.return_value.json.return_value = result
 
-    items, resource_version = list_objs_rv(resource=resource, namespace='ns1')
+    items, resource_version = await list_objs_rv(resource=resource, namespace='ns1')
     assert items == result['items']
 
     assert req_mock.get.called
@@ -35,12 +35,12 @@ def test_when_successful_namespaced(req_mock, resource):
 
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
 @pytest.mark.parametrize('status', [400, 401, 403, 500, 666])
-def test_raises_api_error(req_mock, resource, namespace, status):
+async def test_raises_api_error(req_mock, resource, namespace, status):
     response = requests.Response()
     response.status_code = status
     error = requests.exceptions.HTTPError("boo!", response=response)
     req_mock.get.side_effect = error
 
     with pytest.raises(requests.exceptions.HTTPError) as e:
-        list_objs_rv(resource=resource, namespace=namespace)
+        await list_objs_rv(resource=resource, namespace=namespace)
     assert e.value.response.status_code == status

--- a/tests/k8s/test_read_crd.py
+++ b/tests/k8s/test_read_crd.py
@@ -4,11 +4,11 @@ import requests
 from kopf.clients.fetching import read_crd
 
 
-def test_when_present(req_mock, resource):
+async def test_when_present(req_mock, resource):
     result = {}
     req_mock.get.return_value.json.return_value = result
 
-    crd = read_crd(resource=resource)
+    crd = await read_crd(resource=resource)
     assert crd is result
 
     assert req_mock.get.called
@@ -19,36 +19,36 @@ def test_when_present(req_mock, resource):
 
 
 @pytest.mark.parametrize('status', [403, 404])
-def test_when_absent_with_no_default(req_mock, resource, status):
+async def test_when_absent_with_no_default(req_mock, resource, status):
     response = requests.Response()
     response.status_code = status
     error = requests.exceptions.HTTPError("boo!", response=response)
     req_mock.get.side_effect = error
 
     with pytest.raises(requests.exceptions.HTTPError) as e:
-        read_crd(resource=resource)
+        await read_crd(resource=resource)
     assert e.value.response.status_code == status
 
 
 @pytest.mark.parametrize('default', [None, object()], ids=['none', 'object'])
 @pytest.mark.parametrize('status', [403, 404])
-def test_when_absent_with_default(req_mock, resource, default, status):
+async def test_when_absent_with_default(req_mock, resource, default, status):
     response = requests.Response()
     response.status_code = status
     error = requests.exceptions.HTTPError("boo!", response=response)
     req_mock.get.side_effect = error
 
-    crd = read_crd(resource=resource, default=default)
+    crd = await read_crd(resource=resource, default=default)
     assert crd is default
 
 
 @pytest.mark.parametrize('status', [400, 401, 500, 666])
-def test_raises_api_error_despite_default(req_mock, resource, status):
+async def test_raises_api_error_despite_default(req_mock, resource, status):
     response = requests.Response()
     response.status_code = status
     error = requests.exceptions.HTTPError("boo!", response=response)
     req_mock.get.side_effect = error
 
     with pytest.raises(requests.exceptions.HTTPError) as e:
-        read_crd(resource=resource, default=object())
+        await read_crd(resource=resource, default=object())
     assert e.value.response.status_code == status

--- a/tests/k8s/test_read_obj.py
+++ b/tests/k8s/test_read_obj.py
@@ -5,11 +5,11 @@ from kopf.clients.fetching import read_obj
 
 
 @pytest.mark.resource_clustered  # see `req_mock`
-def test_when_present_clustered(req_mock, resource):
+async def test_when_present_clustered(req_mock, resource):
     result = {}
     req_mock.get.return_value.json.return_value = result
 
-    crd = read_obj(resource=resource, namespace=None, name='name1')
+    crd = await read_obj(resource=resource, namespace=None, name='name1')
     assert crd is result
 
     assert req_mock.get.called
@@ -20,11 +20,11 @@ def test_when_present_clustered(req_mock, resource):
     assert 'namespaces/' not in url
 
 
-def test_when_present_namespaced(req_mock, resource):
+async def test_when_present_namespaced(req_mock, resource):
     result = {}
     req_mock.get.return_value.json.return_value = result
 
-    crd = read_obj(resource=resource, namespace='ns1', name='name1')
+    crd = await read_obj(resource=resource, namespace='ns1', name='name1')
     assert crd is result
 
     assert req_mock.get.called
@@ -36,38 +36,38 @@ def test_when_present_namespaced(req_mock, resource):
 
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
 @pytest.mark.parametrize('status', [403, 404])
-def test_when_absent_with_no_default(req_mock, resource, namespace, status):
+async def test_when_absent_with_no_default(req_mock, resource, namespace, status):
     response = requests.Response()
     response.status_code = status
     error = requests.exceptions.HTTPError("boo!", response=response)
     req_mock.get.side_effect = error
 
     with pytest.raises(requests.exceptions.HTTPError) as e:
-        read_obj(resource=resource, namespace=namespace, name='name1')
+        await read_obj(resource=resource, namespace=namespace, name='name1')
     assert e.value.response.status_code == status
 
 
 @pytest.mark.parametrize('default', [None, object()], ids=['none', 'object'])
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
 @pytest.mark.parametrize('status', [403, 404])
-def test_when_absent_with_default(req_mock, resource, namespace, default, status):
+async def test_when_absent_with_default(req_mock, resource, namespace, default, status):
     response = requests.Response()
     response.status_code = status
     error = requests.exceptions.HTTPError("boo!", response=response)
     req_mock.get.side_effect = error
 
-    crd = read_obj(resource=resource, namespace=namespace, name='name1', default=default)
+    crd = await read_obj(resource=resource, namespace=namespace, name='name1', default=default)
     assert crd is default
 
 
 @pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
 @pytest.mark.parametrize('status', [400, 401, 500, 666])
-def test_raises_api_error_despite_default(req_mock, resource, namespace, status):
+async def test_raises_api_error_despite_default(req_mock, resource, namespace, status):
     response = requests.Response()
     response.status_code = status
     error = requests.exceptions.HTTPError("boo!", response=response)
     req_mock.get.side_effect = error
 
     with pytest.raises(requests.exceptions.HTTPError) as e:
-        read_obj(resource=resource, namespace=namespace, name='name1', default=object())
+        await read_obj(resource=resource, namespace=namespace, name='name1', default=object())
     assert e.value.response.status_code == status


### PR DESCRIPTION
> Issue : #142

## Description

The _client wrappers_ are used to isolate the framework's reactor from the specific HTTPS API calls needed to talk to Kubernetes, and from the ways of doing so. They provide a limited set of operations needed only, and no more than that (no general-purpose DSL for resource manipulation).

In this PR, all remaining synchronous client wrappers are converted to async coroutines, while they remain Pykube-based internally (`pykube-ng` is synchronous, as `requests` are synchronous).

This is needed both for the switch to aiohttp (e.g. #176), and for the re-authentication activities (few issues).

The synchronous calls are moved few levels down the stack, and put into the thread-pool executors. 

Previously, these calls were sync inside of the async event loop, so they were blocking. It was not a big problem, as most of them are executed only once or twice per run in the very beginning; the frequent resource-watching & resource-patching & event-posting calls were already executed in the thread pools. But it now becomes a problem since all API calling methods cannot be so diverse anymore, and have to be uniform (specifically, async).

## Types of Changes

- Refactor/improvements
