### PR TITLE
Refactor the synchronisation primitives

### DIFF
--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -9,14 +9,15 @@ from kopf import config
 from kopf.engines import peering
 from kopf.reactor import running
 from kopf.structs import credentials
+from kopf.structs import primitives
 from kopf.utilities import loaders
 
 
 @dataclasses.dataclass()
 class CLIControls:
     """ `KopfRunner` controls, which are impossible to pass via CLI. """
-    ready_flag: Optional[running.Flag] = None
-    stop_flag: Optional[running.Flag] = None
+    ready_flag: Optional[primitives.Flag] = None
+    stop_flag: Optional[primitives.Flag] = None
     vault: Optional[credentials.Vault] = None
 
 

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -53,7 +53,7 @@ async def authenticate(
     """ Retrieve the credentials once, successfully or not, and exit. """
 
     # Sleep most of the time waiting for a signal to re-auth.
-    await vault.emptiness.wait()
+    await vault.wait_for_emptiness()
 
     # Log initial and re-authentications differently, for readability.
     logger.info(f"{_activity_title} has been initiated.")

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -36,6 +36,7 @@ from kopf.structs import diffs
 from kopf.structs import finalizers
 from kopf.structs import lastseen
 from kopf.structs import patches
+from kopf.structs import primitives
 from kopf.structs import resources
 
 WAITING_KEEPALIVE_INTERVAL = 10 * 60
@@ -149,7 +150,7 @@ async def resource_handler(
         memories: containers.ResourceMemories,
         resource: resources.Resource,
         event: bodies.Event,
-        freeze: asyncio.Event,
+        freeze_mode: primitives.Toggle,
         replenished: asyncio.Event,
         event_queue: posting.K8sEventQueue,
 ) -> None:
@@ -172,7 +173,7 @@ async def resource_handler(
     posting.event_queue_var.set(event_queue)  # till the end of this object's task.
 
     # If the global freeze is set for the processing (i.e. other operator overrides), do nothing.
-    if freeze.is_set():
+    if freeze_mode.is_on():
         logger.debug("Ignoring the events due to freeze.")
         return
 

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -182,7 +182,7 @@ async def spawn_tasks(
     vault = vault if vault is not None else global_vault
     vault = vault if vault is not None else credentials.Vault()
     event_queue: posting.K8sEventQueue = asyncio.Queue(loop=loop)
-    freeze_flag: asyncio.Event = asyncio.Event(loop=loop)
+    freeze_mode: primitives.Toggle = primitives.Toggle(loop=loop)
     signal_flag: asyncio_Future = asyncio.Future(loop=loop)
     ready_flag = ready_flag if ready_flag is not None else asyncio.Event()
     tasks: MutableSequence[asyncio_Task] = []
@@ -248,7 +248,7 @@ async def spawn_tasks(
                     resource=ourselves.resource,
                     handler=functools.partial(peering.peers_handler,
                                               ourselves=ourselves,
-                                              freeze=freeze_flag)))),  # freeze is set/cleared
+                                              freeze_mode=freeze_mode)))),
         ])
 
     # Resource event handling, only once for every known resource (de-duplicated).
@@ -265,7 +265,7 @@ async def spawn_tasks(
                                               memories=memories,
                                               resource=resource,
                                               event_queue=event_queue,
-                                              freeze=freeze_flag)))),  # freeze is only checked
+                                              freeze_mode=freeze_mode)))),
         ])
 
     # On Ctrl+C or pod termination, cancel all tasks gracefully.

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -1,0 +1,57 @@
+"""
+Synchronisation primitives and helper functions.
+"""
+import asyncio
+import concurrent.futures
+import threading
+from typing import Optional, Union, Any
+
+Flag = Union[asyncio.Future, asyncio.Event, concurrent.futures.Future, threading.Event]
+
+
+async def wait_flag(
+        flag: Optional[Flag],
+) -> Any:
+    """
+    Wait for a flag to be raised.
+
+    Non-asyncio primitives are generally not our worry,
+    but we support them for convenience.
+    """
+    if flag is None:
+        pass
+    elif isinstance(flag, asyncio.Future):
+        return await flag
+    elif isinstance(flag, asyncio.Event):
+        return await flag.wait()
+    elif isinstance(flag, concurrent.futures.Future):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, flag.result)
+    elif isinstance(flag, threading.Event):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, flag.wait)
+    else:
+        raise TypeError(f"Unsupported type of a flag: {flag!r}")
+
+
+async def raise_flag(
+        flag: Optional[Flag],
+) -> None:
+    """
+    Raise a flag.
+
+    Non-asyncio primitives are generally not our worry,
+    but we support them for convenience.
+    """
+    if flag is None:
+        pass
+    elif isinstance(flag, asyncio.Future):
+        flag.set_result(None)
+    elif isinstance(flag, asyncio.Event):
+        flag.set()
+    elif isinstance(flag, concurrent.futures.Future):
+        flag.set_result(None)
+    elif isinstance(flag, threading.Event):
+        flag.set()
+    else:
+        raise TypeError(f"Unsupported type of a flag: {flag!r}")

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -55,3 +55,67 @@ async def raise_flag(
         flag.set()
     else:
         raise TypeError(f"Unsupported type of a flag: {flag!r}")
+
+
+class Toggle:
+    """
+    An synchronisation primitive that can be awaited both until set or cleared.
+
+    For one-directional toggles, `asyncio.Event` is sufficient.
+    But these events cannot be awaited until cleared.
+
+    The bi-directional toggles are needed in some places in the code, such as
+    in the population/depletion of a `Vault`, or as an operator's freeze-mode.
+    """
+
+    def __init__(
+            self,
+            __val: bool = False,
+            *,
+            loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        super().__init__()
+        self._condition = asyncio.Condition(loop=loop)
+        self._state: bool = bool(__val)
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        return self._condition._loop
+
+    def __bool__(self) -> bool:
+        """
+        In the boolean context, a toggle evaluates to its current on/off state.
+
+        An equivalent of `.is_on` / `.is_off`.
+        """
+        return bool(self._state)
+
+    def is_on(self) -> bool:
+        """ Check if the toggle is currently on (opposite of `.is_off`). """
+        return bool(self._state)
+
+    def is_off(self) -> bool:
+        """ Check if the toggle is currently off (opposite of `.is_on`). """
+        return bool(not self._state)
+
+    async def turn_on(self) -> None:
+        """ Turn the toggle on, and wake up the tasks waiting for that. """
+        async with self._condition:
+            self._state = True
+            self._condition.notify_all()
+
+    async def turn_off(self) -> None:
+        """ Turn the toggle off, and wake up the tasks waiting for that. """
+        async with self._condition:
+            self._state = False
+            self._condition.notify_all()
+
+    async def wait_for_on(self) -> None:
+        """ Wait until the toggle is turned on (if not yet). """
+        async with self._condition:
+            await self._condition.wait_for(lambda: self._state)
+
+    async def wait_for_off(self) -> None:
+        """ Wait until the toggle is turned off (if not yet). """
+        async with self._condition:
+            await self._condition.wait_for(lambda: not self._state)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ asynctest
 freezegun
 codecov
 coveralls
-mypy
+mypy==0.740

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -15,9 +15,6 @@ async def test_empty_registry_produces_no_credentials():
         vault=vault,
     )
 
-    assert vault.readiness.is_set()
-    assert not vault.emptiness.is_set()
-
     assert not vault
     with pytest.raises(LoginError):
         async for _, _ in vault:
@@ -41,9 +38,6 @@ async def test_noreturn_handler_produces_no_credentials():
         registry=registry,
         vault=vault,
     )
-
-    assert vault.readiness.is_set()
-    assert not vault.emptiness.is_set()
 
     assert not vault
     with pytest.raises(LoginError):
@@ -69,9 +63,6 @@ async def test_single_credentials_provided_to_vault():
         registry=registry,
         vault=vault,
     )
-
-    assert vault.readiness.is_set()
-    assert not vault.emptiness.is_set()
 
     assert vault
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,8 +304,8 @@ def fake_vault(event_loop, mocker, hostname):
     info = ConnectionInfo(server=f'https://{hostname}')
     vault = Vault({key: info}, loop=event_loop)
     token = auth.vault_var.set(vault)
-    mocker.patch.object(vault.readiness, 'wait')
-    mocker.patch.object(vault.emptiness, 'wait')
+    mocker.patch.object(vault._ready, 'wait_for_on')
+    mocker.patch.object(vault._ready, 'wait_for_off')
     try:
         yield vault
     finally:

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -9,6 +9,7 @@ from kopf.reactor.handling import resource_handler
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
+from kopf.structs.primitives import Toggle
 
 EVENT_TYPES = [None, 'ADDED', 'MODIFIED', 'DELETED']
 
@@ -27,7 +28,7 @@ async def test_acquire(registry, handlers, resource, cause_mock, event_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=event_queue,
     )
@@ -65,7 +66,7 @@ async def test_create(registry, handlers, resource, cause_mock, event_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=event_queue,
     )
@@ -107,7 +108,7 @@ async def test_update(registry, handlers, resource, cause_mock, event_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=event_queue,
     )
@@ -149,7 +150,7 @@ async def test_delete(registry, handlers, resource, cause_mock, event_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=event_queue,
     )
@@ -200,7 +201,7 @@ async def test_release(registry, resource, handlers, cause_mock, event_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=event_queue,
     )
@@ -242,7 +243,7 @@ async def test_gone(registry, handlers, resource, cause_mock, event_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=event_queue,
     )
@@ -274,7 +275,7 @@ async def test_free(registry, handlers, resource, cause_mock, event_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=event_queue,
     )
@@ -306,7 +307,7 @@ async def test_noop(registry, handlers, resource, cause_mock, event_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=event_queue,
     )

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -7,6 +7,7 @@ import kopf
 from kopf.reactor.causation import ALL_REASONS, HANDLER_REASONS, Reason
 from kopf.reactor.handling import resource_handler
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.primitives import Toggle
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)
@@ -21,7 +22,7 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
@@ -51,7 +52,7 @@ async def test_diffs_logged_if_present(registry, resource, handlers, cause_type,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
@@ -81,7 +82,7 @@ async def test_diffs_not_logged_if_absent(registry, resource, handlers, cause_ty
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -13,6 +13,7 @@ from kopf.reactor.handling import resource_handler
 from kopf.reactor.states import HandlerState
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.finalizers import FINALIZER
+from kopf.structs.primitives import Toggle
 
 
 @pytest.mark.parametrize('cause_reason', HANDLER_REASONS)
@@ -39,7 +40,7 @@ async def test_delayed_handlers_progress(
             resource=resource,
             memories=ResourceMemories(),
             event={'type': event_type, 'object': cause_mock.body},
-            freeze=asyncio.Event(),
+            freeze_mode=Toggle(),
             replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
@@ -95,7 +96,7 @@ async def test_delayed_handlers_sleep(
             resource=resource,
             memories=ResourceMemories(),
             event={'type': event_type, 'object': cause_mock.body},
-            freeze=asyncio.Event(),
+            freeze_mode=Toggle(),
             replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -8,6 +8,7 @@ from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.handling import resource_handler
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.primitives import Toggle
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
@@ -31,7 +32,7 @@ async def test_fatal_error_stops_handler(
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
@@ -75,7 +76,7 @@ async def test_retry_error_delays_handler(
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
@@ -120,7 +121,7 @@ async def test_arbitrary_error_delays_handler(
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -7,6 +7,7 @@ import kopf
 from kopf.reactor.causation import ALL_REASONS
 from kopf.reactor.handling import resource_handler
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.primitives import Toggle
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)
@@ -22,7 +23,7 @@ async def test_handlers_called_always(
         resource=resource,
         memories=ResourceMemories(),
         event={'type': 'ev-type', 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
@@ -58,7 +59,7 @@ async def test_errors_are_ignored(
         resource=resource,
         memories=ResourceMemories(),
         event={'type': 'ev-type', 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )

--- a/tests/handling/test_freezing.py
+++ b/tests/handling/test_freezing.py
@@ -5,6 +5,7 @@ import kopf
 from kopf.reactor.handling import resource_handler
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.primitives import Toggle
 
 
 async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, assert_logs):
@@ -19,10 +20,6 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
     registry = OperatorRegistry()
     event = {'object': {'metadata': {'namespace': 'ns1', 'name': 'name1'}}}
 
-    # This is what makes it frozen.
-    freeze = asyncio.Event()
-    freeze.set()
-
     caplog.set_level(logging.DEBUG)
     await resource_handler(
         lifecycle=lifecycle,
@@ -30,7 +27,7 @@ async def test_nothing_is_called_when_freeze_is_set(mocker, resource, caplog, as
         resource=resource,
         memories=ResourceMemories(),
         event=event,
-        freeze=freeze,
+        freeze_mode=Toggle(True),  # make it frozen!
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -6,6 +6,7 @@ import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import resource_handler
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.primitives import Toggle
 
 
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
@@ -24,7 +25,7 @@ async def test_1st_step_stores_progress_by_patching(
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
@@ -74,7 +75,7 @@ async def test_2nd_step_finishes_the_handlers(caplog,
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -8,6 +8,7 @@ from kopf.reactor.causation import HANDLER_REASONS
 from kopf.reactor.handling import resource_handler
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
+from kopf.structs.primitives import Toggle
 
 
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
@@ -33,7 +34,7 @@ async def test_skipped_with_no_handlers(
         resource=resource,
         memories=ResourceMemories(),
         event={'type': None, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -8,6 +8,7 @@ import kopf
 from kopf.reactor.causation import HANDLER_REASONS, Reason
 from kopf.reactor.handling import resource_handler
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.primitives import Toggle
 
 
 # The timeout is hard-coded in conftest.py:handlers().
@@ -40,7 +41,7 @@ async def test_timed_out_handler_fails(
             resource=resource,
             memories=ResourceMemories(),
             event={'type': event_type, 'object': cause_mock.body},
-            freeze=asyncio.Event(),
+            freeze_mode=Toggle(),
             replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
@@ -89,7 +90,7 @@ async def test_retries_limited_handler_fails(
         resource=resource,
         memories=ResourceMemories(),
         event={'type': event_type, 'object': cause_mock.body},
-        freeze=asyncio.Event(),
+        freeze_mode=Toggle(),
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )

--- a/tests/primitives/test_flags.py
+++ b/tests/primitives/test_flags.py
@@ -1,0 +1,95 @@
+import asyncio
+import concurrent.futures
+import threading
+
+import pytest
+
+from kopf.structs.primitives import wait_flag, raise_flag
+
+
+@pytest.fixture(params=[
+    pytest.param(asyncio.Event, id='asyncio-event'),
+    pytest.param(asyncio.Future, id='asyncio-future'),
+    pytest.param(threading.Event, id='threading-event'),
+    pytest.param(concurrent.futures.Future, id='concurrent-future'),
+])
+async def flag(request):
+    """
+    Fulfil the flag's waiting expectations, so that a threaded call can finish.
+    Otherwise, the test runs freeze at exit while waiting for the executors.
+    """
+    flag = request.param()
+    try:
+        yield flag
+    finally:
+        if hasattr(flag, 'cancel'):
+            flag.cancel()
+        if hasattr(flag, 'set'):
+            flag.set()
+
+
+async def test_raising_of_unsupported_raises_an_error():
+    with pytest.raises(TypeError):
+        await raise_flag(object())
+
+
+async def test_raising_of_none_does_nothing():
+    await raise_flag(None)
+
+
+async def test_raising_of_asyncio_event():
+    event = asyncio.Event()
+    await raise_flag(event)
+    assert event.is_set()
+
+
+async def test_raising_of_asyncio_future():
+    future = asyncio.Future()
+    await raise_flag(future)
+    assert future.done()
+
+
+async def test_raising_of_threading_event():
+    event = threading.Event()
+    await raise_flag(event)
+    assert event.is_set()
+
+
+async def test_raising_of_concurrent_future():
+    future = concurrent.futures.Future()
+    await raise_flag(future)
+    assert future.done()
+
+
+async def test_waiting_of_unsupported_raises_an_error():
+    with pytest.raises(TypeError):
+        await wait_flag(object())
+
+async def test_waiting_of_none_does_nothing():
+    await wait_flag(None)
+
+
+async def test_waiting_for_unraised_times_out(flag, timer):
+    with timer:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(wait_flag(flag), timeout=0.1)
+    assert timer.seconds >= 0.1
+
+
+async def test_waiting_for_preraised_is_instant(flag, timer):
+    await raise_flag(flag)  # tested separately above
+    with timer:
+        await asyncio.wait_for(wait_flag(flag), timeout=1.0)
+    assert timer.seconds < 0.5  # near-instant, plus code overhead
+
+
+async def test_waiting_for_raised_during_the_wait(flag, timer):
+
+    async def raise_delayed(delay: float) -> None:
+        await asyncio.sleep(delay)
+        await raise_flag(flag)  # tested separately above
+
+    asyncio.create_task(raise_delayed(0.2))
+    with timer:
+        await asyncio.wait_for(wait_flag(flag), timeout=1.0)
+    assert 0.2 <= timer.seconds < 0.5  # near-instant once raised

--- a/tests/primitives/test_toggles.py
+++ b/tests/primitives/test_toggles.py
@@ -1,0 +1,107 @@
+import asyncio
+
+import pytest
+
+from kopf.structs.primitives import Toggle
+
+
+async def test_creation_with_default_loop():
+    loop = asyncio.get_running_loop()
+    toggle = Toggle()
+    assert toggle.loop is loop
+
+
+async def test_creation_with_explicit_loop():
+    loop = asyncio.new_event_loop()
+    toggle = Toggle(loop=loop)
+    assert toggle.loop is loop
+
+
+async def test_created_as_off():
+    toggle = Toggle()
+
+    assert not toggle
+    assert not toggle.is_on()
+    assert toggle.is_off()
+
+
+async def test_initialised_as_off():
+    toggle = Toggle(False)
+
+    assert not toggle
+    assert not toggle.is_on()
+    assert toggle.is_off()
+
+
+async def test_initialised_as_on():
+    toggle = Toggle(True)
+
+    assert toggle
+    assert toggle.is_on()
+    assert not toggle.is_off()
+
+
+async def test_turning_on():
+    toggle = Toggle(False)
+    await toggle.turn_on()
+
+    assert toggle
+    assert toggle.is_on()
+    assert not toggle.is_off()
+
+
+async def test_turning_off():
+    toggle = Toggle(True)
+    await toggle.turn_off()
+
+    assert not toggle
+    assert not toggle.is_on()
+    assert toggle.is_off()
+
+
+async def test_waiting_until_on_fails_when_not_turned_on():
+    toggle = Toggle(False)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(toggle.wait_for_on(), timeout=0.1)
+
+    assert not toggle
+
+
+async def test_waiting_until_off_fails_when_not_turned_off():
+    toggle = Toggle(True)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(toggle.wait_for_off(), timeout=0.1)
+
+    assert toggle
+
+
+async def test_waiting_until_on_wakes_when_turned_on(timer):
+    toggle = Toggle(False)
+
+    async def delayed_turning_on(delay: float):
+        await asyncio.sleep(delay)
+        await toggle.turn_on()
+
+    with timer:
+        asyncio.create_task(delayed_turning_on(0.05))
+        await asyncio.wait_for(toggle.wait_for_on(), timeout=1.0)
+
+    assert toggle
+    assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
+
+
+async def test_waiting_until_off_wakes_when_turned_off(timer):
+    toggle = Toggle(True)
+
+    async def delayed_turning_off(delay: float):
+        await asyncio.sleep(delay)
+        await toggle.turn_off()
+
+    with timer:
+        asyncio.create_task(delayed_turning_off(0.05))
+        await asyncio.wait_for(toggle.wait_for_off(), timeout=1.0)
+
+    assert not toggle
+    assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead


### PR DESCRIPTION

> Issue : #255 

## Description

The existing coroutines to handle the existing synchronisation primitives (a generalised **flag**) are moved to the dedicated module, and tests are added (previously it was considered an implementation details and not tested directly).

A new synchronisation primitive is added to simplify the code and reduce the semantical complexity of the logic by removing the technical low-level details from it:

A **toggle**, which is like an event, but is bi-directional: can be turned on/off, and can be awaited until turned on/off — unlike the events, which can be awaited only until turned on, but not off.


## Types of Changes

- Refactoring


## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
