### PR TITLE
documentation update: we can use names.singular as well in kubectl get

### DIFF
--- a/docs/walkthrough/resources.rst
+++ b/docs/walkthrough/resources.rst
@@ -80,6 +80,7 @@ Get a list of the existing objects of this kind with one of the commands:
 
     kubectl get EphemeralVolumeClaim
     kubectl get ephemeralvolumeclaims
+    kubectl get ephemeralvolumeclaim
     kubectl get evcs
     kubectl get evc
 


### PR DESCRIPTION
documentation update to ensure that names.kind, names.plural, names.singular and names.shortNames can be used. names.singular was missing in the documentation

## What do these changes do?

No code changes, only a simple doc update to illustrate that a crd's names.singular field
also can be used in kubectl get 


## Description

<!-- What was the previous behaviour before the PR is merged? -->

<!-- What will be the new behaviour after the PR is merged? -->
No behaviour change

<!-- A code snippet showing the new features added (if any)? -->

<!-- Does the change affect the end users or is it internal? -->
yes only the doc portion

<!-- Why have you decided to solve the problem this way? What were the trade-offs? (If appropriate.) -->

<!-- Are there any breaking or risky changes? -->
None


## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

> Issues: #12 

> Related:


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Mostly documentation and examples (no code changes)


## Checklist

- [ ] The code addresses only the mentioned problem, and this problem only
- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
