### PR TITLE
[272] Enforce the version of `coverage` manually (pip fails to resolve)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 -e .
 
 # Everything needed to develop (test, debug) the framework.
+coverage<5.0  # manual enforcement where pip fails, see #272.
 pytest-aiohttp
 pytest-asyncio
 pytest-mock>=1.11.1


### PR DESCRIPTION
Resolve `coveralls` vs. `pytest-cov` battle for `coverage` versions due to `coverage==5.0` release 2 days ago.

> Issue : closes #272 

## Description

`coverage==5.0` has been release on 14.12.2019 (2 days ago). This broke the CI/CD, as pip cannot resolve the version conflict: 

* `pytest-cov` wants `coverage>=4.4`, and is executed first.
* `coverage==5.0` is found and installed.
* `coveralls` wants `coverage<5.0`, but it is too late to reinstall.

The fix is to install `coverage<5.0` before any of the dependencies request it. The solution is temporary by its nature. See #273 for a more generic approach (version pinning and auto-upgrading) — will be done somewhen later.


## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
