### PR TITLE
Fix bug #261, JSONPath should include the function name

### DIFF
--- a/examples/crd.yaml
+++ b/examples/crd.yaml
@@ -28,10 +28,10 @@ spec:
     - name: Children
       type: string
       priority: 0
-      JSONPath: .status.children
+      JSONPath: .status.create_fn.children
       description: The children pods created.
     - name: Message
       type: string
       priority: 0
-      JSONPath: .status.message
+      JSONPath: .status.create_fn.message
       description: As returned from the handler (sometimes).


### PR DESCRIPTION
Signed-off-by: Nicolas Kowenski <nicolas.kowenski@id.ethz.ch>

# One-line summary

> Issue : #261

## Description
The JSONPath was missing the function name create_fn

