### PR TITLE
Liveliness/readiness probes

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -58,6 +58,10 @@ For this, create the deployment file:
 Please note that there is only one replica. Keep it so. If there will be
 two or more operators running in the cluster for the same objects,
 they will collide with each other and the consequences are unpredictable.
+In case of pod restarts, only one pod should be running at a time too:
+use ``.spec.strategy.type=Recreate`` (see the documentation_).
+
+.. _documentation: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment
 
 Deploy it to the cluster:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Kopf: Kubernetes Operators Framework
    hierarchies
    async
    loading
+   probing
    peering
    scopes
    errors

--- a/docs/probing.rst
+++ b/docs/probing.rst
@@ -1,0 +1,51 @@
+=============
+Health-checks
+=============
+
+Kopf provides a minimalistic HTTP server to report its health status.
+
+By default, no endpoint is configured, and no health is reported.
+To specify an endpoint to listen for probes, use :option:`--liveness`:
+
+.. code-block:: bash
+
+    kopf run --liveness=http://:8080/healthz --verbose handlers.py
+
+Currently, only HTTP is supported.
+Other protocols (TCP, HTTPS) can be added in the future.
+
+This port and path can be used in a liveness probe of the operator's deployment.
+If the operator does not respond for any reason, Kubernetes will restart it.
+
+.. code-block:: yaml
+
+   apiVersion: apps/v1
+   kind: Deployment
+   spec:
+     template:
+       spec:
+         containers:
+         - name: the-only-one
+           image: ...
+           livenessProbe:
+             httpGet:
+               path: /healthz
+               port: 8080
+
+.. seealso::
+    :doc:`deployment` for deployment patterns.
+
+    Kubernetes manual on `liveness and readiness probes`__.
+
+__ https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+
+.. note::
+    Liveless status report is simplistic and minimalistic at the moment.
+    It only reports success if the health-reporting task runs at all.
+    It can happen so that some of the operator's tasks, threads, or streams
+    do break, freeze, or become unresponsive, while the health-reporting task
+    continues to run. The probability of such case is low, but not zero.
+
+    There are no checks that operator actually operates anything,
+    as there are no reliable criteria for that (total absence of handled
+    resources or events can be an expected state of the cluster).

--- a/docs/probing.rst
+++ b/docs/probing.rst
@@ -41,11 +41,25 @@ If the operator does not respond for any reason, Kubernetes will restart it.
                port: 8080
 
 .. seealso::
-    :doc:`deployment` for deployment patterns.
 
     Kubernetes manual on `liveness and readiness probes`__.
 
 __ https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+
+.. seealso::
+
+    Please be aware of the readiness vs. liveness probing.
+    In case of operators, readiness probing makes no practical sense,
+    as operators do not serve traffic under the load balancing or with services.
+    Liveness probing can help in disastrous cases (e.g. the operator is stuck),
+    but will not help in case of partial failures (one of the API calls stuck).
+    You can read more here:
+    https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html
+
+.. warning::
+
+    Make sure that one and only one pod of an operator is running at a time,
+    especially during the restarts --- see :doc:`deployment`.
 
 
 Probe handlers

--- a/docs/probing.rst
+++ b/docs/probing.rst
@@ -4,6 +4,10 @@ Health-checks
 
 Kopf provides a minimalistic HTTP server to report its health status.
 
+
+Liveness endpoints
+==================
+
 By default, no endpoint is configured, and no health is reported.
 To specify an endpoint to listen for probes, use :option:`--liveness`:
 
@@ -13,6 +17,10 @@ To specify an endpoint to listen for probes, use :option:`--liveness`:
 
 Currently, only HTTP is supported.
 Other protocols (TCP, HTTPS) can be added in the future.
+
+
+Kubernetes probing
+==================
 
 This port and path can be used in a liveness probe of the operator's deployment.
 If the operator does not respond for any reason, Kubernetes will restart it.
@@ -39,6 +47,38 @@ If the operator does not respond for any reason, Kubernetes will restart it.
 
 __ https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 
+
+Probe handlers
+==============
+
+The content of the response is empty by default. It can be populated with
+probing handlers:
+
+.. code-block:: python
+
+    import datetime
+    import kopf
+    import random
+
+    @kopf.on.probe(id='now')
+    def get_current_timestamp(**kwargs):
+        return datetime.datetime.utcnow().isoformat()
+
+    @kopf.on.probe(id='random')
+    def get_random_value(**kwargs):
+        return random.randint(0, 1_000_000)
+
+The probe handlers will be executed on the requests to the liveness URL,
+and cached for a reasonable period of time to prevent overloading
+by mass-requesting the status.
+
+The handler results will be reported as the content of the liveness response:
+
+.. code-block:: console
+
+    $ curl http://localhost:8080/healthz
+    {"now": "2019-11-07T18:03:52.513803", "random": 765846}
+
 .. note::
     Liveless status report is simplistic and minimalistic at the moment.
     It only reports success if the health-reporting task runs at all.
@@ -46,6 +86,7 @@ __ https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-r
     do break, freeze, or become unresponsive, while the health-reporting task
     continues to run. The probability of such case is low, but not zero.
 
-    There are no checks that operator actually operates anything,
-    as there are no reliable criteria for that (total absence of handled
-    resources or events can be an expected state of the cluster).
+    There are no checks that operator actually operates anything
+    (unless they are implemented explicitly with the probe-handlers),
+    as there are no reliable criteria for that -- total absence of handled
+    resources or events can be an expected state of the cluster.

--- a/examples/06-peering/README.md
+++ b/examples/06-peering/README.md
@@ -2,7 +2,7 @@
 
 When multiple operators start for the same cluster (in the cluster or outside),
 they become aware about each other, and exchange the basic information about
-their liveliness and the priorities, and cooperate to avoid the undesired
+their liveness and the priorities, and cooperate to avoid the undesired
 side-effects (e.g., duplicated children creation, infinite cross-changes).
 
 The main use-case for this is the development mode: when a developer starts

--- a/examples/13-hooks/example.py
+++ b/examples/13-hooks/example.py
@@ -63,6 +63,16 @@ async def login_fn(**kwargs):
     )
 
 
+@kopf.on.probe()
+async def tasks_count(**kwargs):
+    return sum([len(flags) for flags in STOPPERS.values()])
+
+
+@kopf.on.probe()
+async def monitored_objects(**kwargs):
+    return {namespace: sorted([name for name in STOPPERS[namespace]]) for namespace in STOPPERS}
+
+
 @kopf.on.event('', 'v1', 'pods')
 async def pod_task(namespace, name, logger, **_):
     async with LOCK:

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -46,6 +46,7 @@ def main() -> None:
 @click.option('-n', '--namespace', default=None)
 @click.option('--standalone', is_flag=True, default=False)
 @click.option('--dev', 'priority', type=int, is_flag=True, flag_value=666)
+@click.option('-L', '--liveness', 'liveness_endpoint', type=str)
 @click.option('-P', '--peering', 'peering_name', type=str, default=None, envvar='KOPF_RUN_PEERING')
 @click.option('-p', '--priority', type=int, default=0)
 @click.option('-m', '--module', 'modules', multiple=True)
@@ -59,6 +60,7 @@ def run(
         priority: int,
         standalone: bool,
         namespace: Optional[str],
+        liveness_endpoint: Optional[str],
 ) -> None:
     """ Start an operator process and handle all the requests. """
     loaders.preload(
@@ -70,6 +72,7 @@ def run(
         namespace=namespace,
         priority=priority,
         peering_name=peering_name,
+        liveness_endpoint=liveness_endpoint,
         stop_flag=__controls.stop_flag,
         ready_flag=__controls.ready_flag,
         vault=__controls.vault,

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -1,0 +1,65 @@
+import asyncio
+import logging
+import urllib.parse
+from typing import Optional, Tuple
+
+import aiohttp.web
+
+logger = logging.getLogger(__name__)
+
+LOCALHOST: str = 'localhost'
+HTTP_PORT: int = 80
+
+_Key = Tuple[str, int]  # hostname, port
+
+
+async def get_health(
+        request: aiohttp.web.Request,
+) -> aiohttp.web.Response:
+    return aiohttp.web.json_response({
+        'status': 'OK',
+    })
+
+
+async def health_reporter(
+        endpoint: str,
+        *,
+        ready_flag: Optional[asyncio.Event] = None,  # used for testing
+) -> None:
+    """
+    Simple HTTP(S)/TCP server to report the operator's health to K8s probes.
+
+    Runs forever until cancelled (which happens if any other root task
+    is cancelled or failed). Once it will stop responding for any reason,
+    Kubernetes will assume the pod is not alive anymore, and will restart it.
+    """
+
+    parts = urllib.parse.urlsplit(endpoint)
+    if parts.scheme == 'http':
+        host = parts.hostname or LOCALHOST
+        port = parts.port or HTTP_PORT
+        path = parts.path
+    else:
+        raise Exception(f"Unsupported scheme: {endpoint}")
+
+    app = aiohttp.web.Application()
+    app.add_routes([aiohttp.web.get(path, get_health)])
+
+    runner = aiohttp.web.AppRunner(app, handle_signals=False)
+    await runner.setup()
+
+    site = aiohttp.web.TCPSite(runner, host, port, shutdown_timeout=1.0)
+    await site.start()
+
+    # Log with the actual URL: normalised, with hostname/port set.
+    url = urllib.parse.urlunsplit([parts.scheme, f'{host}:{port}', path, '', ''])
+    logger.debug("Serving health status at %s", url)
+    if ready_flag is not None:
+        ready_flag.set()
+
+    try:
+        # Sleep forever. No activity is needed.
+        await asyncio.Event().wait()
+    finally:
+        # On any reason of exit, stop reporting the health.
+        await asyncio.shield(runner.cleanup())

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -81,6 +81,26 @@ def login(
     return decorator
 
 
+def probe(
+        *,
+        id: Optional[str] = None,
+        errors: Optional[registries.ErrorsMode] = None,
+        timeout: Optional[float] = None,
+        retries: Optional[int] = None,
+        cooldown: Optional[float] = None,
+        registry: Optional[registries.OperatorRegistry] = None,
+) -> ActivityHandlerDecorator:
+    """ ``@kopf.on.probe()`` handler for arbitrary liveness metrics. """
+    actual_registry = registry if registry is not None else registries.get_default_registry()
+    def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
+        return actual_registry.register_activity_handler(
+            fn=fn, id=id,
+            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            activity=causation.Activity.PROBE,
+        )
+    return decorator
+
+
 def resume(
         group: str, version: str, plural: str,
         *,

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -37,6 +37,7 @@ class Activity(str, enum.Enum):
     STARTUP = 'startup'
     CLEANUP = 'cleanup'
     AUTHENTICATION = 'authentication'
+    PROBE = 'probe'
 
 
 # Constants for cause types, to prevent a direct usage of strings, and typos.

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -38,7 +38,7 @@ from kopf.structs import patches
 from kopf.structs import resources
 
 WAITING_KEEPALIVE_INTERVAL = 10 * 60
-""" How often to wake up from the long sleep, to show the liveliness. """
+""" How often to wake up from the long sleep, to show liveness in the logs. """
 
 DEFAULT_RETRY_DELAY = 1 * 60
 """ The default delay duration for the regular exception in retry-mode. """

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -219,6 +219,7 @@ async def spawn_tasks(
             loop.create_task(_root_task_checker(
                 name="health reporter", ready_flag=ready_flag,
                 coro=probing.health_reporter(
+                    registry=registry,
                     endpoint=liveness_endpoint))),
         ])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ urllib3<1.25
 -e .
 
 # Everything needed to develop (test, debug) the framework.
+pytest-aiohttp
 pytest-asyncio
 pytest-mock>=1.11.1
 pytest-cov

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -41,6 +41,23 @@ def test_on_cleanup_minimal():
     assert handlers[0].cooldown is None
 
 
+def test_on_probe_minimal():
+    registry = kopf.get_default_registry()
+
+    @kopf.on.probe()
+    def fn(**_):
+        pass
+
+    handlers = registry.get_activity_handlers(activity=Activity.PROBE)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].activity == Activity.PROBE
+    assert handlers[0].errors is None
+    assert handlers[0].timeout is None
+    assert handlers[0].retries is None
+    assert handlers[0].cooldown is None
+
+
 def test_on_create_minimal(mocker):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
@@ -170,6 +187,26 @@ def test_on_cleanup_with_all_kwargs(mocker):
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].activity == Activity.CLEANUP
+    assert handlers[0].id == 'id'
+    assert handlers[0].errors == ErrorsMode.PERMANENT
+    assert handlers[0].timeout == 123
+    assert handlers[0].retries == 456
+    assert handlers[0].cooldown == 78
+
+
+def test_on_probe_with_all_kwargs(mocker):
+    registry = OperatorRegistry()
+
+    @kopf.on.probe(
+        id='id', registry=registry,
+        errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_activity_handlers(activity=Activity.PROBE)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].activity == Activity.PROBE
     assert handlers[0].id == 'id'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -1,0 +1,35 @@
+import asyncio
+
+import aiohttp
+
+from kopf.engines.probing import health_reporter
+
+
+async def test_liveness(aiohttp_unused_port):
+
+    # The server startup is not instant, so we need a readiness flag.
+    ready_flag = asyncio.Event()
+
+    port = aiohttp_unused_port()
+    server = asyncio.create_task(
+        health_reporter(
+            endpoint=f'http://:{port}/xyz',
+            ready_flag=ready_flag,
+        )
+    )
+
+    try:
+        url = f'http://localhost:{port}/xyz'
+        await ready_flag.wait()
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                data = await response.json()
+                assert isinstance(data, dict)
+                assert data['status'] == 'OK'
+
+    finally:
+        server.cancel()
+        try:
+            await server
+        except asyncio.CancelledError:
+            pass

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -1,11 +1,20 @@
 import asyncio
 
 import aiohttp
+import pytest
 
 from kopf.engines.probing import health_reporter
+from kopf.reactor.causation import Activity
+from kopf.reactor.registries import OperatorRegistry
 
 
-async def test_liveness(aiohttp_unused_port):
+@pytest.fixture()
+async def liveness_registry():
+    return OperatorRegistry()
+
+
+@pytest.fixture()
+async def liveness_url(liveness_registry, aiohttp_unused_port):
 
     # The server startup is not instant, so we need a readiness flag.
     ready_flag = asyncio.Event()
@@ -14,22 +23,63 @@ async def test_liveness(aiohttp_unused_port):
     server = asyncio.create_task(
         health_reporter(
             endpoint=f'http://:{port}/xyz',
+            registry=liveness_registry,
             ready_flag=ready_flag,
         )
     )
 
     try:
-        url = f'http://localhost:{port}/xyz'
         await ready_flag.wait()
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url) as response:
-                data = await response.json()
-                assert isinstance(data, dict)
-                assert data['status'] == 'OK'
-
+        yield f'http://localhost:{port}/xyz'
     finally:
         server.cancel()
         try:
             await server
         except asyncio.CancelledError:
             pass
+
+
+async def test_liveness_for_just_status(liveness_url):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(liveness_url) as response:
+            data = await response.json()
+            assert isinstance(data, dict)
+
+
+async def test_liveness_with_reporting(liveness_url, liveness_registry):
+
+    def fn1(**kwargs):
+        return {'x': 100}
+
+    def fn2(**kwargs):
+        return {'y': '200'}
+
+    liveness_registry.register_activity_handler(fn=fn1, id='id1', activity=Activity.PROBE)
+    liveness_registry.register_activity_handler(fn=fn2, id='id2', activity=Activity.PROBE)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(liveness_url) as response:
+            data = await response.json()
+            assert isinstance(data, dict)
+            assert data == {'id1': {'x': 100}, 'id2': {'y': '200'}}
+
+
+async def test_liveness_data_is_cached(liveness_url, liveness_registry):
+    counter = 0
+
+    def fn1(**kwargs):
+        nonlocal counter
+        counter += 1
+        return {'counter': counter}
+
+    liveness_registry.register_activity_handler(fn=fn1, id='id1', activity=Activity.PROBE)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(liveness_url) as response:
+            data = await response.json()
+            assert isinstance(data, dict)
+            assert data == {'id1': {'counter': 1}}
+        async with session.get(liveness_url) as response:
+            data = await response.json()
+            assert isinstance(data, dict)
+            assert data == {'id1': {'counter': 1}}  # not 2!


### PR DESCRIPTION
Add a rudimentary liveness probe via an HTTP endpoint

> Issue: closes #18

## Description

Having Kopf's core now fully in `asyncio` and `aiohttp` (#227), we can add a little web server to serve the liveness probes of the operator. 

It can be used by Kubernetes to see if the process is at all alive.

By default, there is no useful information reported, and only HTTP status codes can be used to track the liveness — e.g. 200 OK.

Optionally, the reported information can be collected from the `@kopf.on.probe` handlers, e.g. containing the app-specific metrics (see docs & examples). Some basic DoS/DDoS protection is made. But the endpoint is supposed to be internal, so it is only a precaution for accidental misconfiguration.


## Types of Changes

- New feature (non-breaking change which adds functionality)


## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation

