### PR TITLE
Configure reactions to errors in the handlers, per-handler

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -65,11 +65,11 @@ Regular errors
 
 Kopf assumes that any arbitrary errors
 (i.e. not `TemporaryError` and not `PermanentError`)
-are the environment issues and can self-resolve after some time.
+are environment issues and can self-resolve after some time.
 
 As such, as a default behaviour,
 Kopf retries the handlers with arbitrary errors
-infinitely until they either succeed or fail permanently.
+infinitely until the handlers either succeed or fail permanently.
 
 The reaction to the arbitrary errors can be configured::
 

--- a/examples/03-exceptions/example.py
+++ b/examples/03-exceptions/example.py
@@ -1,11 +1,9 @@
-import time
-
 import kopf
 
 E2E_TRACEBACKS = True
-E2E_CREATION_STOP_WORDS = ['Third failure, the final one']
-E2E_SUCCESS_COUNTS = {}
-E2E_FAILURE_COUNTS = {'create_fn': 1}
+E2E_CREATION_STOP_WORDS = ['Something has changed,']
+E2E_SUCCESS_COUNTS = {'eventual_success_with_few_messages': 1}
+E2E_FAILURE_COUNTS = {'eventual_failure_with_tracebacks': 1, 'instant_failure_with_traceback': 1, 'instant_failure_with_only_a_message': 1}
 
 
 class MyException(Exception):
@@ -13,11 +11,21 @@ class MyException(Exception):
 
 
 @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
-def create_fn(retry, **kwargs):
-    time.sleep(0.1)  # for different timestamps of the events
-    if not retry:
-        raise kopf.TemporaryError("First failure.", delay=1)
-    elif retry == 1:
-        raise MyException("Second failure.")
-    else:
-        raise kopf.PermanentError("Third failure, the final one.")
+def instant_failure_with_only_a_message(**kwargs):
+    raise kopf.PermanentError("Fail once and for all.")
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples')
+def eventual_success_with_few_messages(retry, **kwargs):
+    if retry < 3:  # 0, 1, 2, 3
+        raise kopf.TemporaryError("Expected recoverable error.", delay=1.0)
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', retries=3, cooldown=1.0)
+def eventual_failure_with_tracebacks(**kwargs):
+    raise MyException("An error that is supposed to be recoverable.")
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', errors=kopf.ErrorsMode.PERMANENT, cooldown=1.0)
+def instant_failure_with_traceback(**kwargs):
+    raise MyException("An error that is supposed to be recoverable.")

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -38,6 +38,7 @@ from kopf.reactor.handling import (
     TemporaryError,
     PermanentError,
     HandlerTimeoutError,
+    HandlerRetriesError,
     execute,
 )
 from kopf.reactor.lifecycles import (
@@ -95,6 +96,7 @@ __all__ = [
     'PermanentError', 'HandlerFatalError',
     'TemporaryError', 'HandlerRetryError',
     'HandlerTimeoutError',
+    'HandlerRetriesError',
     'BaseRegistry',  # deprecated
     'SimpleRegistry',  # deprecated
     'GlobalRegistry',  # deprecated

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -45,6 +45,7 @@ from kopf.reactor.lifecycles import (
     set_default_lifecycle,
 )
 from kopf.reactor.registries import (
+    ErrorsMode,
     ResourceRegistry,
     ResourceWatchingRegistry,
     ResourceChangingRegistry,
@@ -90,6 +91,7 @@ __all__ = [
     'get_default_lifecycle', 'set_default_lifecycle',
     'build_object_reference', 'build_owner_reference',
     'append_owner_reference', 'remove_owner_reference',
+    'ErrorsMode',
     'PermanentError', 'HandlerFatalError',
     'TemporaryError', 'HandlerRetryError',
     'HandlerTimeoutError',

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -26,6 +26,7 @@ def resume(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
@@ -36,8 +37,10 @@ def resume(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
-            reason=None, initial=True, id=id, timeout=timeout,
-            fn=fn, labels=labels, annotations=annotations)
+            reason=None, initial=True, id=id,
+            errors=errors, timeout=timeout,
+            fn=fn, labels=labels, annotations=annotations,
+        )
     return decorator
 
 
@@ -45,6 +48,7 @@ def create(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
@@ -55,8 +59,10 @@ def create(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
-            reason=causation.Reason.CREATE, id=id, timeout=timeout,
-            fn=fn, labels=labels, annotations=annotations)
+            reason=causation.Reason.CREATE, id=id,
+            errors=errors, timeout=timeout,
+            fn=fn, labels=labels, annotations=annotations,
+        )
     return decorator
 
 
@@ -64,6 +70,7 @@ def update(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
@@ -74,8 +81,10 @@ def update(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
-            reason=causation.Reason.UPDATE, id=id, timeout=timeout,
-            fn=fn, labels=labels, annotations=annotations)
+            reason=causation.Reason.UPDATE, id=id,
+            errors=errors, timeout=timeout,
+            fn=fn, labels=labels, annotations=annotations,
+        )
     return decorator
 
 
@@ -83,6 +92,7 @@ def delete(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         optional: Optional[bool] = None,
@@ -94,9 +104,11 @@ def delete(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
-            reason=causation.Reason.DELETE, id=id, timeout=timeout,
+            reason=causation.Reason.DELETE, id=id,
+            errors=errors, timeout=timeout,
             fn=fn, requires_finalizer=bool(not optional),
-            labels=labels, annotations=annotations)
+            labels=labels, annotations=annotations,
+        )
     return decorator
 
 
@@ -105,6 +117,7 @@ def field(
         field: Union[str, List[str], Tuple[str, ...]],
         *,
         id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
@@ -115,8 +128,10 @@ def field(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
-            reason=None, field=field, id=id, timeout=timeout,
-            fn=fn, labels=labels, annotations=annotations)
+            reason=None, field=field, id=id,
+            errors=errors, timeout=timeout,
+            fn=fn, labels=labels, annotations=annotations,
+        )
     return decorator
 
 
@@ -133,7 +148,8 @@ def event(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register_resource_watching_handler(
             group=group, version=version, plural=plural,
-            id=id, fn=fn, labels=labels, annotations=annotations)
+            id=id, fn=fn, labels=labels, annotations=annotations,
+        )
     return decorator
 
 
@@ -142,6 +158,7 @@ def event(
 def this(
         *,
         id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> ResourceHandlerDecorator:
@@ -176,7 +193,10 @@ def this(
     """
     actual_registry = registry if registry is not None else handling.subregistry_var.get()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
-        return actual_registry.register(id=id, fn=fn, timeout=timeout)
+        return actual_registry.register(
+            id=id, fn=fn,
+            errors=errors, timeout=timeout,
+        )
     return decorator
 
 
@@ -184,6 +204,7 @@ def register(
         fn: registries.ResourceHandlerFn,
         *,
         id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> registries.ResourceHandlerFn:
@@ -211,4 +232,8 @@ def register(
                 def create_single_task(task=task, **_):
                     pass
     """
-    return this(id=id, timeout=timeout, registry=registry)(fn)
+    decorator = this(
+        id=id, registry=registry,
+        errors=errors, timeout=timeout,
+    )
+    return decorator(fn)

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -28,6 +28,7 @@ def resume(
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
+        retries: Optional[int] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -38,7 +39,7 @@ def resume(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, initial=True, id=id,
-            errors=errors, timeout=timeout,
+            errors=errors, timeout=timeout, retries=retries,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -50,6 +51,7 @@ def create(
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
+        retries: Optional[int] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -60,7 +62,7 @@ def create(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id,
-            errors=errors, timeout=timeout,
+            errors=errors, timeout=timeout, retries=retries,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -72,6 +74,7 @@ def update(
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
+        retries: Optional[int] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -82,7 +85,7 @@ def update(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id,
-            errors=errors, timeout=timeout,
+            errors=errors, timeout=timeout, retries=retries,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -94,6 +97,7 @@ def delete(
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
+        retries: Optional[int] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         optional: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
@@ -105,7 +109,7 @@ def delete(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.DELETE, id=id,
-            errors=errors, timeout=timeout,
+            errors=errors, timeout=timeout, retries=retries,
             fn=fn, requires_finalizer=bool(not optional),
             labels=labels, annotations=annotations,
         )
@@ -119,6 +123,7 @@ def field(
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
+        retries: Optional[int] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -129,7 +134,7 @@ def field(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id,
-            errors=errors, timeout=timeout,
+            errors=errors, timeout=timeout, retries=retries,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -160,6 +165,7 @@ def this(
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
+        retries: Optional[int] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> ResourceHandlerDecorator:
     """
@@ -195,7 +201,7 @@ def this(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register(
             id=id, fn=fn,
-            errors=errors, timeout=timeout,
+            errors=errors, timeout=timeout, retries=retries,
         )
     return decorator
 
@@ -206,6 +212,7 @@ def register(
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
+        retries: Optional[int] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> registries.ResourceHandlerFn:
     """
@@ -234,6 +241,6 @@ def register(
     """
     decorator = this(
         id=id, registry=registry,
-        errors=errors, timeout=timeout,
+        errors=errors, timeout=timeout, retries=retries,
     )
     return decorator(fn)

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -29,6 +29,7 @@ def resume(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -39,7 +40,7 @@ def resume(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, initial=True, id=id,
-            errors=errors, timeout=timeout, retries=retries,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -52,6 +53,7 @@ def create(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -62,7 +64,7 @@ def create(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id,
-            errors=errors, timeout=timeout, retries=retries,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -75,6 +77,7 @@ def update(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -85,7 +88,7 @@ def update(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id,
-            errors=errors, timeout=timeout, retries=retries,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -98,6 +101,7 @@ def delete(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         optional: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
@@ -109,7 +113,7 @@ def delete(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.DELETE, id=id,
-            errors=errors, timeout=timeout, retries=retries,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
             fn=fn, requires_finalizer=bool(not optional),
             labels=labels, annotations=annotations,
         )
@@ -124,6 +128,7 @@ def field(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -134,7 +139,7 @@ def field(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id,
-            errors=errors, timeout=timeout, retries=retries,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -166,6 +171,7 @@ def this(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> ResourceHandlerDecorator:
     """
@@ -201,7 +207,7 @@ def this(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register(
             id=id, fn=fn,
-            errors=errors, timeout=timeout, retries=retries,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
         )
     return decorator
 
@@ -213,6 +219,7 @@ def register(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> registries.ResourceHandlerFn:
     """
@@ -241,6 +248,6 @@ def register(
     """
     decorator = this(
         id=id, registry=registry,
-        errors=errors, timeout=timeout, retries=retries,
+        errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
     )
     return decorator(fn)

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -63,6 +63,10 @@ class HandlerTimeoutError(PermanentError):
     """ An error for the handler's timeout (if set). """
 
 
+class HandlerRetriesError(PermanentError):
+    """ An error for the handler's retries exceeded (if set). """
+
+
 class HandlerChildrenRetry(TemporaryError):
     """ An internal pseudo-error to retry for the next sub-handlers attempt. """
 
@@ -429,6 +433,9 @@ async def _execute_handler(
 
         if handler.timeout is not None and state.runtime.total_seconds() > handler.timeout:
             raise HandlerTimeoutError(f"Handler {handler.id!r} has timed out after {state.runtime}.")
+
+        if handler.retries is not None and state.retries >= handler.retries:
+            raise HandlerRetriesError(f"Handler {handler.id!r} has exceeded {state.retries} retries.")
 
         result = await _call_handler(
             handler,

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -419,6 +419,7 @@ async def _execute_handler(
     exceptions mean the failure of execution itself.
     """
     errors = handler.errors if handler.errors is not None else default_errors
+    cooldown = handler.cooldown if handler.cooldown is not None else DEFAULT_RETRY_DELAY
 
     # Prevent successes/failures from posting k8s-events for resource-watching causes.
     logger: Union[logging.Logger, logging.LoggerAdapter]
@@ -475,7 +476,7 @@ async def _execute_handler(
             return states.HandlerOutcome(final=True, exception=e)
         elif errors == registries.ErrorsMode.TEMPORARY:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will retry.")
-            return states.HandlerOutcome(final=False, exception=e, delay=DEFAULT_RETRY_DELAY)
+            return states.HandlerOutcome(final=False, exception=e, delay=cooldown)
         elif errors == registries.ErrorsMode.PERMANENT:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will stop.")
             return states.HandlerOutcome(final=True, exception=e)

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -431,7 +431,7 @@ async def _execute_handler(
     try:
         logger.debug(f"Invoking handler {handler.id!r}.")
 
-        if handler.timeout is not None and state.runtime.total_seconds() > handler.timeout:
+        if handler.timeout is not None and state.runtime.total_seconds() >= handler.timeout:
             raise HandlerTimeoutError(f"Handler {handler.id!r} has timed out after {state.runtime}.")
 
         if handler.retries is not None and state.retries >= handler.retries:

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -78,6 +78,7 @@ class ResourceHandler(NamedTuple):
     errors: Optional[ErrorsMode] = None
     timeout: Optional[float] = None
     retries: Optional[int] = None
+    cooldown: Optional[float] = None
     initial: Optional[bool] = None
     labels: Optional[bodies.Labels] = None
     annotations: Optional[bodies.Annotations] = None
@@ -119,6 +120,7 @@ class ResourceRegistry(Generic[CauseT]):
             errors: Optional[ErrorsMode] = None,
             timeout: Optional[float] = None,
             retries: Optional[int] = None,
+            cooldown: Optional[float] = None,
             initial: Optional[bool] = None,
             requires_finalizer: bool = False,
             labels: Optional[bodies.Labels] = None,
@@ -131,7 +133,7 @@ class ResourceRegistry(Generic[CauseT]):
         real_id = generate_id(fn=fn, id=id, prefix=self.prefix, suffix=".".join(real_field or []))
         handler = ResourceHandler(
             id=real_id, fn=fn, reason=reason, field=real_field,
-            errors=errors, timeout=timeout, retries=retries,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
             initial=initial, requires_finalizer=requires_finalizer,
             labels=labels, annotations=annotations,
         )
@@ -252,6 +254,7 @@ class OperatorRegistry:
             errors: Optional[ErrorsMode] = None,
             timeout: Optional[float] = None,
             retries: Optional[int] = None,
+            cooldown: Optional[float] = None,
             initial: Optional[bool] = None,
             requires_finalizer: bool = False,
             labels: Optional[bodies.Labels] = None,
@@ -263,7 +266,7 @@ class OperatorRegistry:
         resource = resources_.Resource(group, version, plural)
         return self._resource_changing_handlers[resource].register(
             reason=reason, event=event, field=field, fn=fn, id=id,
-            errors=errors, timeout=timeout, retries=retries,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
             initial=initial, requires_finalizer=requires_finalizer,
             labels=labels, annotations=annotations,
         )

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -75,6 +75,7 @@ class ResourceHandler(NamedTuple):
     id: HandlerId
     reason: Optional[causation.Reason]
     field: Optional[dicts.FieldPath]
+    errors: Optional[ErrorsMode] = None
     timeout: Optional[float] = None
     initial: Optional[bool] = None
     labels: Optional[bodies.Labels] = None
@@ -114,6 +115,7 @@ class ResourceRegistry(Generic[CauseT]):
             reason: Optional[causation.Reason] = None,
             event: Optional[str] = None,  # deprecated, use `reason`
             field: Optional[dicts.FieldSpec] = None,
+            errors: Optional[ErrorsMode] = None,
             timeout: Optional[float] = None,
             initial: Optional[bool] = None,
             requires_finalizer: bool = False,
@@ -126,7 +128,8 @@ class ResourceRegistry(Generic[CauseT]):
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = generate_id(fn=fn, id=id, prefix=self.prefix, suffix=".".join(real_field or []))
         handler = ResourceHandler(
-            id=real_id, fn=fn, reason=reason, field=real_field, timeout=timeout,
+            id=real_id, fn=fn, reason=reason, field=real_field,
+            errors=errors, timeout=timeout,
             initial=initial, requires_finalizer=requires_finalizer,
             labels=labels, annotations=annotations,
         )
@@ -244,6 +247,7 @@ class OperatorRegistry:
             reason: Optional[causation.Reason] = None,
             event: Optional[str] = None,  # deprecated, use `reason`
             field: Optional[dicts.FieldSpec] = None,
+            errors: Optional[ErrorsMode] = None,
             timeout: Optional[float] = None,
             initial: Optional[bool] = None,
             requires_finalizer: bool = False,
@@ -255,7 +259,8 @@ class OperatorRegistry:
         """
         resource = resources_.Resource(group, version, plural)
         return self._resource_changing_handlers[resource].register(
-            reason=reason, event=event, field=field, fn=fn, id=id, timeout=timeout,
+            reason=reason, event=event, field=field, fn=fn, id=id,
+            errors=errors, timeout=timeout,
             initial=initial, requires_finalizer=requires_finalizer,
             labels=labels, annotations=annotations,
         )

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -13,6 +13,7 @@ of the handlers to be executed on each reaction cycle.
 """
 import abc
 import collections
+import enum
 import functools
 import logging
 import warnings
@@ -37,6 +38,13 @@ HandlerId = NewType('HandlerId', str)
 # A specialised type to highlight the purpose or origin of the data of type Any,
 # to not be mixed with other arbitrary Any values, where it is indeed "any".
 HandlerResult = NewType('HandlerResult', object)
+
+
+class ErrorsMode(enum.Enum):
+    """ How arbitrary (non-temporary/non-permanent) exceptions are treated. """
+    IGNORED = enum.auto()
+    TEMPORARY = enum.auto()
+    PERMANENT = enum.auto()
 
 
 class ResourceHandlerFn(Protocol):

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -77,6 +77,7 @@ class ResourceHandler(NamedTuple):
     field: Optional[dicts.FieldPath]
     errors: Optional[ErrorsMode] = None
     timeout: Optional[float] = None
+    retries: Optional[int] = None
     initial: Optional[bool] = None
     labels: Optional[bodies.Labels] = None
     annotations: Optional[bodies.Annotations] = None
@@ -117,6 +118,7 @@ class ResourceRegistry(Generic[CauseT]):
             field: Optional[dicts.FieldSpec] = None,
             errors: Optional[ErrorsMode] = None,
             timeout: Optional[float] = None,
+            retries: Optional[int] = None,
             initial: Optional[bool] = None,
             requires_finalizer: bool = False,
             labels: Optional[bodies.Labels] = None,
@@ -129,7 +131,7 @@ class ResourceRegistry(Generic[CauseT]):
         real_id = generate_id(fn=fn, id=id, prefix=self.prefix, suffix=".".join(real_field or []))
         handler = ResourceHandler(
             id=real_id, fn=fn, reason=reason, field=real_field,
-            errors=errors, timeout=timeout,
+            errors=errors, timeout=timeout, retries=retries,
             initial=initial, requires_finalizer=requires_finalizer,
             labels=labels, annotations=annotations,
         )
@@ -249,6 +251,7 @@ class OperatorRegistry:
             field: Optional[dicts.FieldSpec] = None,
             errors: Optional[ErrorsMode] = None,
             timeout: Optional[float] = None,
+            retries: Optional[int] = None,
             initial: Optional[bool] = None,
             requires_finalizer: bool = False,
             labels: Optional[bodies.Labels] = None,
@@ -260,7 +263,7 @@ class OperatorRegistry:
         resource = resources_.Resource(group, version, plural)
         return self._resource_changing_handlers[resource].register(
             reason=reason, event=event, field=field, fn=fn, id=id,
-            errors=errors, timeout=timeout,
+            errors=errors, timeout=timeout, retries=retries,
             initial=initial, requires_finalizer=requires_finalizer,
             labels=labels, annotations=annotations,
         )

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -16,6 +16,7 @@ def test_all_args(mocker):
     errors = mocker.Mock()
     timeout = mocker.Mock()
     retries = mocker.Mock()
+    cooldown = mocker.Mock()
     initial = mocker.Mock()
     labels = mocker.Mock()
     annotations = mocker.Mock()
@@ -28,6 +29,7 @@ def test_all_args(mocker):
         errors=errors,
         timeout=timeout,
         retries=retries,
+        cooldown=cooldown,
         initial=initial,
         labels=labels,
         annotations=annotations,
@@ -41,6 +43,7 @@ def test_all_args(mocker):
     assert handler.errors is errors
     assert handler.timeout is timeout
     assert handler.retries is retries
+    assert handler.cooldown is cooldown
     assert handler.initial is initial
     assert handler.labels is labels
     assert handler.annotations is annotations

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -13,6 +13,7 @@ def test_all_args(mocker):
     id = mocker.Mock()
     reason = mocker.Mock()
     field = mocker.Mock()
+    errors = mocker.Mock()
     timeout = mocker.Mock()
     initial = mocker.Mock()
     labels = mocker.Mock()
@@ -23,6 +24,7 @@ def test_all_args(mocker):
         id=id,
         reason=reason,
         field=field,
+        errors=errors,
         timeout=timeout,
         initial=initial,
         labels=labels,
@@ -34,6 +36,7 @@ def test_all_args(mocker):
     assert handler.reason is reason
     assert handler.event is reason  # deprecated
     assert handler.field is field
+    assert handler.errors is errors
     assert handler.timeout is timeout
     assert handler.initial is initial
     assert handler.labels is labels

--- a/tests/basic-structs/test_handler.py
+++ b/tests/basic-structs/test_handler.py
@@ -15,6 +15,7 @@ def test_all_args(mocker):
     field = mocker.Mock()
     errors = mocker.Mock()
     timeout = mocker.Mock()
+    retries = mocker.Mock()
     initial = mocker.Mock()
     labels = mocker.Mock()
     annotations = mocker.Mock()
@@ -26,6 +27,7 @@ def test_all_args(mocker):
         field=field,
         errors=errors,
         timeout=timeout,
+        retries=retries,
         initial=initial,
         labels=labels,
         annotations=annotations,
@@ -38,6 +40,7 @@ def test_all_args(mocker):
     assert handler.field is field
     assert handler.errors is errors
     assert handler.timeout is timeout
+    assert handler.retries is retries
     assert handler.initial is initial
     assert handler.labels is labels
     assert handler.annotations is annotations

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -86,7 +86,7 @@ def test_all_examples_are_runnable(mocker, with_crd, exampledir, caplog):
         assert set(name_counts.values()) == {1}
 
     # Verify that once a handler fails, it is never re-executed again.
-    handler_names = re.findall(r"Handler '(.+?)' failed permanently", runner.stdout)
+    handler_names = re.findall(r"Handler '(.+?)' failed (?:permanently|with an exception. Will stop.)", runner.stdout)
     if e2e_failure_counts is not None:
         checked_names = [name for name in handler_names if name in e2e_failure_counts]
         name_counts = collections.Counter(checked_names)

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -94,19 +94,19 @@ def handlers(clear_default_registry):
     async def event_fn(**kwargs):
         return event_mock(**kwargs)
 
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn', timeout=600)
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn', timeout=600, retries=100)
     async def create_fn(**kwargs):
         return create_mock(**kwargs)
 
-    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', id='update_fn', timeout=600)
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', id='update_fn', timeout=600, retries=100)
     async def update_fn(**kwargs):
         return update_mock(**kwargs)
 
-    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples', id='delete_fn', timeout=600)
+    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples', id='delete_fn', timeout=600, retries=100)
     async def delete_fn(**kwargs):
         return delete_mock(**kwargs)
 
-    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn', timeout=600)
+    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn', timeout=600, retries=100)
     async def resume_fn(**kwargs):
         return resume_mock(**kwargs)
 

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import logging
 
 import freezegun
@@ -57,4 +58,51 @@ async def test_timed_out_handler_fails(
 
     assert_logs([
         "Handler .+ has timed out after",
+    ])
+
+
+# The limits are hard-coded in conftest.py:handlers().
+# The extrahandlers are needed to prevent the cycle ending and status purging.
+@pytest.mark.parametrize('cause_type', HANDLER_REASONS)
+async def test_retries_limited_handler_fails(
+        registry, handlers, extrahandlers, resource, cause_mock, cause_type,
+        caplog, assert_logs, k8s_mocked):
+    caplog.set_level(logging.DEBUG)
+    name1 = f'{cause_type}_fn'
+
+    cause_mock.reason = cause_type
+    cause_mock.body.update({
+        'status': {'kopf': {'progress': {
+            'create_fn': {'retries': 100},
+            'update_fn': {'retries': 100},
+            'delete_fn': {'retries': 100},
+            'resume_fn': {'retries': 100},
+        }}}
+    })
+
+    await resource_handler(
+        lifecycle=kopf.lifecycles.one_by_one,
+        registry=registry,
+        resource=resource,
+        event={'type': 'irrelevant', 'object': cause_mock.body},
+        freeze=asyncio.Event(),
+        replenished=asyncio.Event(),
+        event_queue=asyncio.Queue(),
+    )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+    assert not handlers.resume_mock.called
+
+    # Progress is reset, as the handler is not going to retry.
+    assert not k8s_mocked.sleep_or_wait.called
+    assert k8s_mocked.patch_obj.called
+
+    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    assert patch['status']['kopf']['progress'] is not None
+    assert patch['status']['kopf']['progress'][name1]['failure'] is True
+
+    assert_logs([
+        r"Handler .+ has exceeded \d+ retries",
     ])

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -23,6 +23,7 @@ def test_on_create_minimal(mocker):
     assert handlers[0].field is None
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
+    assert handlers[0].retries is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -43,6 +44,7 @@ def test_on_update_minimal(mocker):
     assert handlers[0].field is None
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
+    assert handlers[0].retries is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -63,6 +65,7 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].field is None
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
+    assert handlers[0].retries is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -84,6 +87,7 @@ def test_on_field_minimal(mocker):
     assert handlers[0].field == ('field', 'subfield')
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
+    assert handlers[0].retries is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -102,7 +106,8 @@ def test_on_create_with_all_kwargs(mocker):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.create('group', 'version', 'plural',
-                    id='id', errors=ErrorsMode.PERMANENT, timeout=123, registry=registry,
+                    id='id', registry=registry,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -116,6 +121,7 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].id == 'id'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
+    assert handlers[0].retries == 456
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -127,7 +133,8 @@ def test_on_update_with_all_kwargs(mocker):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.update('group', 'version', 'plural',
-                    id='id', errors=ErrorsMode.PERMANENT, timeout=123, registry=registry,
+                    id='id', registry=registry,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -141,6 +148,7 @@ def test_on_update_with_all_kwargs(mocker):
     assert handlers[0].id == 'id'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
+    assert handlers[0].retries == 456
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -156,7 +164,8 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.delete('group', 'version', 'plural',
-                    id='id', errors=ErrorsMode.PERMANENT, timeout=123, registry=registry,
+                    id='id', registry=registry,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456,
                     optional=optional,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
@@ -171,6 +180,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].id == 'id'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
+    assert handlers[0].retries == 456
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -183,7 +193,8 @@ def test_on_field_with_all_kwargs(mocker):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
-                   id='id', errors=ErrorsMode.PERMANENT, timeout=123, registry=registry,
+                   id='id', registry=registry,
+                   errors=ErrorsMode.PERMANENT, timeout=123, retries=456,
                    labels={'somelabel': 'somevalue'},
                    annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -197,6 +208,7 @@ def test_on_field_with_all_kwargs(mocker):
     assert handlers[0].id == 'id/field.subfield'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
+    assert handlers[0].retries == 456
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -3,7 +3,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import Reason
 from kopf.reactor.handling import subregistry_var
-from kopf.reactor.registries import ResourceRegistry, OperatorRegistry, ResourceChangingRegistry
+from kopf.reactor.registries import ErrorsMode, OperatorRegistry, ResourceChangingRegistry
 from kopf.structs.resources import Resource
 
 
@@ -21,6 +21,7 @@ def test_on_create_minimal(mocker):
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.CREATE
     assert handlers[0].field is None
+    assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
@@ -40,6 +41,7 @@ def test_on_update_minimal(mocker):
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.UPDATE
     assert handlers[0].field is None
+    assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
@@ -59,6 +61,7 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.DELETE
     assert handlers[0].field is None
+    assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
@@ -79,6 +82,7 @@ def test_on_field_minimal(mocker):
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
     assert handlers[0].field == ('field', 'subfield')
+    assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
@@ -98,7 +102,7 @@ def test_on_create_with_all_kwargs(mocker):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.create('group', 'version', 'plural',
-                    id='id', timeout=123, registry=registry,
+                    id='id', errors=ErrorsMode.PERMANENT, timeout=123, registry=registry,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -110,6 +114,7 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].reason == Reason.CREATE
     assert handlers[0].field is None
     assert handlers[0].id == 'id'
+    assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
@@ -122,7 +127,7 @@ def test_on_update_with_all_kwargs(mocker):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.update('group', 'version', 'plural',
-                    id='id', timeout=123, registry=registry,
+                    id='id', errors=ErrorsMode.PERMANENT, timeout=123, registry=registry,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -134,6 +139,7 @@ def test_on_update_with_all_kwargs(mocker):
     assert handlers[0].reason == Reason.UPDATE
     assert handlers[0].field is None
     assert handlers[0].id == 'id'
+    assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
@@ -150,7 +156,8 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.delete('group', 'version', 'plural',
-                    id='id', timeout=123, registry=registry, optional=optional,
+                    id='id', errors=ErrorsMode.PERMANENT, timeout=123, registry=registry,
+                    optional=optional,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -162,6 +169,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].reason == Reason.DELETE
     assert handlers[0].field is None
     assert handlers[0].id == 'id'
+    assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
@@ -175,7 +183,7 @@ def test_on_field_with_all_kwargs(mocker):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
-                   id='id', timeout=123, registry=registry,
+                   id='id', errors=ErrorsMode.PERMANENT, timeout=123, registry=registry,
                    labels={'somelabel': 'somevalue'},
                    annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -187,6 +195,7 @@ def test_on_field_with_all_kwargs(mocker):
     assert handlers[0].reason is None
     assert handlers[0].field ==('field', 'subfield')
     assert handlers[0].id == 'id/field.subfield'
+    assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -24,6 +24,7 @@ def test_on_create_minimal(mocker):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
+    assert handlers[0].cooldown is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -45,6 +46,7 @@ def test_on_update_minimal(mocker):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
+    assert handlers[0].cooldown is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -66,6 +68,7 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
+    assert handlers[0].cooldown is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -88,6 +91,7 @@ def test_on_field_minimal(mocker):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
+    assert handlers[0].cooldown is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -107,7 +111,7 @@ def test_on_create_with_all_kwargs(mocker):
 
     @kopf.on.create('group', 'version', 'plural',
                     id='id', registry=registry,
-                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -122,6 +126,7 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
+    assert handlers[0].cooldown == 78
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -134,7 +139,7 @@ def test_on_update_with_all_kwargs(mocker):
 
     @kopf.on.update('group', 'version', 'plural',
                     id='id', registry=registry,
-                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -149,6 +154,7 @@ def test_on_update_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
+    assert handlers[0].cooldown == 78
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -165,7 +171,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
 
     @kopf.on.delete('group', 'version', 'plural',
                     id='id', registry=registry,
-                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
                     optional=optional,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
@@ -181,6 +187,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
+    assert handlers[0].cooldown == 78
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -194,7 +201,7 @@ def test_on_field_with_all_kwargs(mocker):
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
                    id='id', registry=registry,
-                   errors=ErrorsMode.PERMANENT, timeout=123, retries=456,
+                   errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
                    labels={'somelabel': 'somevalue'},
                    annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -209,6 +216,7 @@ def test_on_field_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
+    assert handlers[0].cooldown == 78
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 


### PR DESCRIPTION
Extra keywords for the handlers to override the default exception-reacting behaviour (timeouts, retries, cool-down periods, arbitrary error interpretations).

> Issue : closes #16

## Description

With this PR, the error handling mode can be configured by handler (for arbitrary exceptions):

* Treat them as permanent: ``errors=kopf.ErrorsMode.PERMANENT``
* Treat them as temporary for N attempts: ``retries=3``
* Treat them as temporary for some time: ``timeout=60`` (exists already)
* Ignore them -- same as permanent, with better logging: ``errors=kopf.ErrorsMode.IGNORED``

The current and historic behaviour (the new default) is to treat all errors as temporary until the timeout is reached, or forever until the resource is deleted (if timeout is not set).

Also, a _cooldown_ period between retries can be configured. Previously, it was hard-coded to 60 seconds.

The example with exceptions is changed accordingly to demo the now extended usage.

*See the list of commits for detailed step-by-step changes.*


## Types of Changes

- New feature (non-breaking change which adds functionality)
- Refactor/improvements


## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
