### PR TITLE
Skip resumes for deleted objects, unless explicitly marked for selection

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -110,6 +110,7 @@ def resume(
         retries: Optional[int] = None,
         cooldown: Optional[float] = None,
         registry: Optional[registries.OperatorRegistry] = None,
+        deleted: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
 ) -> ResourceHandlerDecorator:
@@ -118,7 +119,7 @@ def resume(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
-            reason=None, initial=True, id=id,
+            reason=None, initial=True, deleted=deleted, id=id,
             errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -130,6 +130,11 @@ class ResourceChangingCause(ResourceCause):
         warnings.warn("`cause.event` is deprecated; use `cause.reason`.", DeprecationWarning)
         return self.reason
 
+    @property
+    def deleted(self) -> bool:
+        """ Used to conditionally skip/select the @on.resume handlers if the object is deleted. """
+        return finalizers.is_deleted(self.body)
+
 
 def detect_resource_watching_cause(
         event: bodies.Event,

--- a/tests/registries/test_resumes_mixed_in.py
+++ b/tests/registries/test_resumes_mixed_in.py
@@ -1,0 +1,64 @@
+import pytest
+
+import kopf
+from kopf.reactor.causation import Reason, HANDLER_REASONS
+from kopf.structs.resources import Resource
+
+
+@pytest.mark.parametrize('deleted', [True, False, None])
+@pytest.mark.parametrize('reason', HANDLER_REASONS)
+def test_resumes_ignored_for_non_initial_causes(mocker, reason, deleted):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=reason, initial=False, deleted=deleted)
+
+    @kopf.on.resume('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 0
+
+
+@pytest.mark.parametrize('reason', list(set(HANDLER_REASONS) - {Reason.DELETE}))
+def test_resumes_selected_for_initial_non_deletions(mocker, reason):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
+
+    @kopf.on.resume('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+
+
+@pytest.mark.parametrize('reason', [Reason.DELETE])
+def test_resumes_ignored_for_initial_deletions_by_default(mocker, reason):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=True)
+
+    @kopf.on.resume('group', 'version', 'plural')
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 0
+
+
+@pytest.mark.parametrize('reason', [Reason.DELETE])
+def test_resumes_selected_for_initial_deletions_when_explicitly_marked(mocker, reason):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=True)
+
+    @kopf.on.resume('group', 'version', 'plural', deleted=True)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn


### PR DESCRIPTION
Prevent resource/memory leaks in some edge cases with resuming+deletion handlers.

> Issue : #112 #230 

## Description

In #230, the resume handlers were fixed to be executed as regular resource-changing handlers, with multiple iterations if needed. Previously, they were executed only if they were _lucky_ to be the first and the only in the row, and if never retried due to errors.

---

**Problem:** 

This led to the resuming handlers executed even if the object was marked for deletion during the operator downtime/restart. Which, from one point of view, makes sense — since the object exists out there (only "marked" for deletion, but not actually deleted), so should be "resumed" in memory (despite it will be shut down and freed in few moments). 

But, from another point of view, leads to potential memory/resource leaks, if the deletion handlers are used to free the resources and stop the tasks, and the resuming handlers allocate and start them accordingly — after they were released/stopped.

Consider an example below and a case when the operator starts and notices an object marked for deletion — should it spawn a task then?

```python
    TASKS = {}

    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples')
    async def my_handler(spec, name, **_):
        if name in TASKS:
            TASKS[name].cancel()

    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples')
    @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
    def my_handler(spec, **_):
        if name not in TASKS:
            TASKS[name] = asyncio.create_task(some_coroutine(spec))
```

The order of handlers is not a solution, as it can be altered at runtime due to error retries in the real cases with more logic.

---

**Solution:**

Kopf's goal is to be intuitive and human-friendly in the first place. Based on this consideration, with this PR, the resuming handlers are NOT invoked if the object is undergoing the deletion when the operator is restarted. This also matches the previous (buggy) behaviour.

However, if that is desired, a developer can declare the resume handler as deletion-compatible with `deleted=True` (see the docs in this PR), and the resuming handler will be executed even on the deletions.

The main code snippet in this PR is this one:

```python
                if handler.initial and not cause.initial:
                    pass  # ignore initial handlers in non-initial causes.
                elif handler.initial and cause.deleted and not handler.deleted:
                    pass  # ignore initial handlers on deletion, unless explicitly marked as usable.
                elif match(handler=handler, body=cause.body, changed_fields=changed_fields):
                    yield handler
```

---

Beside of the main change, the tests were added for the resuming decorators and handler selection. It seems, they were absent previously.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
