### PR TITLE
Fix an issue with mistakenly added Bearer auth in addition to Basic auth

### DIFF
--- a/kopf/utilities/piggybacking.py
+++ b/kopf/utilities/piggybacking.py
@@ -120,7 +120,6 @@ def login_via_pykube(
         insecure=config.cluster.get('insecure-skip-tls-verify'),
         username=config.user.get('username'),
         password=config.user.get('password'),
-        scheme='Bearer',
         token=config.user.get('token') or provider_token,
         certificate_path=cert.filename() if cert else None,  # can be a temporary file
         private_key_path=pkey.filename() if pkey else None,  # can be a temporary file


### PR DESCRIPTION
> Issue : #242

## Description

`Authorization: Bearer` header was sent (without a token!) because there was a schema defined by default (`"Bearer"`), which should not be there (`None`).

This caused problems when Basic auth (username+password) was used — it could not co-exist with `Authorization: Bearer` header.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
