### PR TITLE
Startup/cleanup handlers and operator activities

### DIFF
--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -329,6 +329,20 @@ the loop-bound variables -- which is impossible in the module-level code::
 If any of the startup handlers fails, the operator fails to start
 without making any external API calls.
 
+.. note::
+
+    If the operator is running in a Kubernetes cluster, there can be
+    timeouts set for liveness/readiness checls of a pod.
+
+    If the startup takes too longer in total (e.g. due to retries),
+    the pod can be killed by Kubernetes as not responding to the probes.
+
+    Either design the startup activities to be as fast as possible,
+    or configure the liveness/readiness probes accordingly.
+
+    Kopf itself does not set any implicit timeouts for the startup activity,
+    and it can continue forever (unless explicitly limited).
+
 
 Cleanup handlers
 ================
@@ -349,3 +363,19 @@ too long -- due to a limited graceful period or non-graceful termination.
 
 Similarly, the cleanup handlers are not executed if the operator
 is force-killed with no possibility to react (e.g. by SIGKILL).
+
+.. note::
+
+    If the operator is running in a Kubernetes cluster, there can be
+    timeouts set for graceful termination of a pod
+    (``terminationGracePeriodSeconds``, the default is 30 seconds).
+
+    If the cleanup takes longer than that in total (e.g. due to retries),
+    the activity will not be finished in full,
+    as the pod will be SIGKILL'ed by Kubernetes.
+
+    Either design the cleanup activities to be as fast as possible,
+    or configure ``terminationGracePeriodSeconds`` accordingly.
+
+    Kopf itself does not set any implicit timeouts for the cleanup activity,
+    and it can continue forever (unless explicitly limited).

--- a/examples/13-hooks/README.md
+++ b/examples/13-hooks/README.md
@@ -1,0 +1,65 @@
+# Kopf example for startup/cleanup handlers
+
+Kopf operators can have handlers invoked on startup and on cleanup.
+
+The startup handlers are slightly different from the module-level code:
+the actual tasks (e.g. API calls for watching) are not started until
+all the startup handlers succeed.
+If the handlers fail, the operator also fails.
+
+The cleanup handlers are executed when the operator exits either by a signal
+(e.g. SIGTERM), or by raising the stop-flag, or by cancelling
+the operator's asyncio task.
+They are not guaranteed to be fully executed if they take too long.
+
+In this example, we start a background task for every pod we see,
+and ask that task to finish when the operator exits. It takes some time
+for the tasks to notice the request, so the exiting is not instant.
+
+Start the operator:
+
+```bash
+kopf run example.py --verbose
+```
+
+Observe the startup logs:
+
+```
+[18:51:26,535] kopf.reactor.handlin [DEBUG   ] Invoking handler 'startup_fn_simple'.
+[18:51:26,536] kopf.reactor.handlin [INFO    ] Initialising the task-lock...
+[18:51:26,536] kopf.reactor.handlin [INFO    ] Handler 'startup_fn_simple' succeeded.
+[18:51:26,536] kopf.reactor.handlin [DEBUG   ] Invoking handler 'startup_fn_retried'.
+[18:51:26,536] kopf.reactor.handlin [ERROR   ] Handler 'startup_fn_retried' failed temporarily: Going to succeed in 3s
+[18:51:27,543] kopf.reactor.handlin [DEBUG   ] Invoking handler 'startup_fn_retried'.
+[18:51:27,544] kopf.reactor.handlin [ERROR   ] Handler 'startup_fn_retried' failed temporarily: Going to succeed in 2s
+[18:51:28,550] kopf.reactor.handlin [DEBUG   ] Invoking handler 'startup_fn_retried'.
+[18:51:28,550] kopf.reactor.handlin [ERROR   ] Handler 'startup_fn_retried' failed temporarily: Going to succeed in 1s
+[18:51:29,553] kopf.reactor.handlin [DEBUG   ] Invoking handler 'startup_fn_retried'.
+[18:51:29,553] kopf.reactor.handlin [INFO    ] Starting retried...
+[18:51:29,554] kopf.reactor.handlin [INFO    ] Handler 'startup_fn_retried' succeeded.
+[18:51:29,779] kopf.objects         [DEBUG   ] [kube-system/etcd-minikube] Invoking handler 'pod_task'.
+[18:51:29,779] kopf.objects         [INFO    ] [kube-system/etcd-minikube] Handler 'pod_task' succeeded.
+[18:51:36,784] kopf.objects         [INFO    ] [kube-system/etcd-minikube] Served by the background task.
+```
+
+Terminate the operator (depends on your IDE or CLI environment):
+
+```bash
+pkill -TERM kopf
+```
+
+Observe the cleanup logs (notice the timing — the final exit is not instant):
+
+```
+[18:51:44,122] kopf.reactor.running [INFO    ] Signal SIGINT is received. Operator is stopping.
+[18:51:44,123] kopf.reactor.running [DEBUG   ] Root task 'poster of events' is cancelled.
+[18:51:44,123] kopf.reactor.running [DEBUG   ] Root task 'watcher of pods.' is cancelled.
+[18:51:44,128] kopf.reactor.handlin [DEBUG   ] Invoking handler 'cleanup_fn'.
+[18:51:44,129] kopf.reactor.handlin [INFO    ] Cleaning up...
+[18:51:44,130] kopf.reactor.handlin [INFO    ] All pod-tasks are requested to stop...
+[18:51:44,130] kopf.reactor.handlin [INFO    ] Handler 'cleanup_fn' succeeded.
+[18:51:44,130] kopf.reactor.running [DEBUG   ] Root tasks are stopped: finished normally; tasks left: set()
+[18:51:46,789] kopf.objects         [INFO    ] [kube-system/etcd-minikube] Served by the background task.
+[18:51:46,790] kopf.objects         [INFO    ] [kube-system/etcd-minikube] Serving is finished by request.
+[18:51:49,136] kopf.reactor.running [DEBUG   ] Hung tasks are stopped: finished normally; tasks left: set()
+```

--- a/examples/99-all-at-once/example.py
+++ b/examples/99-all-at-once/example.py
@@ -9,6 +9,8 @@ import pykube
 import yaml
 
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
+E2E_STARTUP_STOP_WORDS = ['Served by the background task.']
+E2E_CLEANUP_STOP_WORDS = ['Hung tasks', 'Root tasks']
 E2E_CREATION_STOP_WORDS = ['All handlers succeeded for creation']
 E2E_DELETION_STOP_WORDS = ['Deleted, really deleted']
 E2E_SUCCESS_COUNTS = {'create_1': 1, 'create_2': 1, 'create_pod': 1, 'delete': 1}

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -47,6 +47,7 @@ from kopf.reactor.lifecycles import (
 )
 from kopf.reactor.registries import (
     ErrorsMode,
+    ActivityRegistry,
     ResourceRegistry,
     ResourceWatchingRegistry,
     ResourceChangingRegistry,
@@ -100,6 +101,7 @@ __all__ = [
     'BaseRegistry',  # deprecated
     'SimpleRegistry',  # deprecated
     'GlobalRegistry',  # deprecated
+    'ActivityRegistry',
     'ResourceRegistry',
     'ResourceWatchingRegistry',
     'ResourceChangingRegistry',

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -20,6 +20,7 @@ from kopf.reactor import registries
 from kopf.structs import bodies
 
 ResourceHandlerDecorator = Callable[[registries.ResourceHandlerFn], registries.ResourceHandlerFn]
+ActivityHandlerDecorator = Callable[[registries.ActivityHandlerFn], registries.ActivityHandlerFn]
 
 
 def resume(

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -23,6 +23,44 @@ ResourceHandlerDecorator = Callable[[registries.ResourceHandlerFn], registries.R
 ActivityHandlerDecorator = Callable[[registries.ActivityHandlerFn], registries.ActivityHandlerFn]
 
 
+def startup(
+        *,
+        id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
+        timeout: Optional[float] = None,
+        retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
+) -> ActivityHandlerDecorator:
+    actual_registry = registry if registry is not None else registries.get_default_registry()
+    def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
+        return actual_registry.register_activity_handler(
+            fn=fn, id=id,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            activity=causation.Activity.STARTUP,
+        )
+    return decorator
+
+
+def cleanup(
+        *,
+        id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
+        timeout: Optional[float] = None,
+        retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
+) -> ActivityHandlerDecorator:
+    actual_registry = registry if registry is not None else registries.get_default_registry()
+    def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
+        return actual_registry.register_activity_handler(
+            fn=fn, id=id,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            activity=causation.Activity.CLEANUP,
+        )
+    return decorator
+
+
 def resume(
         group: str, version: str, plural: str,
         *,

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -33,6 +33,8 @@ from kopf.structs import patches
 from kopf.structs import resources
 
 
+class Activity(str, enum.Enum):
+    _TODO = 'todo'
 # Constants for cause types, to prevent a direct usage of strings, and typos.
 # They are not exposed by the framework, but are used internally. See also: `kopf.on`.
 class Reason(str, enum.Enum):

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -34,7 +34,10 @@ from kopf.structs import resources
 
 
 class Activity(str, enum.Enum):
-    _TODO = 'todo'
+    STARTUP = 'startup'
+    CLEANUP = 'cleanup'
+
+
 # Constants for cause types, to prevent a direct usage of strings, and typos.
 # They are not exposed by the framework, but are used internally. See also: `kopf.on`.
 class Reason(str, enum.Enum):

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -81,13 +81,22 @@ TITLES = {
 @dataclasses.dataclass
 class BaseCause:
     logger: Union[logging.Logger, logging.LoggerAdapter]
+
+
+@dataclasses.dataclass
+class ActivityCause(BaseCause):
+    activity: Activity
+
+
+@dataclasses.dataclass
+class ResourceCause(BaseCause):
     resource: resources.Resource
     patch: patches.Patch
     body: bodies.Body
 
 
 @dataclasses.dataclass
-class ResourceWatchingCause(BaseCause):
+class ResourceWatchingCause(ResourceCause):
     """
     The raw event received from the API.
 
@@ -98,7 +107,7 @@ class ResourceWatchingCause(BaseCause):
 
 
 @dataclasses.dataclass
-class ResourceChangingCause(BaseCause):
+class ResourceChangingCause(ResourceCause):
     """
     The cause is what has caused the whole reaction as a chain of handlers.
 

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -67,6 +67,13 @@ async def invoke(
         kwargs.update(
             cause=cause,
             logger=cause.logger,
+        )
+    if isinstance(cause, causation.ActivityCause):
+        kwargs.update(
+            activity=cause.activity,
+        )
+    if isinstance(cause, causation.ResourceCause):
+        kwargs.update(
             patch=cause.patch,
             body=cause.body,
             spec=dicts.DictView(cause.body, 'spec'),

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -17,7 +17,11 @@ from kopf.reactor import lifecycles
 from kopf.reactor import registries
 from kopf.structs import dicts
 
-Invokable = Union[lifecycles.LifeCycleFn, registries.ResourceHandlerFn]
+Invokable = Union[
+    lifecycles.LifeCycleFn,
+    registries.ActivityHandlerFn,
+    registries.ResourceHandlerFn,
+]
 
 
 @contextlib.contextmanager

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -59,12 +59,11 @@ async def invoke(
     """
 
     # Add aliases for the kwargs, directly linked to the body, or to the assumed defaults.
-    if isinstance(cause, causation.ResourceWatchingCause):
+    if isinstance(cause, causation.BaseCause):
         kwargs.update(
-            event=cause.raw,
-            patch=cause.patch,
+            cause=cause,
             logger=cause.logger,
-            type=cause.type,
+            patch=cause.patch,
             body=cause.body,
             spec=dicts.DictView(cause.body, 'spec'),
             meta=dicts.DictView(cause.body, 'metadata'),
@@ -73,23 +72,18 @@ async def invoke(
             name=cause.body.get('metadata', {}).get('name'),
             namespace=cause.body.get('metadata', {}).get('namespace'),
         )
+    if isinstance(cause, causation.ResourceWatchingCause):
+        kwargs.update(
+            event=cause.raw,
+            type=cause.type,
+        )
     if isinstance(cause, causation.ResourceChangingCause):
         kwargs.update(
-            cause=cause,
             event=cause.reason,  # deprecated; kept for backward-compatibility
             reason=cause.reason,
-            body=cause.body,
             diff=cause.diff,
             old=cause.old,
             new=cause.new,
-            patch=cause.patch,
-            logger=cause.logger,
-            spec=dicts.DictView(cause.body, 'spec'),
-            meta=dicts.DictView(cause.body, 'metadata'),
-            status=dicts.DictView(cause.body, 'status'),
-            uid=cause.body.get('metadata', {}).get('uid'),
-            name=cause.body.get('metadata', {}).get('name'),
-            namespace=cause.body.get('metadata', {}).get('namespace'),
         )
 
     if is_async_fn(fn):

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -19,7 +19,7 @@ from kopf.reactor import states
 
 logger = logging.getLogger(__name__)
 
-Handlers = Sequence[registries.ResourceHandler]
+Handlers = Sequence[registries.BaseHandler]
 
 
 class LifeCycleFn(Protocol):
@@ -62,7 +62,7 @@ def shuffled(handlers: Handlers, **kwargs: Any) -> Handlers:
 def asap(handlers: Handlers, *, state: states.State, **kwargs: Any) -> Handlers:
     """ Execute one handler at a time, skip on failure, try the next one, retry after the full cycle. """
 
-    def keyfn(handler: registries.ResourceHandler) -> int:
+    def keyfn(handler: registries.BaseHandler) -> int:
         return state[handler.id].retries or 0
 
     return sorted(handlers, key=keyfn)[:1]

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -13,13 +13,14 @@ of the handlers to be executed on each reaction cycle.
 """
 import abc
 import collections
+import dataclasses
 import enum
 import functools
 import logging
 import warnings
 from types import FunctionType, MethodType
 from typing import (Any, MutableMapping, Optional, Sequence, Collection, Iterable, Iterator,
-                    NamedTuple, Union, List, Set, FrozenSet, Mapping, NewType, Callable, cast,
+                    Union, List, Set, FrozenSet, Mapping, NewType, Callable, cast,
                     Generic, TypeVar)
 
 from typing_extensions import Protocol
@@ -70,7 +71,8 @@ class ResourceHandlerFn(Protocol):
 
 
 # A registered handler (function + event meta info).
-class ResourceHandler(NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class ResourceHandler:
     fn: ResourceHandlerFn
     id: HandlerId
     reason: Optional[causation.Reason]

--- a/kopf/reactor/states.py
+++ b/kopf/reactor/states.py
@@ -190,7 +190,7 @@ class State(Mapping[registries.HandlerId, HandlerState]):
     def from_scratch(
             cls,
             *,
-            handlers: Sequence[registries.ResourceHandler],
+            handlers: Sequence[registries.BaseHandler],
     ) -> "State":
         return cls.from_body(cast(bodies.Body, {}), handlers=handlers)
 
@@ -199,7 +199,7 @@ class State(Mapping[registries.HandlerId, HandlerState]):
             cls,
             body: bodies.Body,
             *,
-            handlers: Sequence[registries.ResourceHandler],
+            handlers: Sequence[registries.BaseHandler],
     ) -> "State":
         storage = body.get('status', {}).get('kopf', {})
         progress = storage.get('progress', {})

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -3,6 +3,7 @@ All the functions to properly build the object hierarchies.
 """
 from typing import Optional, Iterable, Iterator, cast, MutableMapping, Any, Union
 
+from kopf.reactor import causation
 from kopf.reactor import handling
 from kopf.structs import bodies
 from kopf.structs import dicts
@@ -152,7 +153,7 @@ def _guess_owner(
     except LookupError:
         pass
     else:
-        if cause is not None:
+        if cause is not None and isinstance(cause, causation.ResourceCause):
             return cause.body
 
     raise LookupError("Owner must be set explicitly, since running outside of a handler.")

--- a/tests/basic-structs/test_causes.py
+++ b/tests/basic-structs/test_causes.py
@@ -1,14 +1,49 @@
 import pytest
 
-from kopf.reactor.causation import ResourceChangingCause
+from kopf.reactor.causation import ActivityCause, ResourceWatchingCause, ResourceChangingCause
 
 
-def test_no_args():
+@pytest.mark.parametrize('cls', [ActivityCause, ResourceWatchingCause, ResourceChangingCause])
+def test_cause_with_no_args(cls):
     with pytest.raises(TypeError):
-        ResourceChangingCause()
+        cls()
 
 
-def test_all_args(mocker):
+def test_activity_cause(mocker):
+    logger = mocker.Mock()
+    activity = mocker.Mock()
+    cause = ActivityCause(
+        activity=activity,
+        logger=logger,
+    )
+    assert cause.activity is activity
+    assert cause.logger is logger
+
+
+def test_resource_watching_cause(mocker):
+    logger = mocker.Mock()
+    resource = mocker.Mock()
+    body = mocker.Mock()
+    patch = mocker.Mock()
+    type = mocker.Mock()
+    raw = mocker.Mock()
+    cause = ResourceWatchingCause(
+        resource=resource,
+        logger=logger,
+        body=body,
+        patch=patch,
+        type=type,
+        raw=raw,
+    )
+    assert cause.resource is resource
+    assert cause.logger is logger
+    assert cause.body is body
+    assert cause.patch is patch
+    assert cause.type is type
+    assert cause.raw is raw
+
+
+def test_resource_changing_cause_with_all_args(mocker):
     logger = mocker.Mock()
     resource = mocker.Mock()
     reason = mocker.Mock()
@@ -41,7 +76,7 @@ def test_all_args(mocker):
     assert cause.new is new
 
 
-def test_required_args(mocker):
+def test_resource_changing_cause_with_only_required_args(mocker):
     logger = mocker.Mock()
     resource = mocker.Mock()
     reason = mocker.Mock()

--- a/tests/basic-structs/test_handlers.py
+++ b/tests/basic-structs/test_handlers.py
@@ -1,14 +1,41 @@
 import pytest
 
-from kopf.reactor.registries import ResourceHandler
+from kopf.reactor.registries import ActivityHandler, ResourceHandler
 
 
-def test_no_args():
+@pytest.mark.parametrize('cls', [ActivityHandler, ResourceHandler])
+def test_handler_with_no_args(cls):
     with pytest.raises(TypeError):
-        ResourceHandler()
+        cls()
 
 
-def test_all_args(mocker):
+def test_activity_handler_with_all_args(mocker):
+    fn = mocker.Mock()
+    id = mocker.Mock()
+    errors = mocker.Mock()
+    timeout = mocker.Mock()
+    retries = mocker.Mock()
+    cooldown = mocker.Mock()
+    activity = mocker.Mock()
+    handler = ActivityHandler(
+        fn=fn,
+        id=id,
+        errors=errors,
+        timeout=timeout,
+        retries=retries,
+        cooldown=cooldown,
+        activity=activity,
+    )
+    assert handler.fn is fn
+    assert handler.id is id
+    assert handler.errors is errors
+    assert handler.timeout is timeout
+    assert handler.retries is retries
+    assert handler.cooldown is cooldown
+    assert handler.activity is activity
+
+
+def test_resource_handler_with_all_args(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
     reason = mocker.Mock()

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -1,0 +1,146 @@
+from typing import Mapping
+
+import freezegun
+import pytest
+
+from kopf.reactor.causation import Activity
+from kopf.reactor.handling import ActivityError, PermanentError, TemporaryError, activity_trigger
+from kopf.reactor.lifecycles import all_at_once
+from kopf.reactor.registries import HandlerId, OperatorRegistry
+from kopf.reactor.states import HandlerOutcome
+
+
+def test_activity_error_exception():
+    outcome = HandlerOutcome(final=True)
+    outcomes: Mapping[HandlerId, HandlerOutcome]
+    outcomes = {HandlerId('id'): outcome}
+    error = ActivityError("message", outcomes=outcomes)
+    assert str(error) == "message"
+    assert error.outcomes == outcomes
+
+
+@pytest.mark.parametrize('activity', list(Activity))
+async def test_results_are_returned_on_success(activity):
+
+    def sample_fn1(**_):
+        return 123
+
+    def sample_fn2(**_):
+        return 456
+
+    registry = OperatorRegistry()
+    registry.register_activity_handler(fn=sample_fn1, id='id1', activity=activity)
+    registry.register_activity_handler(fn=sample_fn2, id='id2', activity=activity)
+
+    results = await activity_trigger(
+        registry=registry,
+        activity=activity,
+        lifecycle=all_at_once,
+    )
+
+    assert set(results.keys()) == {'id1', 'id2'}
+    assert results['id1'] == 123
+    assert results['id2'] == 456
+
+
+@pytest.mark.parametrize('activity', list(Activity))
+async def test_errors_are_raised_aggregated(activity):
+
+    def sample_fn1(**_):
+        raise PermanentError("boo!123")
+
+    def sample_fn2(**_):
+        raise PermanentError("boo!456")
+
+    registry = OperatorRegistry()
+    registry.register_activity_handler(fn=sample_fn1, id='id1', activity=activity)
+    registry.register_activity_handler(fn=sample_fn2, id='id2', activity=activity)
+
+    with pytest.raises(ActivityError) as e:
+        await activity_trigger(
+            registry=registry,
+            activity=activity,
+            lifecycle=all_at_once,
+        )
+
+    assert set(e.value.outcomes.keys()) == {'id1', 'id2'}
+    assert e.value.outcomes['id1'].final
+    assert e.value.outcomes['id1'].delay is None
+    assert e.value.outcomes['id1'].result is None
+    assert e.value.outcomes['id1'].exception is not None
+    assert e.value.outcomes['id2'].final
+    assert e.value.outcomes['id2'].delay is None
+    assert e.value.outcomes['id2'].result is None
+    assert e.value.outcomes['id2'].exception is not None
+    assert str(e.value.outcomes['id1'].exception) == "boo!123"
+    assert str(e.value.outcomes['id2'].exception) == "boo!456"
+
+
+@pytest.mark.parametrize('activity', list(Activity))
+async def test_errors_are_cascaded_from_one_of_the_originals(activity):
+
+    def sample_fn(**_):
+        raise PermanentError("boo!")
+
+    registry = OperatorRegistry()
+    registry.register_activity_handler(fn=sample_fn, id='id', activity=activity)
+
+    with pytest.raises(ActivityError) as e:
+        await activity_trigger(
+            registry=registry,
+            activity=activity,
+            lifecycle=all_at_once,
+        )
+
+    assert e.value.__cause__
+    assert type(e.value.__cause__) is PermanentError
+    assert str(e.value.__cause__) == "boo!"
+
+
+@pytest.mark.parametrize('activity', list(Activity))
+async def test_retries_are_simulated(activity, mocker):
+    mock = mocker.MagicMock()
+
+    def sample_fn(**_):
+        mock()
+        raise TemporaryError('to be retried', delay=0)
+
+    registry = OperatorRegistry()
+    registry.register_activity_handler(fn=sample_fn, id='id', activity=activity, retries=3)
+
+    with pytest.raises(ActivityError) as e:
+        await activity_trigger(
+            registry=registry,
+            activity=activity,
+            lifecycle=all_at_once,
+        )
+
+    assert isinstance(e.value.outcomes['id'].exception, PermanentError)
+    assert mock.call_count == 3
+
+
+@pytest.mark.parametrize('activity', list(Activity))
+async def test_delays_are_simulated(activity, mocker):
+
+    def sample_fn(**_):
+        raise TemporaryError('to be retried', delay=123)
+
+    registry = OperatorRegistry()
+    registry.register_activity_handler(fn=sample_fn, id='id', activity=activity, retries=3)
+
+    with freezegun.freeze_time() as frozen:
+
+        async def sleep_or_wait_substitute(*_, **__):
+            frozen.tick(123)
+
+        sleep_or_wait = mocker.patch('kopf.engines.sleeping.sleep_or_wait',
+                                     wraps=sleep_or_wait_substitute)
+
+        with pytest.raises(ActivityError) as e:
+            await activity_trigger(
+                registry=registry,
+                activity=activity,
+                lifecycle=all_at_once,
+            )
+
+    assert sleep_or_wait.call_count == 3  # 3 retries, 1 sleep each

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -1,7 +1,26 @@
 import pytest
 
-from kopf import ResourceWatchingRegistry, ResourceChangingRegistry, OperatorRegistry
+from kopf import ActivityRegistry
+from kopf import ResourceWatchingRegistry, ResourceChangingRegistry
+from kopf import OperatorRegistry
 from kopf import SimpleRegistry, GlobalRegistry  # deprecated, but tested
+
+
+@pytest.fixture(params=[
+    pytest.param(ActivityRegistry, id='activity-registry'),
+    pytest.param(ResourceWatchingRegistry, id='resource-watching-registry'),
+    pytest.param(ResourceChangingRegistry, id='resource-changing-registry'),
+    pytest.param(SimpleRegistry, id='simple-registry'),  # deprecated
+])
+def generic_registry_cls(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    pytest.param(ActivityRegistry, id='activity-registry'),
+])
+def activity_registry_cls(request):
+    return request.param
 
 
 @pytest.fixture(params=[

--- a/tests/registries/test_creation.py
+++ b/tests/registries/test_creation.py
@@ -1,4 +1,10 @@
-from kopf import ResourceRegistry, OperatorRegistry
+from kopf import ActivityRegistry, ResourceRegistry, OperatorRegistry
+
+
+def test_activity_registry_with_no_prefix(activity_registry_cls):
+    registry = activity_registry_cls()
+    assert isinstance(registry, ActivityRegistry)
+    assert registry.prefix is None
 
 
 def test_resource_registry_with_no_prefix(resource_registry_cls):

--- a/tests/registries/test_registering.py
+++ b/tests/registries/test_registering.py
@@ -1,15 +1,19 @@
 import collections.abc
 
+import pytest
+
+from kopf.reactor.causation import Activity
+
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.
 def some_fn():
     pass
 
 
-def test_resource_registry_via_iter(mocker, resource_registry_cls):
+def test_generic_registry_via_iter(mocker, generic_registry_cls):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = resource_registry_cls()
+    registry = generic_registry_cls()
     iterator = registry.iter_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
@@ -21,10 +25,10 @@ def test_resource_registry_via_iter(mocker, resource_registry_cls):
     assert not handlers
 
 
-def test_resource_registry_via_list(mocker, resource_registry_cls):
+def test_generic_registry_via_list(mocker, generic_registry_cls):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = resource_registry_cls()
+    registry = generic_registry_cls()
     handlers = registry.get_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -33,15 +37,31 @@ def test_resource_registry_via_list(mocker, resource_registry_cls):
     assert not handlers
 
 
-def test_resource_registry_with_minimal_signature(mocker, resource_registry_cls):
+def test_generic_registry_with_minimal_signature(mocker, generic_registry_cls):
     cause = mocker.Mock(event=None, diff=None)
 
-    registry = resource_registry_cls()
+    registry = generic_registry_cls()
     registry.register(some_fn)
     handlers = registry.get_handlers(cause)
 
     assert len(handlers) == 1
     assert handlers[0].fn is some_fn
+
+
+@pytest.mark.parametrize('activity', list(Activity))
+def test_operator_registry_with_activity_via_iter(
+        operator_registry_cls, activity):
+
+    registry = operator_registry_cls()
+    iterator = registry.iter_activity_handlers(activity=activity)
+
+    assert isinstance(iterator, collections.abc.Iterator)
+    assert not isinstance(iterator, collections.abc.Collection)
+    assert not isinstance(iterator, collections.abc.Container)
+    assert not isinstance(iterator, (list, tuple))
+
+    handlers = list(iterator)
+    assert not handlers
 
 
 def test_operator_registry_with_resource_watching_via_iter(
@@ -76,6 +96,19 @@ def test_operator_registry_with_resource_changing_via_iter(
     assert not handlers
 
 
+@pytest.mark.parametrize('activity', list(Activity))
+def test_operator_registry_with_activity_via_list(
+        operator_registry_cls, activity):
+
+    registry = operator_registry_cls()
+    handlers = registry.get_activity_handlers(activity=activity)
+
+    assert isinstance(handlers, collections.abc.Iterable)
+    assert isinstance(handlers, collections.abc.Container)
+    assert isinstance(handlers, collections.abc.Collection)
+    assert not handlers
+
+
 def test_operator_registry_with_resource_watching_via_list(
         mocker, operator_registry_cls, resource):
     cause = mocker.Mock(resource=resource, event=None, diff=None)
@@ -100,6 +133,18 @@ def test_operator_registry_with_resource_changing_via_list(
     assert isinstance(handlers, collections.abc.Container)
     assert isinstance(handlers, collections.abc.Collection)
     assert not handlers
+
+
+@pytest.mark.parametrize('activity', list(Activity))
+def test_operator_registry_with_activity_with_minimal_signature(
+        operator_registry_cls, activity):
+
+    registry = operator_registry_cls()
+    registry.register_activity_handler(some_fn)
+    handlers = registry.get_activity_handlers(activity=activity)
+
+    assert len(handlers) == 1
+    assert handlers[0].fn is some_fn
 
 
 def test_operator_registry_with_resource_watching_with_minimal_signature(


### PR DESCRIPTION
> Issue : #59

## Description

Startup/cleanup handlers are not resource-related, so they cannot rely on the Kubernetes watch-streams to be triggered. In addition, they should happen before & after the reactor actually starts/stops working with the resources.

This PR adds the `@kopf.on.startup` & `@kopf.on.cleanup` handlers.

The `@kopf.on.startup` handlers are executed on the operator startup. If one of the handlers fails, the operator does not start.

The `@kopf.on.cleanup` handlers are executed in the end after a stop signal is received or a stop-flag is set. The cleanup handlers are not guaranted to be executed at all -- e.g. if the process is SIGKILL'ed or crashes. In all normal shutdown sequences, it is attempted to be executed in full.

As a side goal, this PR introduces the operator _activities_ in general, of which starup/cleanup handlers are only specific cases. The _activities_ will be used for (re-)authentication later.

*See the list of commits for detailed step-by-step changes.*

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Refactor/improvements

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
