### PR TITLE
Ignore errors marked for ignoring in the activities (auth piggybacking)

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -554,7 +554,7 @@ async def _execute_handler(
     except Exception as e:
         if errors == registries.ErrorsMode.IGNORED:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will ignore.")
-            return states.HandlerOutcome(final=True, exception=e)
+            return states.HandlerOutcome(final=True)
         elif errors == registries.ErrorsMode.TEMPORARY:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will retry.")
             return states.HandlerOutcome(final=False, exception=e, delay=cooldown)

--- a/tests/authentication/test_login.py
+++ b/tests/authentication/test_login.py
@@ -2,10 +2,9 @@
 Remember: We do not test the clients, we assume they work when used properly.
 We test our own functions here, and check if the clients were called.
 """
-import pytest
-
 import pykube
-from kopf import login, LoginError
+
+from kopf import login
 
 
 def test_client_login_works_incluster(login_mocks, kubernetes):
@@ -82,32 +81,6 @@ def test_client_is_independent_of_pykube_viaconfig(login_mocks, no_pykube, kuber
     login_mocks.client_in_cluster.side_effect = kubernetes.config.ConfigException
 
     login()
-
-    assert login_mocks.client_in_cluster.called
-    assert login_mocks.client_from_file.called
-
-
-# TODO: do we actually fail on every method failure? Or should we use another one?
-def test_login_fails_on_errors_in_pykube(login_mocks, any_kubernetes):
-    login_mocks.pykube_in_cluster.side_effect = FileNotFoundError
-    login_mocks.pykube_from_file.side_effect = FileNotFoundError
-
-    with pytest.raises(LoginError):
-        login()
-
-    assert login_mocks.pykube_in_cluster.called
-    assert login_mocks.pykube_from_file.called
-
-
-def test_login_fails_on_errors_in_client(login_mocks, kubernetes):
-    login_mocks.client_in_cluster.side_effect = kubernetes.config.ConfigException
-    login_mocks.client_from_file.side_effect = kubernetes.config.ConfigException
-
-    with pytest.raises(LoginError):
-        login()
-
-    assert login_mocks.pykube_in_cluster.called
-    assert not login_mocks.pykube_from_file.called
 
     assert login_mocks.client_in_cluster.called
     assert login_mocks.client_from_file.called

--- a/tests/persistence/test_outcomes.py
+++ b/tests/persistence/test_outcomes.py
@@ -2,6 +2,14 @@ from kopf.reactor.registries import HandlerResult
 from kopf.reactor.states import HandlerOutcome
 
 
+def test_creation_for_ignored_handlers():
+    outcome = HandlerOutcome(final=True)
+    assert outcome.final
+    assert outcome.delay is None
+    assert outcome.result is None
+    assert outcome.exception is None
+
+
 def test_creation_for_results():
     result = HandlerResult(object())
     outcome = HandlerOutcome(final=True, result=result)


### PR DESCRIPTION
Fix GKE's authentication, which otherwise fails on pykube-ng's piggybacking.

> Issue : #226 

## Description

When GKE is used, `pykube-ng` fails to retrieve the credentials.  But `kubernetes` succeeds. — It was the initial intention to use whatever credentials are available.

However, due to an exception returned by one of the login handlers, the whole (re-) authentication activity fails.

```
[2019-11-19 21:20:13,014] kopf.reactor.activit [INFO    ] Initial authentication has been initiated.
[2019-11-19 21:20:13,019] kopf.activities.auth [DEBUG   ] Invoking handler 'login_via_pykube'.
[2019-11-19 21:20:13,090] kopf.activities.auth [DEBUG   ] Pykube is configured via kubeconfig file.
[2019-11-19 21:20:14,339] google.auth.transpor [DEBUG   ] Making request: GET http://169.254.169.254
[2019-11-19 21:20:17,341] google.auth.compute_ [INFO    ] Compute Engine Metadata server unavailable onattempt 1 of 3
[2019-11-19 21:20:17,342] google.auth.transpor [DEBUG   ] Making request: GET http://169.254.169.254
[2019-11-19 21:20:20,348] google.auth.compute_ [INFO    ] Compute Engine Metadata server unavailable onattempt 2 of 3
[2019-11-19 21:20:20,349] google.auth.transpor [DEBUG   ] Making request: GET http://169.254.169.254
[2019-11-19 21:20:23,354] google.auth.compute_ [INFO    ] Compute Engine Metadata server unavailable onattempt 3 of 3
[2019-11-19 21:20:23,355] kopf.activities.auth [ERROR   ] Handler 'login_via_pykube' failed with an exception. Will ignore.
Traceback (most recent call last):
………
google.auth.exceptions.DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application. For more information, please see https://cloud.google.com/docs/authentication/getting-started
[2019-11-19 21:20:23,369] kopf.activities.auth [DEBUG   ] Invoking handler 'login_via_client'.
[2019-11-19 21:20:23,441] kopf.activities.auth [DEBUG   ] Client is configured via kubeconfig file.
[2019-11-19 21:20:23,441] kopf.activities.auth [INFO    ] Handler 'login_via_client' succeeded.
[2019-11-19 21:20:23,441] kopf.reactor.activit [INFO    ] Initial authentication has finished.
```

With this PR, the ignored errors are indeed ignored. The handler is treated as successful but producing no results (but logged with the full stacktrace). Other handlers' results will be used instead.

_This PR neither fixes nor works around an issue with the  pykube-ng's authentication in any way. The exception will be logged. It is a matter of user-side env vars configs to make it work. It is only important that this exception does not ruin the rest of the piggybacking authentication._


## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
