### PR TITLE
Hot-fix the cluster-scoped resource discovery in namespaced operators

### DIFF
--- a/kopf/clients/discovery.py
+++ b/kopf/clients/discovery.py
@@ -1,0 +1,35 @@
+from typing import Dict, Optional, cast
+
+from kopf.clients import auth
+from kopf.structs import resources
+
+
+async def discover(
+        *,
+        resource: resources.Resource,
+        session: auth.APISession,
+) -> Optional[Dict[str, object]]:
+    if resource not in session._discovered_resources:
+        async with session._discovery_lock:
+            if resource not in session._discovered_resources:
+
+                response = await session.get(
+                    url=resource.get_version_url(server=session.server),
+                )
+                response.raise_for_status()
+                respdata = await response.json()
+
+                session._discovered_resources.update({
+                    resources.Resource(resource.group, resource.version, info['name']): info
+                    for info in respdata['resources']
+                })
+    return session._discovered_resources.get(resource, None)
+
+
+async def is_namespaced(
+        *,
+        resource: resources.Resource,
+        session: auth.APISession,
+) -> bool:
+    info = await discover(resource=resource, session=session)
+    return cast(bool, info['namespaced']) if info is not None else True  # assume namespaced

--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 import aiohttp
 
 from kopf.clients import auth
+from kopf.clients import discovery
 from kopf.structs import bodies
 from kopf.structs import patches
 from kopf.structs import resources
@@ -36,6 +37,10 @@ async def patch_obj(
 
     namespace = body.get('metadata', {}).get('namespace') if body is not None else namespace
     name = body.get('metadata', {}).get('name') if body is not None else name
+
+    is_namespaced = await discovery.is_namespaced(resource=resource, session=session)
+    namespace = namespace if is_namespaced else None
+
     if body is None:
         body = cast(bodies.Body, {'metadata': {'name': name}})
         if namespace is not None:

--- a/kopf/structs/resources.py
+++ b/kopf/structs/resources.py
@@ -25,7 +25,7 @@ class Resource(NamedTuple):
             name: Optional[str] = None,
             params: Optional[Mapping[str, str]] = None,
     ) -> str:
-        parts: List[Optional[str]] = [
+        return self._build_url(server, params, [
             '/api' if self.group == '' and self.version == 'v1' else '/apis',
             self.group,
             self.version,
@@ -33,7 +33,26 @@ class Resource(NamedTuple):
             namespace,
             self.plural,
             name,
-        ]
+        ])
+
+    def get_version_url(
+            self,
+            *,
+            server: Optional[str] = None,
+            params: Optional[Mapping[str, str]] = None,
+    ) -> str:
+        return self._build_url(server, params, [
+            '/api' if self.group == '' and self.version == 'v1' else '/apis',
+            self.group,
+            self.version,
+        ])
+
+    def _build_url(
+            self,
+            server: Optional[str],
+            params: Optional[Mapping[str, str]],
+            parts: List[Optional[str]],
+    ) -> str:
         query = urllib.parse.urlencode(params, encoding='utf-8') if params else ''
         path = '/'.join([part for part in parts if part])
         url = path + ('?' if query else '') + query

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import sys
 import time
 from unittest.mock import Mock
 
-import aiohttp
+import aiohttp.web
 import asynctest
 import pytest
 import pytest_mock
@@ -175,7 +175,17 @@ def resp_mocker(fake_vault, enforced_session, resource, aresponses):
 
 
 @pytest.fixture()
-def stream(fake_vault, resp_mocker, aresponses, hostname, resource):
+def version_api(resp_mocker, aresponses, hostname, resource):
+    result = {'resources': [{
+        'name': resource.plural,
+        'namespaced': True,
+    }]}
+    list_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
+    aresponses.add(hostname, resource.get_version_url(), 'get', list_mock)
+
+
+@pytest.fixture()
+def stream(fake_vault, resp_mocker, aresponses, hostname, resource, version_api):
     """ A mock for the stream of events as if returned by K8s client. """
 
     def feed(*args, namespace=None):

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -2,5 +2,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _autouse_resp_mocker(resp_mocker):
+def _autouse_resp_mocker(resp_mocker, version_api):
     pass


### PR DESCRIPTION
> Issue : #249 
> Broken in #227

## Description

`pykube-ng` did a discovery of the resources and cached them in memory, so it knew which resources are namespaced, which are cluster-scoped — and generated the URLs accordingly.

When switched to `aiohttp`, this discovery logic was lost, so all URLs became either cluster-scoped (by default) or namespaced (if the operator had `--namespace` defined). 

The only thing broken is the cluster-scoped resources in the namespaced operators: they could not be reached (404 Not Found), because they do not exist in the namespaces.

**This is a hot-fix for 0.23. No unit-tests — to be added later. Tested manually in presumably all combinations in Minikube — now, it works as it was before 0.23.**


## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
