### PR TITLE
Use `memo` for arbitrary per-resource payload during operator lifetime

### DIFF
--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -56,6 +56,8 @@ Arguments
 The following keyword arguments are available to the handlers
 (though some handlers may have some of them empty):
 
+* ``memo`` for arbitrary in-memory runtime-only keys/fields and values stored
+  during the operator lifetime, per-object; they are lost on operator restarts.
 * ``body`` for the whole body of the handled objects.
 * ``spec`` as an alias for ``body['spec']``.
 * ``meta`` as an alias for ``body['metadata']``.

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -26,6 +26,7 @@ import warnings
 from typing import Any, Optional, Union, TypeVar
 
 from kopf.structs import bodies
+from kopf.structs import containers
 from kopf.structs import diffs
 from kopf.structs import finalizers
 from kopf.structs import lastseen
@@ -98,6 +99,7 @@ class ResourceCause(BaseCause):
     resource: resources.Resource
     patch: patches.Patch
     body: bodies.Body
+    memo: containers.ObjectDict
 
 
 @dataclasses.dataclass

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -189,6 +189,7 @@ async def resource_handler(
             resource=resource,
             logger=logger,
             patch=patch,
+            memo=memory.user_data,
         )
         await handle_resource_watching_cause(
             lifecycle=lifecycles.all_at_once,
@@ -210,6 +211,7 @@ async def resource_handler(
             old=old,
             new=new,
             diff=diff,
+            memo=memory.user_data,
             initial=memory.noticed_by_listing and not memory.fully_handled_once,
             requires_finalizer=registry.requires_finalizer(resource=resource, body=body),
         )

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -75,6 +75,7 @@ async def invoke(
     if isinstance(cause, causation.ResourceCause):
         kwargs.update(
             patch=cause.patch,
+            memo=cause.memo,
             body=cause.body,
             spec=dicts.DictView(cause.body, 'spec'),
             meta=dicts.DictView(cause.body, 'metadata'),

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -8,24 +8,24 @@ It is used internally to track allocated system resources for each Kubernetes
 object, even if that object does not show up in the event streams for long time.
 """
 import dataclasses
-from typing import MutableMapping
+from typing import MutableMapping, Dict, Any
 
 from kopf.structs import bodies
 
 
-class ObjectDict(dict):
+class ObjectDict(Dict[Any, Any]):
     """ A container to hold arbitrary keys-fields assigned by the users. """
 
-    def __setattr__(self, key, value):
+    def __setattr__(self, key: str, value: Any) -> None:
         self[key] = value
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str) -> None:
         try:
             del self[key]
         except KeyError as e:
             raise AttributeError(str(e))
 
-    def __getattr__(self, key):
+    def __getattr__(self, key: str) -> Any:
         try:
             return self[key]
         except KeyError as e:

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -13,9 +13,33 @@ from typing import MutableMapping
 from kopf.structs import bodies
 
 
+class ObjectDict(dict):
+    """ A container to hold arbitrary keys-fields assigned by the users. """
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    def __delitem__(self, key):
+        try:
+            del self[key]
+        except KeyError as e:
+            raise AttributeError(str(e))
+
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError as e:
+            raise AttributeError(str(e))
+
+
 @dataclasses.dataclass(frozen=False)
 class ResourceMemory:
-    """ A memo about a single resource/object. Usually stored in `Memories`. """
+    """ A system memo about a single resource/object. Usually stored in `Memories`. """
+
+    # For arbitrary user data to be stored in memory, passed as `memo` to all the handlers.
+    user_data: ObjectDict = dataclasses.field(default_factory=ObjectDict)
+
+    # For resuming handlers tracking and deciding on should they be called or not.
     noticed_by_listing: bool = False
     fully_handled_once: bool = False
 

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -19,7 +19,7 @@ class ObjectDict(Dict[Any, Any]):
     def __setattr__(self, key: str, value: Any) -> None:
         self[key] = value
 
-    def __delitem__(self, key: str) -> None:
+    def __delattr__(self, key: str) -> None:
         try:
             del self[key]
         except KeyError as e:

--- a/tests/basic-structs/test_causes.py
+++ b/tests/basic-structs/test_causes.py
@@ -25,6 +25,7 @@ def test_resource_watching_cause(mocker):
     resource = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
+    memo = mocker.Mock()
     type = mocker.Mock()
     raw = mocker.Mock()
     cause = ResourceWatchingCause(
@@ -32,6 +33,7 @@ def test_resource_watching_cause(mocker):
         logger=logger,
         body=body,
         patch=patch,
+        memo=memo,
         type=type,
         raw=raw,
     )
@@ -39,6 +41,7 @@ def test_resource_watching_cause(mocker):
     assert cause.logger is logger
     assert cause.body is body
     assert cause.patch is patch
+    assert cause.memo is memo
     assert cause.type is type
     assert cause.raw is raw
 
@@ -50,6 +53,7 @@ def test_resource_changing_cause_with_all_args(mocker):
     initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
+    memo = mocker.Mock()
     diff = mocker.Mock()
     old = mocker.Mock()
     new = mocker.Mock()
@@ -60,6 +64,7 @@ def test_resource_changing_cause_with_all_args(mocker):
         initial=initial,
         body=body,
         patch=patch,
+        memo=memo,
         diff=diff,
         old=old,
         new=new,
@@ -71,6 +76,7 @@ def test_resource_changing_cause_with_all_args(mocker):
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
+    assert cause.memo is memo
     assert cause.diff is diff
     assert cause.old is old
     assert cause.new is new
@@ -83,6 +89,7 @@ def test_resource_changing_cause_with_only_required_args(mocker):
     initial = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
+    memo = mocker.Mock()
     cause = ResourceChangingCause(
         resource=resource,
         logger=logger,
@@ -90,6 +97,7 @@ def test_resource_changing_cause_with_only_required_args(mocker):
         initial=initial,
         body=body,
         patch=patch,
+        memo=memo,
     )
     assert cause.resource is resource
     assert cause.logger is logger
@@ -98,6 +106,7 @@ def test_resource_changing_cause_with_only_required_args(mocker):
     assert cause.initial is initial
     assert cause.body is body
     assert cause.patch is patch
+    assert cause.memo is memo
     assert cause.diff is not None
     assert not cause.diff
     assert cause.old is None

--- a/tests/basic-structs/test_containers.py
+++ b/tests/basic-structs/test_containers.py
@@ -61,13 +61,39 @@ def test_object_dict_keys_are_fields():
     assert obj.xyz == 100
 
 
-def test_object_dict_raises_key_errors():
+def test_object_dict_keys_deleted():
+    obj = ObjectDict()
+    obj['xyz'] = 100
+    del obj['xyz']
+    assert obj == {}
+
+
+def test_object_dict_fields_deleted():
+    obj = ObjectDict()
+    obj.xyz = 100
+    del obj.xyz
+    assert obj == {}
+
+
+def test_object_dict_raises_key_errors_on_get():
     obj = ObjectDict()
     with pytest.raises(KeyError):
         obj['unexistent']
 
 
-def test_object_dict_raises_attribute_errors():
+def test_object_dict_raises_attribute_errors_on_get():
     obj = ObjectDict()
     with pytest.raises(AttributeError):
         obj.unexistent
+
+
+def test_object_dict_raises_key_errors_on_del():
+    obj = ObjectDict()
+    with pytest.raises(KeyError):
+        del obj['unexistent']
+
+
+def test_object_dict_raises_attribute_errors_on_del():
+    obj = ObjectDict()
+    with pytest.raises(AttributeError):
+        del obj.unexistent

--- a/tests/basic-structs/test_containers.py
+++ b/tests/basic-structs/test_containers.py
@@ -1,5 +1,9 @@
+import collections.abc
+
+import pytest
+
 from kopf.structs.bodies import Body
-from kopf.structs.containers import ResourceMemory, ResourceMemories
+from kopf.structs.containers import ResourceMemory, ResourceMemories, ObjectDict
 
 BODY: Body = {
     'metadata': {
@@ -38,3 +42,32 @@ async def test_forgetting_deletes_when_present():
 async def test_forgetting_ignores_when_absent():
     memories = ResourceMemories()
     await memories.forget(BODY)
+
+
+def test_object_dict_creation():
+    obj = ObjectDict()
+    assert isinstance(obj, collections.abc.MutableMapping)
+
+
+def test_object_dict_fields_are_keys():
+    obj = ObjectDict()
+    obj.xyz = 100
+    assert obj['xyz'] == 100
+
+
+def test_object_dict_keys_are_fields():
+    obj = ObjectDict()
+    obj['xyz'] = 100
+    assert obj.xyz == 100
+
+
+def test_object_dict_raises_key_errors():
+    obj = ObjectDict()
+    with pytest.raises(KeyError):
+        obj['unexistent']
+
+
+def test_object_dict_raises_attribute_errors():
+    obj = ObjectDict()
+    with pytest.raises(AttributeError):
+        obj.unexistent

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -116,13 +116,16 @@ def kwargs():
         resource=object(),
         logger=object(),
         patch=object(),
+        memo=object(),
     )
+
 
 def check_kwargs(cause, kwargs):
     __traceback_hide__ = True
     assert cause.resource is kwargs['resource']
     assert cause.logger is kwargs['logger']
     assert cause.patch is kwargs['patch']
+    assert cause.memo is kwargs['memo']
 
 
 #

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -178,11 +178,13 @@ def cause_mock(mocker, resource):
         # Avoid collision of our mocked values with the passed kwargs.
         original_event = kwargs.pop('event', None)
         original_reason = kwargs.pop('reason', None)
+        original_memo = kwargs.pop('memo', None)
         original_body = kwargs.pop('body', None)
         original_diff = kwargs.pop('diff', None)
         original_new = kwargs.pop('new', None)
         original_old = kwargs.pop('old', None)
         reason = mock.reason if mock.reason is not None else original_reason
+        memo = copy.deepcopy(mock.memo) if mock.memo is not None else original_memo
         body = copy.deepcopy(mock.body) if mock.body is not None else original_body
         diff = copy.deepcopy(mock.diff) if mock.diff is not None else original_diff
         new = copy.deepcopy(mock.new) if mock.new is not None else original_new
@@ -195,6 +197,7 @@ def cause_mock(mocker, resource):
         # I.e. everything except what we mock: reason & body.
         cause = ResourceChangingCause(
             reason=reason,
+            memo=memo,
             body=body,
             diff=diff,
             new=new,
@@ -214,8 +217,9 @@ def cause_mock(mocker, resource):
     mocker.patch('kopf.reactor.causation.detect_resource_changing_cause', new=new_detect_fn)
 
     # The mock object stores some values later used by the factory substitute.
-    mock = mocker.Mock(spec_set=['reason', 'body', 'diff', 'new', 'old'])
+    mock = mocker.Mock(spec_set=['reason', 'memo', 'body', 'diff', 'new', 'old'])
     mock.reason = None
+    mock.memo = None
     mock.body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
     mock.diff = None
     mock.new = None

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -7,6 +7,7 @@ from kopf.reactor.causation import Reason, ResourceChangingCause, ResourceWatchi
 from kopf.reactor.handling import cause_var
 from kopf.reactor.invocation import context
 from kopf.structs.bodies import Body, Meta, Labels, Event
+from kopf.structs.containers import ObjectDict
 from kopf.structs.patches import Patch
 
 OWNER_API_VERSION = 'owner-api-version'
@@ -34,6 +35,7 @@ def owner(request, resource):
             logger=logging.getLogger('kopf.test.fake.logger'),
             resource=resource,
             patch=Patch(),
+            memo=ObjectDict(),
             body=OWNER,
             initial=False,
             reason=Reason.NOOP,
@@ -45,6 +47,7 @@ def owner(request, resource):
             logger=logging.getLogger('kopf.test.fake.logger'),
             resource=resource,
             patch=Patch(),
+            memo=ObjectDict(),
             body=OWNER,
             type='irrelevant',
             raw=Event(type='irrelevant', object=OWNER),

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -173,6 +173,7 @@ async def test_special_kwargs_added(fn, resource):
         patch=Patch(),
         initial=False,
         reason=Reason.NOOP,
+        memo=object(),
         body=body,
         diff=object(),
         old=object(),

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -7,6 +7,7 @@ from kopf.reactor.causation import ResourceChangingCause, Reason
 from kopf.reactor.invocation import invoke
 from kopf.reactor.states import State
 from kopf.structs.bodies import Body
+from kopf.structs.containers import ObjectDict
 from kopf.structs.patches import Patch
 
 
@@ -28,6 +29,7 @@ async def test_protocol_invocation(lifecycle, resource):
         logger=logging.getLogger('kopf.test.fake.logger'),
         resource=resource,
         patch=Patch(),
+        memo=ObjectDict(),
         body=Body(),
         initial=False,
         reason=Reason.NOOP,


### PR DESCRIPTION

> Issue : #112 

## Description

Since the per-resource in-memory runtime-only containers are already present in the core for internal purposes, it is easy to expose `memo` kwarg to the handlers, so that the can store arbitrary information or objects about resources.

Same as for the internal use, this should be the objects that are scoped to the operator life time, fully lost on restarts, i.e. not persistent. E.g. threads, tasks, locks, events. Maybe some regular scalars, if their meaning is also scoped to the operator process.

Example:

```python
import kopf

@kopf.on.create('zalando.org', 'v1', 'kopfexamples', cooldown=10)
def create_fn_1(memo, **kwargs):
    print(f'{memo.xyz}')

@kopf.on.create('zalando.org', 'v1', 'kopfexamples')
def create_fn_2(memo, **kwargs):
    memo.xyz = 100
```

In this example, `create_fn_1` raises AttributeError on the 1st attempt, then goes to `create_fn_2`, and then retries `create_fn_1` in 10 seconds with the `.xyz` field already set.

Both dictionary and object interfaces are supported.

_The documentation is intentionally limited — let's first see how it will be used, and what can be the examples._


## Types of Changes

- New feature (non-breaking change which adds functionality)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
