### PR TITLE
Filter by arbitrary callback function

### DIFF
--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -353,6 +353,12 @@ The following filters are available for all event, cause, and field handlers:
     def my_handler(spec, **_):
         pass
 
+* Check on any field on the body with a when callback. The filter callback takes the same args as a handler::
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', when=lambda body, **_: body.get('spec', {}).get('myfield', '') == 'somevalue')
+    def my_handler(spec, **_):
+        pass
+
 
 Startup handlers
 ================

--- a/examples/11-filtering-handlers/example.py
+++ b/examples/11-filtering-handlers/example.py
@@ -29,3 +29,13 @@ def create_with_annotations_exist(logger, **kwargs):
 @kopf.on.create('zalando.org', 'v1', 'kopfexamples', annotations={'someannotation': 'othervalue'})
 def create_with_annotations_not_satisfied(logger, **kwargs):
     logger.info("Annotation not satisfied.")
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', when=lambda body, **_: True)
+def create_with_filter_satisfied(logger, **kwargs):
+    logger.info("Filter satisfied.")
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', when=lambda body, **_: False)
+def create_with_filter_not_satisfied(logger, **kwargs):
+    logger.info("Filter not satisfied.")

--- a/examples/11-filtering-handlers/test_example_11.py
+++ b/examples/11-filtering-handlers/test_example_11.py
@@ -51,3 +51,5 @@ def test_handler_filtering(mocker):
     assert '[default/kopf-example-1] Annotation satisfied.' in runner.stdout
     assert '[default/kopf-example-1] Annotation exists.' in runner.stdout
     assert '[default/kopf-example-1] Annotation not satisfied.' not in runner.stdout
+    assert '[default/kopf-example-1] Filter satisfied.' in runner.stdout
+    assert '[default/kopf-example-1] Filter not satisfied.' not in runner.stdout

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -118,6 +118,7 @@ def resume(
         deleted: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
+        when: Optional[registries.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
@@ -126,7 +127,7 @@ def resume(
             group=group, version=version, plural=plural,
             reason=None, initial=True, deleted=deleted, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            fn=fn, labels=labels, annotations=annotations,
+            fn=fn, labels=labels, annotations=annotations, when=when,
         )
     return decorator
 
@@ -143,6 +144,7 @@ def create(
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
+        when: Optional[registries.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.create()`` handler for the object creation. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
@@ -151,7 +153,7 @@ def create(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            fn=fn, labels=labels, annotations=annotations,
+            fn=fn, labels=labels, annotations=annotations, when=when,
         )
     return decorator
 
@@ -168,6 +170,7 @@ def update(
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
+        when: Optional[registries.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.update()`` handler for the object update or change. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
@@ -176,7 +179,7 @@ def update(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            fn=fn, labels=labels, annotations=annotations,
+            fn=fn, labels=labels, annotations=annotations, when=when,
         )
     return decorator
 
@@ -194,6 +197,7 @@ def delete(
         optional: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
+        when: Optional[registries.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
@@ -203,7 +207,7 @@ def delete(
             reason=causation.Reason.DELETE, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             fn=fn, requires_finalizer=bool(not optional),
-            labels=labels, annotations=annotations,
+            labels=labels, annotations=annotations, when=when,
         )
     return decorator
 
@@ -221,6 +225,7 @@ def field(
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
+        when: Optional[registries.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
@@ -229,7 +234,7 @@ def field(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            fn=fn, labels=labels, annotations=annotations,
+            fn=fn, labels=labels, annotations=annotations, when=when,
         )
     return decorator
 
@@ -241,13 +246,14 @@ def event(
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
+        when: Optional[registries.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register_resource_watching_handler(
             group=group, version=version, plural=plural,
-            id=id, fn=fn, labels=labels, annotations=annotations,
+            id=id, fn=fn, labels=labels, annotations=annotations, when=when,
         )
     return decorator
 

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -292,7 +292,7 @@ async def handle_resource_changing_cause(
     done = None
     skip = None
 
-    requires_finalizer = registry.requires_finalizer(resource=cause.resource, body=cause.body)
+    requires_finalizer = registry.requires_finalizer(resource=cause.resource, cause=cause)
     has_finalizer = finalizers.has_finalizers(body=cause.body)
 
     if requires_finalizer and not has_finalizer:

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -41,7 +41,11 @@ def context(
         for var, token in reversed(tokens):
             var.reset(token)
 
-def get_invoke_arguments(*args: Any, cause: Optional[causation.BaseCause] = None, **kwargs: Any) -> Dict[str, Any]:
+def get_invoke_arguments(
+    *args: Any,
+    cause: Optional[causation.BaseCause] = None,
+    **kwargs: Any
+) -> Dict[str, Any]:
     """
     Expand kwargs dict with fields from the causation.
     """

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -9,7 +9,7 @@ import asyncio
 import contextlib
 import contextvars
 import functools
-from typing import Optional, Any, Union, List, Iterable, Iterator, Tuple
+from typing import Optional, Any, Union, List, Iterable, Iterator, Tuple, Dict
 
 from kopf import config
 from kopf.reactor import causation
@@ -41,6 +41,51 @@ def context(
         for var, token in reversed(tokens):
             var.reset(token)
 
+def get_invoke_arguments(*args: Any, cause: Optional[causation.BaseCause] = None, **kwargs: Any) -> Dict[str, Any]:
+    """
+    Expand kwargs dict with fields from the causation.
+    """
+    new_kwargs = {}
+    new_kwargs.update(kwargs)
+
+    # Add aliases for the kwargs, directly linked to the body, or to the assumed defaults.
+    if isinstance(cause, causation.BaseCause):
+        new_kwargs.update(
+            cause=cause,
+            logger=cause.logger,
+        )
+    if isinstance(cause, causation.ActivityCause):
+        new_kwargs.update(
+            activity=cause.activity,
+        )
+    if isinstance(cause, causation.ResourceCause):
+        new_kwargs.update(
+            patch=cause.patch,
+            memo=cause.memo,
+            body=cause.body,
+            spec=dicts.DictView(cause.body, 'spec'),
+            meta=dicts.DictView(cause.body, 'metadata'),
+            status=dicts.DictView(cause.body, 'status'),
+            uid=cause.body.get('metadata', {}).get('uid'),
+            name=cause.body.get('metadata', {}).get('name'),
+            namespace=cause.body.get('metadata', {}).get('namespace'),
+        )
+    if isinstance(cause, causation.ResourceWatchingCause):
+        new_kwargs.update(
+            event=cause.raw,
+            type=cause.type,
+        )
+    if isinstance(cause, causation.ResourceChangingCause):
+        new_kwargs.update(
+            event=cause.reason,  # deprecated; kept for backward-compatibility
+            reason=cause.reason,
+            diff=cause.diff,
+            old=cause.old,
+            new=cause.new,
+        )
+
+    return new_kwargs
+
 
 async def invoke(
         fn: Invokable,
@@ -62,41 +107,7 @@ async def invoke(
     See: https://pymotw.com/3/asyncio/executors.html
     """
 
-    # Add aliases for the kwargs, directly linked to the body, or to the assumed defaults.
-    if isinstance(cause, causation.BaseCause):
-        kwargs.update(
-            cause=cause,
-            logger=cause.logger,
-        )
-    if isinstance(cause, causation.ActivityCause):
-        kwargs.update(
-            activity=cause.activity,
-        )
-    if isinstance(cause, causation.ResourceCause):
-        kwargs.update(
-            patch=cause.patch,
-            memo=cause.memo,
-            body=cause.body,
-            spec=dicts.DictView(cause.body, 'spec'),
-            meta=dicts.DictView(cause.body, 'metadata'),
-            status=dicts.DictView(cause.body, 'status'),
-            uid=cause.body.get('metadata', {}).get('uid'),
-            name=cause.body.get('metadata', {}).get('name'),
-            namespace=cause.body.get('metadata', {}).get('namespace'),
-        )
-    if isinstance(cause, causation.ResourceWatchingCause):
-        kwargs.update(
-            event=cause.raw,
-            type=cause.type,
-        )
-    if isinstance(cause, causation.ResourceChangingCause):
-        kwargs.update(
-            event=cause.reason,  # deprecated; kept for backward-compatibility
-            reason=cause.reason,
-            diff=cause.diff,
-            old=cause.old,
-            new=cause.new,
-        )
+    kwargs = get_invoke_arguments(*args, cause=cause, **kwargs)
 
     if is_async_fn(fn):
         result = await fn(*args, **kwargs)  # type: ignore

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -97,8 +97,9 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
         warnings.warn("SimpleRegistry.iter_event_handlers() is deprecated; use "
                       "ResourceWatchingRegistry.iter_handlers().", DeprecationWarning)
 
+        cause = _create_watching_cause(resource, event)
         for handler in self._handlers:
-            if registries.match(handler=handler, body=event['object'], ignore_fields=True):
+            if registries.match(handler=handler, cause=cause, ignore_fields=True):
                 yield handler
 
     def iter_cause_handlers(
@@ -113,7 +114,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
             if handler.reason is None or handler.reason == cause.reason:
                 if handler.initial and not cause.initial:
                     pass  # ignore initial handlers in non-initial causes.
-                elif registries.match(handler=handler, body=cause.body,
+                elif registries.match(handler=handler, cause=cause,
                                       changed_fields=changed_fields):
                     yield handler
 

--- a/tests/registries/legacy/test_legacy_decorators.py
+++ b/tests/registries/legacy/test_legacy_decorators.py
@@ -189,7 +189,7 @@ def test_on_field_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    when = lambda body: False
+    when = lambda **_: False
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
                    id='id', timeout=123, registry=registry,

--- a/tests/registries/legacy/test_legacy_decorators.py
+++ b/tests/registries/legacy/test_legacy_decorators.py
@@ -24,6 +24,7 @@ def test_on_create_minimal(mocker):
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_update_minimal(mocker):
@@ -43,6 +44,7 @@ def test_on_update_minimal(mocker):
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_delete_minimal(mocker):
@@ -62,6 +64,7 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_field_minimal(mocker):
@@ -82,6 +85,7 @@ def test_on_field_minimal(mocker):
     assert handlers[0].timeout is None
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_field_fails_without_field():
@@ -97,10 +101,13 @@ def test_on_create_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda **_: False
+
     @kopf.on.create('group', 'version', 'plural',
                     id='id', timeout=123, registry=registry,
                     labels={'somelabel': 'somevalue'},
-                    annotations={'someanno': 'somevalue'})
+                    annotations={'someanno': 'somevalue'},
+                    when=when)
     def fn(**_):
         pass
 
@@ -113,7 +120,7 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].timeout == 123
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
-
+    assert handlers[0].when == when
 
 def test_on_update_with_all_kwargs(mocker):
     registry = GlobalRegistry()
@@ -121,10 +128,13 @@ def test_on_update_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda **_: False
+
     @kopf.on.update('group', 'version', 'plural',
                     id='id', timeout=123, registry=registry,
                     labels={'somelabel': 'somevalue'},
-                    annotations={'someanno': 'somevalue'})
+                    annotations={'someanno': 'somevalue'},
+                    when=when)
     def fn(**_):
         pass
 
@@ -137,6 +147,7 @@ def test_on_update_with_all_kwargs(mocker):
     assert handlers[0].timeout == 123
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
+    assert handlers[0].when == when
 
 
 @pytest.mark.parametrize('optional', [
@@ -149,10 +160,13 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda **_: False
+
     @kopf.on.delete('group', 'version', 'plural',
                     id='id', timeout=123, registry=registry, optional=optional,
                     labels={'somelabel': 'somevalue'},
-                    annotations={'someanno': 'somevalue'})
+                    annotations={'someanno': 'somevalue'},
+                    when=when)
     def fn(**_):
         pass
 
@@ -165,6 +179,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].timeout == 123
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
+    assert handlers[0].when == when
 
 
 def test_on_field_with_all_kwargs(mocker):
@@ -174,10 +189,13 @@ def test_on_field_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda body: False
+
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
                    id='id', timeout=123, registry=registry,
                    labels={'somelabel': 'somevalue'},
-                   annotations={'someanno': 'somevalue'})
+                   annotations={'someanno': 'somevalue'},
+                   when=when)
     def fn(**_):
         pass
 
@@ -190,6 +208,7 @@ def test_on_field_with_all_kwargs(mocker):
     assert handlers[0].timeout == 123
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
+    assert handlers[0].when == when
 
 
 def test_subhandler_declaratively(mocker):

--- a/tests/registries/legacy/test_legacy_requires_finalizer.py
+++ b/tests/registries/legacy/test_legacy_requires_finalizer.py
@@ -3,6 +3,7 @@ import pytest
 import kopf
 from kopf import GlobalRegistry
 from kopf.structs.resources import Resource
+from kopf.reactor.causation import ResourceCause
 
 OBJECT_BODY = {
     'apiVersion': 'group/version',
@@ -18,6 +19,13 @@ OBJECT_BODY = {
     }
 }
 
+CAUSE = ResourceCause(
+    logger=None,
+    resource=None,
+    patch=None,
+    body=OBJECT_BODY,
+    memo=None
+)
 
 @pytest.mark.parametrize('optional, expected', [
     pytest.param(True, False, id='optional'),
@@ -32,7 +40,7 @@ def test_requires_finalizer_deletion_handler(optional, expected):
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -54,7 +62,7 @@ def test_requires_finalizer_multiple_handlers(optional, expected):
     def fn2(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -67,7 +75,7 @@ def test_requires_finalizer_no_deletion_handler():
     def fn1(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer is False
 
 
@@ -89,7 +97,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -111,7 +119,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -133,7 +141,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -155,5 +163,5 @@ def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations,
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -262,7 +262,7 @@ def test_on_resume_with_all_kwargs(mocker, reason):
     cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    when = lambda body: False
+    when = lambda **_: False
 
     @kopf.on.resume('group', 'version', 'plural',
                     id='id', registry=registry,
@@ -297,7 +297,7 @@ def test_on_create_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    when = lambda body: False
+    when = lambda **_: False
 
     @kopf.on.create('group', 'version', 'plural',
                     id='id', registry=registry,
@@ -330,7 +330,7 @@ def test_on_update_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    when = lambda body: False
+    when = lambda **_: False
 
     @kopf.on.update('group', 'version', 'plural',
                     id='id', registry=registry,
@@ -367,7 +367,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    when = lambda body: False
+    when = lambda **_: False
 
     @kopf.on.delete('group', 'version', 'plural',
                     id='id', registry=registry,
@@ -402,7 +402,7 @@ def test_on_field_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    when = lambda body: False
+    when = lambda **_: False
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
                    id='id', registry=registry,

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -84,6 +84,7 @@ def test_on_resume_minimal(mocker, reason):
     assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_create_minimal(mocker):
@@ -107,6 +108,7 @@ def test_on_create_minimal(mocker):
     assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_update_minimal(mocker):
@@ -130,6 +132,7 @@ def test_on_update_minimal(mocker):
     assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_delete_minimal(mocker):
@@ -153,6 +156,7 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_field_minimal(mocker):
@@ -177,6 +181,7 @@ def test_on_field_minimal(mocker):
     assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
+    assert handlers[0].when is None
 
 
 def test_on_field_fails_without_field():
@@ -257,12 +262,15 @@ def test_on_resume_with_all_kwargs(mocker, reason):
     cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda body: False
+
     @kopf.on.resume('group', 'version', 'plural',
                     id='id', registry=registry,
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     deleted=True,
                     labels={'somelabel': 'somevalue'},
-                    annotations={'someanno': 'somevalue'})
+                    annotations={'someanno': 'somevalue'},
+                    when=when)
     def fn(**_):
         pass
 
@@ -280,6 +288,7 @@ def test_on_resume_with_all_kwargs(mocker, reason):
     assert handlers[0].deleted == True
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
+    assert handlers[0].when == when
 
 
 def test_on_create_with_all_kwargs(mocker):
@@ -288,11 +297,14 @@ def test_on_create_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda body: False
+
     @kopf.on.create('group', 'version', 'plural',
                     id='id', registry=registry,
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     labels={'somelabel': 'somevalue'},
-                    annotations={'someanno': 'somevalue'})
+                    annotations={'someanno': 'somevalue'},
+                    when=when)
     def fn(**_):
         pass
 
@@ -309,6 +321,7 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
+    assert handlers[0].when == when
 
 
 def test_on_update_with_all_kwargs(mocker):
@@ -317,11 +330,14 @@ def test_on_update_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda body: False
+
     @kopf.on.update('group', 'version', 'plural',
                     id='id', registry=registry,
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     labels={'somelabel': 'somevalue'},
-                    annotations={'someanno': 'somevalue'})
+                    annotations={'someanno': 'somevalue'},
+                    when=when)
     def fn(**_):
         pass
 
@@ -338,6 +354,7 @@ def test_on_update_with_all_kwargs(mocker):
     assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
+    assert handlers[0].when == when
 
 
 @pytest.mark.parametrize('optional', [
@@ -350,12 +367,15 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda body: False
+
     @kopf.on.delete('group', 'version', 'plural',
                     id='id', registry=registry,
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     optional=optional,
                     labels={'somelabel': 'somevalue'},
-                    annotations={'someanno': 'somevalue'})
+                    annotations={'someanno': 'somevalue'},
+                    when=when)
     def fn(**_):
         pass
 
@@ -372,6 +392,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
+    assert handlers[0].when == when
 
 
 def test_on_field_with_all_kwargs(mocker):
@@ -381,11 +402,14 @@ def test_on_field_with_all_kwargs(mocker):
     cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
+    when = lambda body: False
+
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
                    id='id', registry=registry,
                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                    labels={'somelabel': 'somevalue'},
-                   annotations={'someanno': 'somevalue'})
+                   annotations={'someanno': 'somevalue'},
+                   when=when)
     def fn(**_):
         pass
 
@@ -402,6 +426,7 @@ def test_on_field_with_all_kwargs(mocker):
     assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
+    assert handlers[0].when == when
 
 
 def test_subhandler_declaratively(mocker):

--- a/tests/registries/test_requires_finalizer.py
+++ b/tests/registries/test_requires_finalizer.py
@@ -3,6 +3,7 @@ import pytest
 import kopf
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.resources import Resource
+from kopf.reactor.causation import ResourceCause
 
 OBJECT_BODY = {
     'apiVersion': 'group/version',
@@ -18,6 +19,13 @@ OBJECT_BODY = {
     }
 }
 
+CAUSE = ResourceCause(
+    logger=None,
+    resource=None,
+    patch=None,
+    body=OBJECT_BODY,
+    memo=None
+)
 
 @pytest.mark.parametrize('optional, expected', [
     pytest.param(True, False, id='optional'),
@@ -32,7 +40,7 @@ def test_requires_finalizer_deletion_handler(optional, expected):
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -54,7 +62,7 @@ def test_requires_finalizer_multiple_handlers(optional, expected):
     def fn2(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -67,7 +75,7 @@ def test_requires_finalizer_no_deletion_handler():
     def fn1(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer is False
 
 
@@ -89,7 +97,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -111,7 +119,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -133,7 +141,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
 
@@ -155,5 +163,5 @@ def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations,
     def fn(**_):
         pass
 
-    requires_finalizer = registry.requires_finalizer(resource=resource, body=OBJECT_BODY)
+    requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected


### PR DESCRIPTION
# Filter by arbitrary callback function

> Issue : #98

## Description

In some cases, it might be needed that only a subset of resources are handled. An example might be implementing the cert-manager external issuer process where cert-manager creates a CertificateRequest CRD and waits for it to be acted on and marked as complete, and each issuer should filter on `spec.issuerRef` to find the requests it should service.

This PR enables that use case by allowing you to specify a `when` callback that is run before invoking a handler to filter out handlers that are not appropriate.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
