### PR TITLE
Fix Windows Compatibility

### DIFF
--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -163,8 +163,13 @@ async def spawn_tasks(
 
     # On Ctrl+C or pod termination, cancel all tasks gracefully.
     if threading.current_thread() is threading.main_thread():
-        loop.add_signal_handler(signal.SIGINT, signal_flag.set_result, signal.SIGINT)
-        loop.add_signal_handler(signal.SIGTERM, signal_flag.set_result, signal.SIGTERM)
+        # Handle NotImplementedError when ran on Windows since asyncio only supports Unix signals
+        try:
+            loop.add_signal_handler(signal.SIGINT, signal_flag.set_result, signal.SIGINT)
+            loop.add_signal_handler(signal.SIGTERM, signal_flag.set_result, signal.SIGTERM)
+        except NotImplementedError:
+            logger.warning("OS signals are ignored: can't add signal handler in Windows.")
+
     else:
         logger.warning("OS signals are ignored: running not in the main thread.")
 


### PR DESCRIPTION
When running kopf on Windows it fails due to NotImplementedError thrown by add_signal_handler method in asyncio

> Issue : #219 

# Description
In the asyncio docs it appears that the [add_signal_handler](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.add_signal_handler) method is only available in Unix which is why it throws a NotImplementedError when kopf is run on Windows.
This PR should fix Windows compatibility by catching NotImplementedError thrown by asyncio and continuing.

# Types of Changes
* Bug fix (non-breaking change which fixes an issue)