### PR TITLE
Add a couple of short and fancy aliases for KopfExample CRD

### DIFF
--- a/examples/crd.yaml
+++ b/examples/crd.yaml
@@ -17,6 +17,8 @@ spec:
     shortNames:
       - kopfexes
       - kopfex
+      - kexes
+      - kex
   additionalPrinterColumns:
     - name: Duration
       type: string


### PR DESCRIPTION
Call it `kex` now.

> Issue : #12 

## Description

There is no big practical reason for such aliases.  Just for shorter typing and examples in the demos/slides.

Besides, it sounds fancy, and "keks" means "cake" in Russian.

## Types of Changes

- Configuration change
