### PR TITLE
[275] Parse JSON lines ourselves to avoid aiohttp's "Line is too long"

### DIFF
--- a/tests/k8s/test_watching_iterjsonlines.py
+++ b/tests/k8s/test_watching_iterjsonlines.py
@@ -1,5 +1,5 @@
 import asynctest
-from kopf.clients.watching import _iter_lines
+from kopf.clients.watching import _iter_jsonlines
 
 
 async def test_empty_content():
@@ -9,7 +9,7 @@ async def test_empty_content():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_lines(content):
+    async for line in _iter_jsonlines(content):
         lines.append(line)
 
     assert lines == []
@@ -21,10 +21,10 @@ async def test_empty_chunk():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_lines(content):
+    async for line in _iter_jsonlines(content):
         lines.append(line)
 
-    assert lines == [b'']
+    assert lines == []
 
 
 async def test_one_chunk_one_line():
@@ -33,7 +33,7 @@ async def test_one_chunk_one_line():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_lines(content):
+    async for line in _iter_jsonlines(content):
         lines.append(line)
 
     assert lines == [b'hello']
@@ -45,7 +45,7 @@ async def test_one_chunk_two_lines():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_lines(content):
+    async for line in _iter_jsonlines(content):
         lines.append(line)
 
     assert lines == [b'hello', b'world']
@@ -53,25 +53,25 @@ async def test_one_chunk_two_lines():
 
 async def test_one_chunk_empty_lines():
     async def iter_chunked(n: int):
-        yield b'\nhello\nworld\n'
+        yield b'\n\nhello\n\nworld\n\n'
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_lines(content):
+    async for line in _iter_jsonlines(content):
         lines.append(line)
 
-    assert lines == [b'', b'hello', b'world', b'']
+    assert lines == [b'hello', b'world']
 
 
 async def test_few_chunks_split():
     async def iter_chunked(n: int):
-        yield b'\nhel'
-        yield b'lo\nwo'
-        yield b'rld\n'
+        yield b'\n\nhell'
+        yield b'o\n\nwor'
+        yield b'ld\n\n'
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_lines(content):
+    async for line in _iter_jsonlines(content):
         lines.append(line)
 
-    assert lines == [b'', b'hello', b'world', b'']
+    assert lines == [b'hello', b'world']

--- a/tests/k8s/test_watching_iterlines.py
+++ b/tests/k8s/test_watching_iterlines.py
@@ -3,11 +3,11 @@ from kopf.clients.watching import _iter_lines
 
 
 async def test_empty_content():
-    async def iter_chunks():
+    async def iter_chunked(n: int):
         if False:  # to make this function a generator
             yield b''
 
-    content = asynctest.Mock(iter_chunks=iter_chunks)
+    content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in _iter_lines(content):
         lines.append(line)
@@ -16,10 +16,10 @@ async def test_empty_content():
 
 
 async def test_empty_chunk():
-    async def iter_chunks():
-        yield (b'', False)
+    async def iter_chunked(n: int):
+        yield b''
 
-    content = asynctest.Mock(iter_chunks=iter_chunks)
+    content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in _iter_lines(content):
         lines.append(line)
@@ -28,10 +28,10 @@ async def test_empty_chunk():
 
 
 async def test_one_chunk_one_line():
-    async def iter_chunks():
-        yield (b'hello', False)
+    async def iter_chunked(n: int):
+        yield b'hello'
 
-    content = asynctest.Mock(iter_chunks=iter_chunks)
+    content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in _iter_lines(content):
         lines.append(line)
@@ -40,10 +40,10 @@ async def test_one_chunk_one_line():
 
 
 async def test_one_chunk_two_lines():
-    async def iter_chunks():
-        yield (b'hello\nworld', False)
+    async def iter_chunked(n: int):
+        yield b'hello\nworld'
 
-    content = asynctest.Mock(iter_chunks=iter_chunks)
+    content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in _iter_lines(content):
         lines.append(line)
@@ -52,10 +52,10 @@ async def test_one_chunk_two_lines():
 
 
 async def test_one_chunk_empty_lines():
-    async def iter_chunks():
-        yield (b'\nhello\nworld\n', False)
+    async def iter_chunked(n: int):
+        yield b'\nhello\nworld\n'
 
-    content = asynctest.Mock(iter_chunks=iter_chunks)
+    content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in _iter_lines(content):
         lines.append(line)
@@ -64,12 +64,12 @@ async def test_one_chunk_empty_lines():
 
 
 async def test_few_chunks_split():
-    async def iter_chunks():
-        yield (b'\nhel', False)
-        yield (b'lo\nwo', False)
-        yield (b'rld\n', False)
+    async def iter_chunked(n: int):
+        yield b'\nhel'
+        yield b'lo\nwo'
+        yield b'rld\n'
 
-    content = asynctest.Mock(iter_chunks=iter_chunks)
+    content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in _iter_lines(content):
         lines.append(line)

--- a/tests/k8s/test_watching_iterlines.py
+++ b/tests/k8s/test_watching_iterlines.py
@@ -1,0 +1,77 @@
+import asynctest
+from kopf.clients.watching import _iter_lines
+
+
+async def test_empty_content():
+    async def iter_chunks():
+        if False:  # to make this function a generator
+            yield b''
+
+    content = asynctest.Mock(iter_chunks=iter_chunks)
+    lines = []
+    async for line in _iter_lines(content):
+        lines.append(line)
+
+    assert lines == []
+
+
+async def test_empty_chunk():
+    async def iter_chunks():
+        yield (b'', False)
+
+    content = asynctest.Mock(iter_chunks=iter_chunks)
+    lines = []
+    async for line in _iter_lines(content):
+        lines.append(line)
+
+    assert lines == [b'']
+
+
+async def test_one_chunk_one_line():
+    async def iter_chunks():
+        yield (b'hello', False)
+
+    content = asynctest.Mock(iter_chunks=iter_chunks)
+    lines = []
+    async for line in _iter_lines(content):
+        lines.append(line)
+
+    assert lines == [b'hello']
+
+
+async def test_one_chunk_two_lines():
+    async def iter_chunks():
+        yield (b'hello\nworld', False)
+
+    content = asynctest.Mock(iter_chunks=iter_chunks)
+    lines = []
+    async for line in _iter_lines(content):
+        lines.append(line)
+
+    assert lines == [b'hello', b'world']
+
+
+async def test_one_chunk_empty_lines():
+    async def iter_chunks():
+        yield (b'\nhello\nworld\n', False)
+
+    content = asynctest.Mock(iter_chunks=iter_chunks)
+    lines = []
+    async for line in _iter_lines(content):
+        lines.append(line)
+
+    assert lines == [b'', b'hello', b'world', b'']
+
+
+async def test_few_chunks_split():
+    async def iter_chunks():
+        yield (b'\nhel', False)
+        yield (b'lo\nwo', False)
+        yield (b'rld\n', False)
+
+    content = asynctest.Mock(iter_chunks=iter_chunks)
+    lines = []
+    async for line in _iter_lines(content):
+        lines.append(line)
+
+    assert lines == [b'', b'hello', b'world', b'']


### PR DESCRIPTION
Parse the JSON lines of Kubernetes watch-streams with no memory limit.

> Issue : #275

## Description

Kubernetes can send JSON lines with huge objects. E.g., secrets of 2MB in #275. 

`aiohttp` has a hard-coded limit the lines received from the stream, and it is 128KB ([`aiohttp.streams.DEFAULT_LIMIT = 2**16`](https://github.com/aio-libs/aiohttp/blob/6a5ab96bd9cb404b4abfd5160fe8f34a29d941e5/aiohttp/streams.py#L20) = 64 KB for the low watermark of the buffer, multiplied by 2x for high watermark, where the exception is raised).

There is no way to externally configure the buffer size of the aiohttp's StreamReader, so as there is no way to inject our own `StreamReader` instances with `limit=` properly set. The [docs say](https://docs.aiohttp.org/en/stable/streams.html):

> User should never instantiate streams manually but use existing `aiohttp.web.Request.content` and `aiohttp.ClientResponse.content` properties for accessing raw BODY data.

For this reason, we implement our own per-line iterator with no memory control — it takes as much memory, as it is needed. Though, we try not to waste it too much by not having duplicates of each line in the buffer and by not having multiple copies of the same line.

The efficiency is not tested and is not measured. Specifically, it can be slow if there are hundreds or thousands of such huge resources or events are happening very often. But we assume it is sufficient for now, and can later be improved when some performance optimisations and measurements are performed.

_FYI: The provided test clearly shows how the pure aiohttp approach fails with "Line is too long" — if used without this wrapping iterator._


## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
