### PR TITLE
Avoid meaningless logging of essence patches & empty diffs

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -311,7 +311,7 @@ async def handle_resource_changing_cause(
 
             if state.done:
                 logger.info(f"All handlers succeeded for {title}.")
-                state.purge(patch=cause.patch)
+                state.purge(patch=cause.patch, body=cause.body)
 
             done = state.done
             delay = state.delay

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -293,7 +293,7 @@ async def handle_resource_changing_cause(
     if cause.reason in causation.HANDLER_REASONS:
         title = causation.TITLES.get(cause.reason, repr(cause.reason))
         logger.debug(f"{title.capitalize()} event: %r", body)
-        if cause.diff is not None and cause.old is not None and cause.new is not None:
+        if cause.diff and cause.old is not None and cause.new is not None:
             logger.debug(f"{title.capitalize()} diff: %r", cause.diff)
 
         handlers = registry.get_resource_changing_handlers(cause=cause)

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -83,10 +83,7 @@ async def test_create(registry, handlers, resource, cause_mock, event_type,
     assert 'metadata' in patch
     assert 'annotations' in patch['metadata']
     assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
-    assert 'status' in patch
-    assert 'kopf' in patch['status']
-    assert 'progress' in patch['status']['kopf']
-    assert patch['status']['kopf']['progress'] is None  # 1 out of 1 handlers done
+    assert 'status' not in patch  # because only 1 handler, nothing to purge
 
     assert_logs([
         "Creation event:",
@@ -128,10 +125,7 @@ async def test_update(registry, handlers, resource, cause_mock, event_type,
     assert 'metadata' in patch
     assert 'annotations' in patch['metadata']
     assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
-    assert 'status' in patch
-    assert 'kopf' in patch['status']
-    assert 'progress' in patch['status']['kopf']
-    assert patch['status']['kopf']['progress'] is None  # 1 out of 1 handlers done
+    assert 'status' not in patch  # because only 1 handler, nothing to purge
 
     assert_logs([
         "Update event:",
@@ -170,10 +164,7 @@ async def test_delete(registry, handlers, resource, cause_mock, event_type,
     assert not event_queue.empty()
 
     patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
-    assert 'status' in patch
-    assert 'kopf' in patch['status']
-    assert 'progress' in patch['status']['kopf']
-    assert patch['status']['kopf']['progress'] is None  # 1 out of 1 handlers done
+    assert 'status' not in patch  # because only 1 handler, nothing to purge
 
     assert_logs([
         "Deletion event",

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -33,8 +33,6 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
 
 @pytest.mark.parametrize('diff', [
     pytest.param((('op', ('field',), 'old', 'new'),), id='realistic-diff'),
-    pytest.param((), id='empty-tuple-diff'),
-    pytest.param([], id='empty-list-diff'),
 ])
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_diffs_logged_if_present(registry, resource, handlers, cause_type, cause_mock,
@@ -64,13 +62,18 @@ async def test_diffs_logged_if_present(registry, resource, handlers, cause_type,
 
 
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
+@pytest.mark.parametrize('diff', [
+    pytest.param(None, id='none-diff'),  # same as the default, but for clarity
+    pytest.param([], id='empty-list-diff'),
+    pytest.param((), id='empty-tuple-diff'),
+])
 async def test_diffs_not_logged_if_absent(registry, resource, handlers, cause_type, cause_mock,
-                                          caplog, assert_logs):
+                                          caplog, assert_logs, diff):
     caplog.set_level(logging.DEBUG)
 
     event_type = None if cause_type == Reason.RESUME else 'irrelevant'
     cause_mock.reason = cause_type
-    cause_mock.diff = None  # same as the default, but for clarity
+    cause_mock.diff = diff
 
     await resource_handler(
         lifecycle=kopf.lifecycles.all_at_once,


### PR DESCRIPTION
Less patching, less logging when not needed.

> Issue : #1234 (only if appropriate)

## Description

Skip logging the empty diffs. They are useless. Especially on the resuming events, when the object is not changed actually. — As they are already skipped for the creation/deletion events, when the diff is a full-body vs. `None` diff.

Skip patching the body essence if it is the same as the one already stored on the object. This pollutes the logs with difficult-to-read JSON dumps, especially on the resuming events — when these patches and logs contain no useful information.

Skip purging the handler progress if there is no progress stored (e.g. for one-handler cases, when it succeeds immediately). This produced unnecessary API patches, and polluted the logs for no good reason.

These changes will reduce the amount of meaningless logs produced.

## Types of Changes

- Refactor/improvements

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
