### PR TITLE
Ensure predictable mypy's type-checking rules in CI/CD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ asynctest
 freezegun
 codecov
 coveralls
-mypy
+mypy==0.740

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-# Temporary - only to address https://github.com/kennethreitz/requests/issues/5067
-urllib3<1.25
-
 # The runtime dependencies of the framework, as if via `pip install kopf`.
 -e .
 


### PR DESCRIPTION
The type-checking rules should be predictable over time.

> Issue : originally detected in #262, originally introduced in #200 

## Description

### mypy

New `mypy` releases sometimes break the CI/CD builds when no significant code changes are introduced to the codebase. The CI/CD builds are expected to succeed as before.

Just happened in #262 — a documentation/CRD change, that got `asyncio.wait()` type-checks in `kopf.reactor.running` broken. A broken build: https://travis-ci.org/zalando-incubator/kopf/builds/620169471

Caused by a regression in `mypy==0.750` with type inference (https://github.com/python/mypy/issues/8051). The fix is going to be released 1 month after the regression was introduced: 21.11.2019 .. 16.12.2019. We cannot afford to wait 1 month with a broken CI/CD pipeline.

Previously, there were similar sudden changes in `mypy` with new rules in a new mypy release: e.g. #208.

It is expected that such backward-incompatible changes or regressions will be introduced in the future too — due to active development of `mypy`. So, since now, we keep the version pinned, and upgrade it explicitly as a separate PR (manual or maybe automatic) — possibly with relevant code changes to satisfy new type-checking rules.


### urllib3

The urllib3 version ceiling was introduced in May 2019 in https://github.com/zalando-incubator/kopf/commit/a256445abb44e854c17993c41cee95b995a42675 — due to setuptools/pkg_resources version conflicts and inability to run the CI/CD scripts.  This ceiling was applied only to our own CI/CD. The apps were free to handle these issues their own way.

The issue seems to be fixed in https://github.com/psf/requests/issues/5067 in April 2019.

## Types of Changes

- Configuration change
