### PR TITLE
Rename "cooldown" to "backoff" for handler retrying

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -123,8 +123,8 @@ Once the number of retries is reached, the handler fails permanently.
 By default, there is no limit, so the retries continue forever.
 
 
-Cool-down on errors
-===================
+Backoff
+=======
 
 The interval between retries on arbitrary errors, when an external environment
 is supposed to recover and be able to succeed the handler execution,
@@ -132,7 +132,7 @@ can be configured::
 
     import kopf
 
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', cooldown=30)
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', backoff=30)
     def create_fn(spec, **_):
         raise Exception()
 

--- a/examples/03-exceptions/example.py
+++ b/examples/03-exceptions/example.py
@@ -21,11 +21,11 @@ def eventual_success_with_few_messages(retry, **kwargs):
         raise kopf.TemporaryError("Expected recoverable error.", delay=1.0)
 
 
-@kopf.on.create('zalando.org', 'v1', 'kopfexamples', retries=3, cooldown=1.0)
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', retries=3, backoff=1.0)
 def eventual_failure_with_tracebacks(**kwargs):
     raise MyException("An error that is supposed to be recoverable.")
 
 
-@kopf.on.create('zalando.org', 'v1', 'kopfexamples', errors=kopf.ErrorsMode.PERMANENT, cooldown=1.0)
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', errors=kopf.ErrorsMode.PERMANENT, backoff=1.0)
 def instant_failure_with_traceback(**kwargs):
     raise MyException("An error that is supposed to be recoverable.")

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -29,14 +29,15 @@ def startup(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityHandlerDecorator:
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
         return actual_registry.register_activity_handler(
             fn=fn, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             activity=causation.Activity.STARTUP,
         )
     return decorator
@@ -48,14 +49,15 @@ def cleanup(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityHandlerDecorator:
     actual_registry = registry if registry is not None else registries.get_default_registry()
     def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
         return actual_registry.register_activity_handler(
             fn=fn, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             activity=causation.Activity.CLEANUP,
         )
     return decorator
@@ -67,7 +69,8 @@ def login(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityHandlerDecorator:
     """ ``@kopf.on.login()`` handler for custom (re-)authentication. """
@@ -75,7 +78,7 @@ def login(
     def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
         return actual_registry.register_activity_handler(
             fn=fn, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             activity=causation.Activity.AUTHENTICATION,
         )
     return decorator
@@ -87,7 +90,8 @@ def probe(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityHandlerDecorator:
     """ ``@kopf.on.probe()`` handler for arbitrary liveness metrics. """
@@ -95,7 +99,7 @@ def probe(
     def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
         return actual_registry.register_activity_handler(
             fn=fn, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             activity=causation.Activity.PROBE,
         )
     return decorator
@@ -108,7 +112,8 @@ def resume(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
         deleted: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
@@ -120,7 +125,7 @@ def resume(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, initial=True, deleted=deleted, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -133,7 +138,8 @@ def create(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated; use backoff.
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -144,7 +150,7 @@ def create(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -157,7 +163,8 @@ def update(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -168,7 +175,7 @@ def update(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -181,7 +188,8 @@ def delete(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
         optional: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
@@ -193,7 +201,7 @@ def delete(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.DELETE, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             fn=fn, requires_finalizer=bool(not optional),
             labels=labels, annotations=annotations,
         )
@@ -208,7 +216,8 @@ def field(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
@@ -219,7 +228,7 @@ def field(
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             fn=fn, labels=labels, annotations=annotations,
         )
     return decorator
@@ -251,7 +260,8 @@ def this(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> ResourceHandlerDecorator:
     """
@@ -287,7 +297,7 @@ def this(
     def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
         return actual_registry.register(
             id=id, fn=fn,
-            errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
         )
     return decorator
 
@@ -299,7 +309,8 @@ def register(
         errors: Optional[registries.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
-        cooldown: Optional[float] = None,
+        backoff: Optional[float] = None,
+        cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.ResourceChangingRegistry] = None,
 ) -> registries.ResourceHandlerFn:
     """
@@ -328,6 +339,6 @@ def register(
     """
     decorator = this(
         id=id, registry=registry,
-        errors=errors, timeout=timeout, retries=retries, cooldown=cooldown,
+        errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
     )
     return decorator(fn)

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -500,7 +500,7 @@ async def _execute_handler(
     exceptions mean the failure of execution itself.
     """
     errors = handler.errors if handler.errors is not None else default_errors
-    cooldown = handler.cooldown if handler.cooldown is not None else DEFAULT_RETRY_DELAY
+    backoff = handler.backoff if handler.backoff is not None else DEFAULT_RETRY_DELAY
 
     # Prevent successes/failures from posting k8s-events for resource-watching causes.
     logger: Union[logging.Logger, logging.LoggerAdapter]
@@ -557,7 +557,7 @@ async def _execute_handler(
             return states.HandlerOutcome(final=True)
         elif errors == registries.ErrorsMode.TEMPORARY:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will retry.")
-            return states.HandlerOutcome(final=False, exception=e, delay=cooldown)
+            return states.HandlerOutcome(final=False, exception=e, delay=backoff)
         elif errors == registries.ErrorsMode.PERMANENT:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will stop.")
             return states.HandlerOutcome(final=True, exception=e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ asynctest
 freezegun
 codecov
 coveralls
-mypy
+mypy==0.740

--- a/tests/basic-structs/test_handlers_deprecated_cooldown.py
+++ b/tests/basic-structs/test_handlers_deprecated_cooldown.py
@@ -1,15 +1,8 @@
-import pytest
-
+# Original test-file: tests/basic-structs/test_handlers.py
 from kopf.reactor.registries import ActivityHandler, ResourceHandler
 
 
-@pytest.mark.parametrize('cls', [ActivityHandler, ResourceHandler])
-def test_handler_with_no_args(cls):
-    with pytest.raises(TypeError):
-        cls()
-
-
-def test_activity_handler_with_all_args(mocker):
+def test_activity_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
     errors = mocker.Mock()
@@ -23,8 +16,8 @@ def test_activity_handler_with_all_args(mocker):
         errors=errors,
         timeout=timeout,
         retries=retries,
-        backoff=backoff,
-        cooldown=None,  # deprecated, but still required
+        backoff=None,
+        cooldown=backoff,  # deprecated, but still required
         activity=activity,
     )
     assert handler.fn is fn
@@ -37,7 +30,7 @@ def test_activity_handler_with_all_args(mocker):
     assert handler.activity is activity
 
 
-def test_resource_handler_with_all_args(mocker):
+def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
     reason = mocker.Mock()
@@ -58,8 +51,8 @@ def test_resource_handler_with_all_args(mocker):
         errors=errors,
         timeout=timeout,
         retries=retries,
-        backoff=backoff,
-        cooldown=None,  # deprecated, but still required
+        backoff=None,
+        cooldown=backoff,  # deprecated, but still required
         initial=initial,
         labels=labels,
         annotations=annotations,

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -21,7 +21,8 @@ def test_on_startup_minimal():
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
-    assert handlers[0].cooldown is None
+    assert handlers[0].backoff is None
+    assert handlers[0].cooldown is None  # deprecated alias
 
 
 def test_on_cleanup_minimal():
@@ -38,7 +39,8 @@ def test_on_cleanup_minimal():
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
-    assert handlers[0].cooldown is None
+    assert handlers[0].backoff is None
+    assert handlers[0].cooldown is None  # deprecated alias
 
 
 def test_on_probe_minimal():
@@ -55,7 +57,8 @@ def test_on_probe_minimal():
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
-    assert handlers[0].cooldown is None
+    assert handlers[0].backoff is None
+    assert handlers[0].cooldown is None  # deprecated alias
 
 
 # Resume handlers are mixed-in into all resource-changing reactions with initial listing.
@@ -77,7 +80,8 @@ def test_on_resume_minimal(mocker, reason):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
-    assert handlers[0].cooldown is None
+    assert handlers[0].backoff is None
+    assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -99,7 +103,8 @@ def test_on_create_minimal(mocker):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
-    assert handlers[0].cooldown is None
+    assert handlers[0].backoff is None
+    assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -121,7 +126,8 @@ def test_on_update_minimal(mocker):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
-    assert handlers[0].cooldown is None
+    assert handlers[0].backoff is None
+    assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -143,7 +149,8 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
-    assert handlers[0].cooldown is None
+    assert handlers[0].backoff is None
+    assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -166,7 +173,8 @@ def test_on_field_minimal(mocker):
     assert handlers[0].errors is None
     assert handlers[0].timeout is None
     assert handlers[0].retries is None
-    assert handlers[0].cooldown is None
+    assert handlers[0].backoff is None
+    assert handlers[0].cooldown is None  # deprecated alias
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
 
@@ -183,7 +191,7 @@ def test_on_startup_with_all_kwargs(mocker):
 
     @kopf.on.startup(
         id='id', registry=registry,
-        errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78)
+        errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78)
     def fn(**_):
         pass
 
@@ -195,7 +203,8 @@ def test_on_startup_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
-    assert handlers[0].cooldown == 78
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
 
 
 def test_on_cleanup_with_all_kwargs(mocker):
@@ -203,7 +212,7 @@ def test_on_cleanup_with_all_kwargs(mocker):
 
     @kopf.on.cleanup(
         id='id', registry=registry,
-        errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78)
+        errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78)
     def fn(**_):
         pass
 
@@ -215,7 +224,8 @@ def test_on_cleanup_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
-    assert handlers[0].cooldown == 78
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
 
 
 def test_on_probe_with_all_kwargs(mocker):
@@ -223,7 +233,7 @@ def test_on_probe_with_all_kwargs(mocker):
 
     @kopf.on.probe(
         id='id', registry=registry,
-        errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78)
+        errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78)
     def fn(**_):
         pass
 
@@ -235,7 +245,8 @@ def test_on_probe_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
-    assert handlers[0].cooldown == 78
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
 
 
 # Resume handlers are mixed-in into all resource-changing reactions with initial listing.
@@ -248,7 +259,7 @@ def test_on_resume_with_all_kwargs(mocker, reason):
 
     @kopf.on.resume('group', 'version', 'plural',
                     id='id', registry=registry,
-                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     deleted=True,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
@@ -264,7 +275,8 @@ def test_on_resume_with_all_kwargs(mocker, reason):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
-    assert handlers[0].cooldown == 78
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].deleted == True
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
@@ -278,7 +290,7 @@ def test_on_create_with_all_kwargs(mocker):
 
     @kopf.on.create('group', 'version', 'plural',
                     id='id', registry=registry,
-                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -293,7 +305,8 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
-    assert handlers[0].cooldown == 78
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -306,7 +319,7 @@ def test_on_update_with_all_kwargs(mocker):
 
     @kopf.on.update('group', 'version', 'plural',
                     id='id', registry=registry,
-                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -321,7 +334,8 @@ def test_on_update_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
-    assert handlers[0].cooldown == 78
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -338,7 +352,7 @@ def test_on_delete_with_all_kwargs(mocker, optional):
 
     @kopf.on.delete('group', 'version', 'plural',
                     id='id', registry=registry,
-                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
+                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     optional=optional,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'})
@@ -354,7 +368,8 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
-    assert handlers[0].cooldown == 78
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 
@@ -368,7 +383,7 @@ def test_on_field_with_all_kwargs(mocker):
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield',
                    id='id', registry=registry,
-                   errors=ErrorsMode.PERMANENT, timeout=123, retries=456, cooldown=78,
+                   errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                    labels={'somelabel': 'somevalue'},
                    annotations={'someanno': 'somevalue'})
     def fn(**_):
@@ -383,7 +398,8 @@ def test_on_field_with_all_kwargs(mocker):
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
     assert handlers[0].retries == 456
-    assert handlers[0].cooldown == 78
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
 

--- a/tests/registries/test_decorators_deprecated_cooldown.py
+++ b/tests/registries/test_decorators_deprecated_cooldown.py
@@ -1,0 +1,139 @@
+import pytest
+
+import kopf
+from kopf.reactor.causation import Reason, Activity, HANDLER_REASONS
+from kopf.structs.resources import Resource
+
+
+def test_on_startup_with_cooldown():
+    registry = kopf.get_default_registry()
+
+    @kopf.on.startup(cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_activity_handlers(activity=Activity.STARTUP)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
+
+
+def test_on_cleanup_with_cooldown():
+    registry = kopf.get_default_registry()
+
+    @kopf.on.cleanup(cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_activity_handlers(activity=Activity.CLEANUP)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
+
+
+def test_on_probe_with_cooldown():
+    registry = kopf.get_default_registry()
+
+    @kopf.on.probe(cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_activity_handlers(activity=Activity.PROBE)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
+
+
+# Resume handlers are mixed-in into all resource-changing reactions with initial listing.
+@pytest.mark.parametrize('reason', HANDLER_REASONS)
+def test_on_resume_with_cooldown(mocker, reason):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.resume('group', 'version', 'plural', cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
+
+
+def test_on_create_with_cooldown(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.create('group', 'version', 'plural', cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
+
+
+def test_on_update_with_cooldown(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.update('group', 'version', 'plural', cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
+
+
+@pytest.mark.parametrize('optional', [
+    pytest.param(True, id='optional'),
+    pytest.param(False, id='mandatory'),
+])
+def test_on_delete_with_cooldown(mocker, optional):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.delete('group', 'version', 'plural', cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias
+
+
+def test_on_field_with_cooldown(mocker):
+    registry = kopf.get_default_registry()
+    resource = Resource('group', 'version', 'plural')
+    diff = [('op', ('field', 'subfield'), 'old', 'new')]
+    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @kopf.on.field('group', 'version', 'plural', 'field.subfield', cooldown=78)
+    def fn(**_):
+        pass
+
+    handlers = registry.get_resource_changing_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].backoff == 78
+    assert handlers[0].cooldown == 78  # deprecated alias


### PR DESCRIPTION
Fix a terminology issue, but keep it backward compatible.
 
> Issue : #222, #16

## Description

Due to my not so good English vocabulary, a slightly inappropriate word was used for the delay between retries of the handlers in #222: "cooldown". 

"Cooldowns" are used in the RPG games for the spells. In Computer Science, the proper word would be ["backoff"](https://en.wiktionary.org/wiki/backoff): 

* [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff), 
* [`retry` library's `backoff=` kwarg](https://github.com/invl/retry#retry-decorator), 
* Kubernetes pods' `CrashLoopBackOff`, 
* Kubernetes jobs' [`spec.backoffLimit`](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#pod-backoff-failure-policy),
* etc.

It is better to fix this terminology issue before it spreads all over the codebase.  _(It is also possible that this kwarg will be extended to "exponential backoff" in the future.)_

The handlers'/decorators' `cooldown=` kwarg and `.cooldown` read-only property are kept there for backward compatibility as aliases for `backoff=`/`.backoff` — since there was at least one public release with this naming (we do not know if it is already used somewhere or not). 

The aliases are tested only to minimally guarantee that they work as expected until they are removed in the next major release (1.0). The rest of the tests are switched to the proper name.


## Types of Changes

- Refactor/improvements

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
