### PR TITLE
[246] Prepare for aiohttp v4, but stay with v3

### DIFF
--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -25,7 +25,7 @@ async def post_event(
         type: str,
         reason: str,
         message: str = '',
-        session: Optional[auth.APISession] = None,  # injected by the decorator
+        context: Optional[auth.APIContext] = None,  # injected by the decorator
 ) -> None:
     """
     Issue an event for the object.
@@ -34,12 +34,12 @@ async def post_event(
     and where the rate-limits should be maintained. It can (and should)
     be done by the client library, as it is done in the Go client.
     """
-    if session is None:
+    if context is None:
         raise RuntimeError("API instance is not injected by the decorator.")
 
     # See #164. For cluster-scoped objects, use the current namespace from the current context.
     # It could be "default", but in some systems, we are limited to one specific namespace only.
-    namespace: str = ref.get('namespace') or session.default_namespace or 'default'
+    namespace: str = ref.get('namespace') or context.default_namespace or 'default'
     full_ref: bodies.ObjectReference = copy.copy(ref)
     full_ref['namespace'] = namespace
 
@@ -74,8 +74,8 @@ async def post_event(
     }
 
     try:
-        response = await session.post(
-            url=EVENTS_CORE_V1_CRD.get_url(server=session.server, namespace=namespace),
+        response = await context.session.post(
+            url=EVENTS_CORE_V1_CRD.get_url(server=context.server, namespace=namespace),
             headers={'Content-Type': 'application/json'},
             json=body,
         )

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -22,14 +22,14 @@ async def read_crd(
         *,
         resource: resources.Resource,
         default: Union[_T, _UNSET] = _UNSET.token,
-        session: Optional[auth.APISession] = None,  # injected by the decorator
+        context: Optional[auth.APIContext] = None,  # injected by the decorator
 ) -> Union[bodies.Body, _T]:
-    if session is None:
+    if context is None:
         raise RuntimeError("API instance is not injected by the decorator.")
 
     try:
-        response = await session.get(
-            url=CRD_CRD.get_url(server=session.server, name=resource.name),
+        response = await context.session.get(
+            url=CRD_CRD.get_url(server=context.server, name=resource.name),
         )
         response.raise_for_status()
         respdata = await response.json()
@@ -48,17 +48,17 @@ async def read_obj(
         namespace: Optional[str] = None,
         name: Optional[str] = None,
         default: Union[_T, _UNSET] = _UNSET.token,
-        session: Optional[auth.APISession] = None,  # injected by the decorator
+        context: Optional[auth.APIContext] = None,  # injected by the decorator
 ) -> Union[bodies.Body, _T]:
-    if session is None:
+    if context is None:
         raise RuntimeError("API instance is not injected by the decorator.")
 
-    is_namespaced = await discovery.is_namespaced(resource=resource, session=session)
+    is_namespaced = await discovery.is_namespaced(resource=resource, context=context)
     namespace = namespace if is_namespaced else None
 
     try:
-        response = await session.get(
-            url=resource.get_url(server=session.server, namespace=namespace, name=name),
+        response = await context.session.get(
+            url=resource.get_url(server=context.server, namespace=namespace, name=name),
         )
         response.raise_for_status()
         respdata = await response.json()
@@ -75,7 +75,7 @@ async def list_objs_rv(
         *,
         resource: resources.Resource,
         namespace: Optional[str] = None,
-        session: Optional[auth.APISession] = None,  # injected by the decorator
+        context: Optional[auth.APIContext] = None,  # injected by the decorator
 ) -> Tuple[Collection[bodies.Body], str]:
     """
     List the objects of specific resource type.
@@ -89,14 +89,14 @@ async def list_objs_rv(
 
     * The resource is namespace-scoped AND operator is namespaced-restricted.
     """
-    if session is None:
+    if context is None:
         raise RuntimeError("API instance is not injected by the decorator.")
 
-    is_namespaced = await discovery.is_namespaced(resource=resource, session=session)
+    is_namespaced = await discovery.is_namespaced(resource=resource, context=context)
     namespace = namespace if is_namespaced else None
 
-    response = await session.get(
-        url=resource.get_url(server=session.server, namespace=namespace),
+    response = await context.session.get(
+        url=resource.get_url(server=context.server, namespace=namespace),
     )
     response.raise_for_status()
     rsp = await response.json()

--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -170,7 +170,7 @@ async def watch_objs(
         namespace: Optional[str] = None,
         timeout: Optional[float] = None,
         since: Optional[str] = None,
-        session: Optional[auth.APISession] = None,  # injected by the decorator
+        context: Optional[auth.APIContext] = None,  # injected by the decorator
         freeze_waiter: asyncio_Future,
 ) -> AsyncIterator[bodies.RawEvent]:
     """
@@ -185,10 +185,10 @@ async def watch_objs(
 
     * The resource is namespace-scoped AND operator is namespaced-restricted.
     """
-    if session is None:
+    if context is None:
         raise RuntimeError("API instance is not injected by the decorator.")
 
-    is_namespaced = await discovery.is_namespaced(resource=resource, session=session)
+    is_namespaced = await discovery.is_namespaced(resource=resource, context=context)
     namespace = namespace if is_namespaced else None
 
     params: Dict[str, str] = {}
@@ -199,8 +199,8 @@ async def watch_objs(
         params['timeoutSeconds'] = str(timeout)
 
     # Talk to the API and initiate a streaming response.
-    response = await session.get(
-        url=resource.get_url(server=session.server, namespace=namespace, params=params),
+    response = await context.session.get(
+        url=resource.get_url(server=context.server, namespace=namespace, params=params),
         timeout=aiohttp.ClientTimeout(total=None),
     )
     response.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'typing_extensions',
         'click',
         'iso8601',
-        'aiohttp',
+        'aiohttp<4.0.0',
         'aiojobs',
         'pykube-ng>=0.27',  # used only for config parsing
     ],

--- a/tests/authentication/test_credentials.py
+++ b/tests/authentication/test_credentials.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from kopf.clients.auth import reauthenticated_request, vault_var
+from kopf.clients.auth import reauthenticated_request, vault_var, APIContext
 from kopf.structs.credentials import Vault, ConnectionInfo
 
 # These are Minikube's locally geenrated certificates (CN=minikubeCA).
@@ -84,8 +84,8 @@ lUXVsCYgw8yNCm10xGCelpJ4nxxPhf5apbz4F3nGORGfsv5C+x++
 
 
 @reauthenticated_request
-async def fn(session):
-    return session
+async def fn(context: APIContext):
+    return context.session
 
 
 @pytest.fixture(autouse=True)

--- a/tests/authentication/test_tempfiles.py
+++ b/tests/authentication/test_tempfiles.py
@@ -32,6 +32,19 @@ def test_purged():
     assert os.path.isfile(path1)
     assert os.path.isfile(path2)
 
+    tempfiles.purge()
+
+    assert not os.path.isfile(path1)
+    assert not os.path.isfile(path2)
+
+
+def test_garbage_collected():
+    tempfiles = _TempFiles()
+    path1 = tempfiles[b'hello']
+    path2 = tempfiles[b'world']
+    assert os.path.isfile(path1)
+    assert os.path.isfile(path2)
+
     del tempfiles
     gc.collect()
     gc.collect()


### PR DESCRIPTION
`aiohttp` v4 _would_ bring few changes incompatible with Kopf and _would_ break both the CI/CD pipelines and the Kopf-based operators. Some of these issues can be proactively fixed now. Others can be prevented by non-upgrading to v4.

> Issue : closes #246

## Description

The main incompatibility is that it is now impossible to inherit from `aiohttp.ClientSession` — explicitly restrictred in `aiohttp`. 

This PR converts our `APISession` from inheriting `aiohttp.ClientSession` to containing  `aiohttp.ClientSession` (i.e. a composition instead of inheritance). 

Since it is not a _session_ anymore, it is also renamed to a _context_ — the closest semantic equivalent I could find. Nevertheless, it is not part of the public interface, so we are free to change and rename it as needed.

_Beside of that, it also resolves the design flaw with few private/protected fields injected into the conceptually irrelevant 3rd-party session objects._

---

This PR, however, does NOT make Kopf fully compatible with `aiohttp` v4. Beside of the ClientSession, `aresponses` (used in tests) has some issues with the new `aiohttp`, and `aiohttp` v4 itself has incompatibilities with `async-timeout` v4.

It is not wise to dive that deep into the dependencies. Instead, we restrict `aiohttp` to major v3, and wait until v4 is released and stabilised (now, it is all in alpha).


## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
