### PR TITLE
Rebalance the modules to reduce complexity

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -30,6 +30,9 @@ from kopf.on import (
 from kopf.reactor import (
     lifecycles,  # as a separate name on the public namespace
 )
+from kopf.reactor.errors import (
+    ErrorsMode,
+)
 from kopf.reactor.handling import (
     TemporaryError,
     PermanentError,
@@ -42,7 +45,6 @@ from kopf.reactor.lifecycles import (
     set_default_lifecycle,
 )
 from kopf.reactor.registries import (
-    ErrorsMode,
     ActivityRegistry,
     ResourceRegistry,
     ResourceWatchingRegistry,

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -200,7 +200,7 @@ async def apply_peers(
     await patching.patch_obj(resource=resource, namespace=namespace, name=name, patch=patch)
 
 
-async def peers_handler(
+async def process_peering_event(
         *,
         event: bodies.Event,
         freeze_mode: primitives.Toggle,

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -50,7 +50,7 @@ async def health_reporter(
                 now = datetime.datetime.utcnow()
                 if probing_timestamp is None or now - probing_timestamp >= probing_max_age:
 
-                    activity_results = await handling.activity_trigger(
+                    activity_results = await handling.run_activity(
                         lifecycle=lifecycles.all_at_once,
                         registry=registry,
                         activity=causation.Activity.PROBE,

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -6,8 +6,8 @@ from typing import Optional, Tuple, MutableMapping
 
 import aiohttp.web
 
+from kopf.reactor import activities
 from kopf.reactor import causation
-from kopf.reactor import handling
 from kopf.reactor import lifecycles
 from kopf.reactor import registries
 
@@ -50,7 +50,7 @@ async def health_reporter(
                 now = datetime.datetime.utcnow()
                 if probing_timestamp is None or now - probing_timestamp >= probing_max_age:
 
-                    activity_results = await handling.run_activity(
+                    activity_results = await activities.run_activity(
                         lifecycle=lifecycles.all_at_once,
                         registry=registry,
                         activity=causation.Activity.PROBE,

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple, MutableMapping
 import aiohttp.web
 
 from kopf.reactor import activities
+from kopf.reactor import callbacks
 from kopf.reactor import causation
 from kopf.reactor import lifecycles
 from kopf.reactor import registries
@@ -32,7 +33,7 @@ async def health_reporter(
     is cancelled or failed). Once it will stop responding for any reason,
     Kubernetes will assume the pod is not alive anymore, and will restart it.
     """
-    probing_container: MutableMapping[registries.HandlerId, registries.HandlerResult] = {}
+    probing_container: MutableMapping[registries.HandlerId, callbacks.HandlerResult] = {}
     probing_timestamp: Optional[datetime.datetime] = None
     probing_max_age = datetime.timedelta(seconds=10.0)
     probing_lock = asyncio.Lock()

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -9,6 +9,7 @@ import aiohttp.web
 from kopf.reactor import activities
 from kopf.reactor import callbacks
 from kopf.reactor import causation
+from kopf.reactor import handlers
 from kopf.reactor import lifecycles
 from kopf.reactor import registries
 
@@ -33,7 +34,7 @@ async def health_reporter(
     is cancelled or failed). Once it will stop responding for any reason,
     Kubernetes will assume the pod is not alive anymore, and will restart it.
     """
-    probing_container: MutableMapping[registries.HandlerId, callbacks.HandlerResult] = {}
+    probing_container: MutableMapping[handlers.HandlerId, callbacks.HandlerResult] = {}
     probing_timestamp: Optional[datetime.datetime] = None
     probing_max_age = datetime.timedelta(seconds=10.0)
     probing_lock = asyncio.Lock()

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -14,13 +14,14 @@ This module is a part of the framework's public interface.
 
 from typing import Optional, Callable, Union, Tuple, List
 
+from kopf.reactor import callbacks
 from kopf.reactor import causation
 from kopf.reactor import handling
 from kopf.reactor import registries
 from kopf.structs import bodies
 
-ResourceHandlerDecorator = Callable[[registries.ResourceHandlerFn], registries.ResourceHandlerFn]
-ActivityHandlerDecorator = Callable[[registries.ActivityHandlerFn], registries.ActivityHandlerFn]
+ResourceHandlerDecorator = Callable[[callbacks.ResourceHandlerFn], callbacks.ResourceHandlerFn]
+ActivityHandlerDecorator = Callable[[callbacks.ActivityHandlerFn], callbacks.ActivityHandlerFn]
 
 
 def startup(
@@ -34,7 +35,7 @@ def startup(
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityHandlerDecorator:
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
+    def decorator(fn: callbacks.ActivityHandlerFn) -> callbacks.ActivityHandlerFn:
         return actual_registry.register_activity_handler(
             fn=fn, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
@@ -54,7 +55,7 @@ def cleanup(
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityHandlerDecorator:
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
+    def decorator(fn: callbacks.ActivityHandlerFn) -> callbacks.ActivityHandlerFn:
         return actual_registry.register_activity_handler(
             fn=fn, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
@@ -75,7 +76,7 @@ def login(
 ) -> ActivityHandlerDecorator:
     """ ``@kopf.on.login()`` handler for custom (re-)authentication. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
+    def decorator(fn: callbacks.ActivityHandlerFn) -> callbacks.ActivityHandlerFn:
         return actual_registry.register_activity_handler(
             fn=fn, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
@@ -96,7 +97,7 @@ def probe(
 ) -> ActivityHandlerDecorator:
     """ ``@kopf.on.probe()`` handler for arbitrary liveness metrics. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ActivityHandlerFn) -> registries.ActivityHandlerFn:
+    def decorator(fn: callbacks.ActivityHandlerFn) -> callbacks.ActivityHandlerFn:
         return actual_registry.register_activity_handler(
             fn=fn, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
@@ -118,11 +119,11 @@ def resume(
         deleted: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-        when: Optional[registries.WhenHandlerFn] = None,
+        when: Optional[callbacks.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, initial=True, deleted=deleted, id=id,
@@ -144,11 +145,11 @@ def create(
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-        when: Optional[registries.WhenHandlerFn] = None,
+        when: Optional[callbacks.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.create()`` handler for the object creation. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.CREATE, id=id,
@@ -170,11 +171,11 @@ def update(
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-        when: Optional[registries.WhenHandlerFn] = None,
+        when: Optional[callbacks.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.update()`` handler for the object update or change. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.UPDATE, id=id,
@@ -197,11 +198,11 @@ def delete(
         optional: Optional[bool] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-        when: Optional[registries.WhenHandlerFn] = None,
+        when: Optional[callbacks.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=causation.Reason.DELETE, id=id,
@@ -225,11 +226,11 @@ def field(
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-        when: Optional[registries.WhenHandlerFn] = None,
+        when: Optional[callbacks.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
         return actual_registry.register_resource_changing_handler(
             group=group, version=version, plural=plural,
             reason=None, field=field, id=id,
@@ -246,11 +247,11 @@ def event(
         registry: Optional[registries.OperatorRegistry] = None,
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
-        when: Optional[registries.WhenHandlerFn] = None,
+        when: Optional[callbacks.WhenHandlerFn] = None,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     actual_registry = registry if registry is not None else registries.get_default_registry()
-    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
         return actual_registry.register_resource_watching_handler(
             group=group, version=version, plural=plural,
             id=id, fn=fn, labels=labels, annotations=annotations, when=when,
@@ -300,7 +301,7 @@ def this(
     create function will have its own value, not the latest in the for-cycle.
     """
     actual_registry = registry if registry is not None else handling.subregistry_var.get()
-    def decorator(fn: registries.ResourceHandlerFn) -> registries.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
         return actual_registry.register(
             id=id, fn=fn,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
@@ -309,7 +310,7 @@ def this(
 
 
 def register(
-        fn: registries.ResourceHandlerFn,
+        fn: callbacks.ResourceHandlerFn,
         *,
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,
@@ -318,7 +319,7 @@ def register(
         backoff: Optional[float] = None,
         cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.ResourceChangingRegistry] = None,
-) -> registries.ResourceHandlerFn:
+) -> callbacks.ResourceHandlerFn:
     """
     Register a function as a sub-handler of the currently executed handler.
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -16,6 +16,7 @@ from typing import Optional, Callable
 
 from kopf.reactor import callbacks
 from kopf.reactor import causation
+from kopf.reactor import errors as errors_
 from kopf.reactor import handling
 from kopf.reactor import registries
 from kopf.structs import bodies
@@ -28,7 +29,7 @@ ActivityHandlerDecorator = Callable[[callbacks.ActivityHandlerFn], callbacks.Act
 def startup(
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -48,7 +49,7 @@ def startup(
 def cleanup(
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -68,7 +69,7 @@ def cleanup(
 def login(
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -89,7 +90,7 @@ def login(
 def probe(
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -111,7 +112,7 @@ def resume(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -138,7 +139,7 @@ def create(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -164,7 +165,7 @@ def update(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -190,7 +191,7 @@ def delete(
         group: str, version: str, plural: str,
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -219,7 +220,7 @@ def field(
         field: dicts.FieldSpec,
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -265,7 +266,7 @@ def event(
 def this(
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -314,7 +315,7 @@ def register(
         fn: callbacks.ResourceHandlerFn,
         *,
         id: Optional[str] = None,
-        errors: Optional[registries.ErrorsMode] = None,
+        errors: Optional[errors_.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -12,13 +12,14 @@ This module is a part of the framework's public interface.
 
 # TODO: add cluster=True support (different API methods)
 
-from typing import Optional, Callable, Union, Tuple, List
+from typing import Optional, Callable
 
 from kopf.reactor import callbacks
 from kopf.reactor import causation
 from kopf.reactor import handling
 from kopf.reactor import registries
 from kopf.structs import bodies
+from kopf.structs import dicts
 
 ResourceHandlerDecorator = Callable[[callbacks.ResourceHandlerFn], callbacks.ResourceHandlerFn]
 ActivityHandlerDecorator = Callable[[callbacks.ActivityHandlerFn], callbacks.ActivityHandlerFn]
@@ -215,7 +216,7 @@ def delete(
 
 def field(
         group: str, version: str, plural: str,
-        field: Union[str, List[str], Tuple[str, ...]],
+        field: dicts.FieldSpec,
         *,
         id: Optional[str] = None,
         errors: Optional[registries.ErrorsMode] = None,

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -17,15 +17,29 @@ The process is intentionally split into multiple packages:
   belong to neither the reactor, nor the engines, nor the client wrappers.
 """
 import logging
-from typing import NoReturn
+from typing import NoReturn, Mapping
 
 from kopf.reactor import causation
 from kopf.reactor import handling
 from kopf.reactor import lifecycles
 from kopf.reactor import registries
+from kopf.reactor import states
 from kopf.structs import credentials
 
 logger = logging.getLogger(__name__)
+
+
+class ActivityError(Exception):
+    """ An error in the activity, as caused by mandatory handlers' failures. """
+
+    def __init__(
+            self,
+            msg: str,
+            *,
+            outcomes: Mapping[registries.HandlerId, states.HandlerOutcome],
+    ) -> None:
+        super().__init__(msg)
+        self.outcomes = outcomes
 
 
 async def authenticator(
@@ -58,7 +72,7 @@ async def authenticate(
     # Log initial and re-authentications differently, for readability.
     logger.info(f"{_activity_title} has been initiated.")
 
-    activity_results = await handling.run_activity(
+    activity_results = await run_activity(
         lifecycle=lifecycles.all_at_once,
         registry=registry,
         activity=causation.Activity.AUTHENTICATION,
@@ -72,3 +86,37 @@ async def authenticate(
 
     # Feed the credentials into the vault, and unfreeze the re-authenticating clients.
     await vault.populate({str(handler_id): info for handler_id, info in activity_results.items()})
+
+
+async def run_activity(
+        *,
+        lifecycle: lifecycles.LifeCycleFn,
+        registry: registries.OperatorRegistry,
+        activity: causation.Activity,
+) -> Mapping[registries.HandlerId, registries.HandlerResult]:
+    logger = logging.getLogger(f'kopf.activities.{activity.value}')
+
+    # For the activity handlers, we have neither bodies, nor patches, just the state.
+    cause = causation.ActivityCause(logger=logger, activity=activity)
+    handlers = registry.get_activity_handlers(activity=activity)
+    outcomes = await handling.run_handlers_until_done(
+        cause=cause,
+        handlers=handlers,
+        lifecycle=lifecycle,
+    )
+
+    # Activities assume that all handlers must eventually succeed.
+    # We raise from the 1st exception only: just to have something real in the tracebacks.
+    # For multiple handlers' errors, the logs should be investigated instead.
+    exceptions = [outcome.exception
+                  for outcome in outcomes.values()
+                  if outcome.exception is not None]
+    if exceptions:
+        raise ActivityError("One or more handlers failed.", outcomes=outcomes) from exceptions[0]
+
+    # If nothing has failed, we return identifiable results. The outcomes/states are internal.
+    # The order of results is not guaranteed (the handlers can succeed on one of the retries).
+    results = {handler_id: outcome.result
+               for handler_id, outcome in outcomes.items()
+               if outcome.result is not None}
+    return results

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -21,6 +21,7 @@ from typing import NoReturn, Mapping
 
 from kopf.reactor import callbacks
 from kopf.reactor import causation
+from kopf.reactor import handlers
 from kopf.reactor import handling
 from kopf.reactor import lifecycles
 from kopf.reactor import registries
@@ -37,7 +38,7 @@ class ActivityError(Exception):
             self,
             msg: str,
             *,
-            outcomes: Mapping[registries.HandlerId, states.HandlerOutcome],
+            outcomes: Mapping[handlers.HandlerId, states.HandlerOutcome],
     ) -> None:
         super().__init__(msg)
         self.outcomes = outcomes
@@ -94,7 +95,7 @@ async def run_activity(
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.OperatorRegistry,
         activity: causation.Activity,
-) -> Mapping[registries.HandlerId, callbacks.HandlerResult]:
+) -> Mapping[handlers.HandlerId, callbacks.HandlerResult]:
     logger = logging.getLogger(f'kopf.activities.{activity.value}')
 
     # For the activity handlers, we have neither bodies, nor patches, just the state.

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -58,7 +58,7 @@ async def authenticate(
     # Log initial and re-authentications differently, for readability.
     logger.info(f"{_activity_title} has been initiated.")
 
-    activity_results = await handling.activity_trigger(
+    activity_results = await handling.run_activity(
         lifecycle=lifecycles.all_at_once,
         registry=registry,
         activity=causation.Activity.AUTHENTICATION,

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -19,6 +19,7 @@ The process is intentionally split into multiple packages:
 import logging
 from typing import NoReturn, Mapping
 
+from kopf.reactor import callbacks
 from kopf.reactor import causation
 from kopf.reactor import handling
 from kopf.reactor import lifecycles
@@ -93,7 +94,7 @@ async def run_activity(
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.OperatorRegistry,
         activity: causation.Activity,
-) -> Mapping[registries.HandlerId, registries.HandlerResult]:
+) -> Mapping[registries.HandlerId, callbacks.HandlerResult]:
     logger = logging.getLogger(f'kopf.activities.{activity.value}')
 
     # For the activity handlers, we have neither bodies, nor patches, just the state.

--- a/kopf/reactor/callbacks.py
+++ b/kopf/reactor/callbacks.py
@@ -1,0 +1,71 @@
+"""
+Callback signatures for typing.
+
+Since these signatures contain a lot of copy-pasted kwargs and are
+not so important for the codebase, they are moved to this separate module.
+"""
+import logging
+from typing import NewType, Any, Union, Optional
+
+from typing_extensions import Protocol
+
+from kopf.structs import bodies
+from kopf.structs import diffs
+from kopf.structs import patches
+
+# A specialised type to highlight the purpose or origin of the data of type Any,
+# to not be mixed with other arbitrary Any values, where it is indeed "any".
+HandlerResult = NewType('HandlerResult', object)
+
+
+class ActivityHandlerFn(Protocol):
+    def __call__(
+            self,
+            *args: Any,
+            logger: Union[logging.Logger, logging.LoggerAdapter],
+            **kwargs: Any,
+    ) -> Optional[HandlerResult]: ...
+
+
+class ResourceHandlerFn(Protocol):
+    def __call__(
+            self,
+            *args: Any,
+            type: str,
+            event: Union[str, bodies.Event],
+            body: bodies.Body,
+            meta: bodies.Meta,
+            spec: bodies.Spec,
+            status: bodies.Status,
+            uid: str,
+            name: str,
+            namespace: Optional[str],
+            patch: patches.Patch,
+            logger: Union[logging.Logger, logging.LoggerAdapter],
+            diff: diffs.Diff,
+            old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
+            new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
+            **kwargs: Any,
+    ) -> Optional[HandlerResult]: ...
+
+
+class WhenHandlerFn(Protocol):
+    def __call__(
+            self,
+            *args: Any,
+            type: str,
+            event: Union[str, bodies.Event],
+            body: bodies.Body,
+            meta: bodies.Meta,
+            spec: bodies.Spec,
+            status: bodies.Status,
+            uid: str,
+            name: str,
+            namespace: Optional[str],
+            patch: patches.Patch,
+            logger: Union[logging.Logger, logging.LoggerAdapter],
+            diff: diffs.Diff,
+            old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
+            new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
+            **kwargs: Any,
+    ) -> bool: ...

--- a/kopf/reactor/errors.py
+++ b/kopf/reactor/errors.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class ErrorsMode(enum.Enum):
+    """ How arbitrary (non-temporary/non-permanent) exceptions are treated. """
+    IGNORED = enum.auto()
+    TEMPORARY = enum.auto()
+    PERMANENT = enum.auto()

--- a/kopf/reactor/handlers.py
+++ b/kopf/reactor/handlers.py
@@ -1,0 +1,68 @@
+import dataclasses
+import warnings
+from typing import NewType, Callable, Optional, Any
+
+from kopf.reactor import callbacks
+from kopf.reactor import causation
+from kopf.reactor import errors as errors_
+from kopf.structs import bodies
+from kopf.structs import dicts
+
+# Strings are taken from the users, but then tainted as this type for stricter type-checking:
+# to prevent usage of some other strings (e.g. operator id) as the handlers ids.
+HandlerId = NewType('HandlerId', str)
+
+
+# A registered handler (function + meta info).
+# FIXME: Must be frozen, but mypy fails in _call_handler() with a cryptic error:
+# FIXME:    Argument 1 to "invoke" has incompatible type "Optional[HandlerResult]";
+# FIXME:    expected "Union[LifeCycleFn, ActivityHandlerFn, ResourceHandlerFn]"
+@dataclasses.dataclass
+class BaseHandler:
+    id: HandlerId
+    fn: Callable[..., Optional[callbacks.HandlerResult]]
+    errors: Optional[errors_.ErrorsMode]
+    timeout: Optional[float]
+    retries: Optional[int]
+    backoff: Optional[float]
+    cooldown: dataclasses.InitVar[Optional[float]]  # deprecated, use `backoff`
+
+    def __post_init__(self, cooldown: Optional[float]) -> None:
+        if self.backoff is not None and cooldown is not None:
+            raise TypeError("Either backoff or cooldown can be set, not both.")
+        elif cooldown is not None:
+            warnings.warn("cooldown=... is deprecated, use backoff=...", DeprecationWarning)
+            self.backoff = cooldown
+
+    # @property cannot be used due to a data field definition with the same name.
+    def __getattribute__(self, name: str) -> Any:
+        if name == 'cooldown':
+            warnings.warn("handler.cooldown is deprecated, use handler.backoff", DeprecationWarning)
+            return self.backoff
+        else:
+            return super().__getattribute__(name)
+
+
+@dataclasses.dataclass
+class ActivityHandler(BaseHandler):
+    fn: callbacks.ActivityHandlerFn  # type clarification
+    activity: Optional[causation.Activity] = None
+    _fallback: bool = False  # non-public!
+
+
+@dataclasses.dataclass
+class ResourceHandler(BaseHandler):
+    fn: callbacks.ResourceHandlerFn  # type clarification
+    reason: Optional[causation.Reason]
+    field: Optional[dicts.FieldPath]
+    initial: Optional[bool] = None
+    deleted: Optional[bool] = None  # used for mixed-in (initial==True) @on.resume handlers only.
+    labels: Optional[bodies.Labels] = None
+    annotations: Optional[bodies.Annotations] = None
+    when: Optional[callbacks.WhenHandlerFn] = None
+    requires_finalizer: Optional[bool] = None
+
+    @property
+    def event(self) -> Optional[causation.Reason]:
+        warnings.warn("`handler.event` is deprecated; use `handler.reason`.", DeprecationWarning)
+        return self.reason

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -1,42 +1,27 @@
 """
-Conversion of low-level events to high-level causes, and handling them.
+Execution of pre-selected handlers, in batches or individually.
 
-These functions are invoked from the queueing module `kopf.reactor.queueing`,
-which are the actual event loop of the operator process.
+These functions are invoked from the queueing module `kopf.reactor.processing`,
+where the raw watch-events are interpreted and wrapped into extended *causes*.
 
-The conversion of the low-level events to the high-level causes is done by
-checking the object's state and comparing it to the preserved last-seen state.
-
-The framework itself makes the necessary changes to the object, -- such as the
-finalizers attachment, last-seen state updates, and handler status tracking, --
-thus provoking the low-level watch-events and additional queueing calls.
-But these internal changes are filtered out from the cause detection
-and therefore do not trigger the user-defined handlers.
+The handler execution can also be used in other places, such as in-memory
+activities, when there is no underlying Kubernetes object to patch'n'watch.
 """
 import asyncio
 import collections.abc
-import datetime
 import logging
 from contextvars import ContextVar
 from typing import Optional, Union, Iterable, Collection, Mapping, MutableMapping, Any
 
-from kopf.clients import patching
 from kopf.engines import logging as logging_engine
-from kopf.engines import posting
 from kopf.engines import sleeping
 from kopf.reactor import causation
 from kopf.reactor import invocation
 from kopf.reactor import lifecycles
 from kopf.reactor import registries
 from kopf.reactor import states
-from kopf.structs import bodies
-from kopf.structs import containers
 from kopf.structs import dicts
 from kopf.structs import diffs
-from kopf.structs import finalizers
-from kopf.structs import lastseen
-from kopf.structs import patches
-from kopf.structs import resources
 
 WAITING_KEEPALIVE_INTERVAL = 10 * 60
 """ How often to wake up from the long sleep, to show liveness in the logs. """
@@ -79,222 +64,6 @@ subregistry_var: ContextVar[registries.ResourceChangingRegistry] = ContextVar('s
 subexecuted_var: ContextVar[bool] = ContextVar('subexecuted_var')
 handler_var: ContextVar[registries.BaseHandler] = ContextVar('handler_var')
 cause_var: ContextVar[causation.BaseCause] = ContextVar('cause_var')
-
-
-async def process_resource_event(
-        lifecycle: lifecycles.LifeCycleFn,
-        registry: registries.OperatorRegistry,
-        memories: containers.ResourceMemories,
-        resource: resources.Resource,
-        event: bodies.Event,
-        replenished: asyncio.Event,
-        event_queue: posting.K8sEventQueue,
-) -> None:
-    """
-    Handle a single custom object low-level watch-event.
-
-    Convert the low-level events, as provided by the watching/queueing tasks,
-    to the high-level causes, and then call the cause-handling logic.
-
-    All the internally provoked changes are intercepted, do not create causes,
-    and therefore do not call the handling logic.
-    """
-    body: bodies.Body = event['object']
-    patch: patches.Patch = patches.Patch()
-    delay: Optional[float] = None
-
-    # Each object has its own prefixed logger, to distinguish parallel handling.
-    logger = logging_engine.ObjectLogger(body=body)
-    posting.event_queue_loop_var.set(asyncio.get_running_loop())
-    posting.event_queue_var.set(event_queue)  # till the end of this object's task.
-
-    # Recall what is stored about that object. Share it in little portions with the consumers.
-    # And immediately forget it if the object is deleted from the cluster (but keep in memory).
-    memory = await memories.recall(body, noticed_by_listing=event['type'] is None)
-    if event['type'] == 'DELETED':
-        await memories.forget(body)
-
-    # Invoke all silent spies. No causation, no progress storage is performed.
-    if registry.has_resource_watching_handlers(resource=resource):
-        resource_watching_cause = causation.detect_resource_watching_cause(
-            event=event,
-            resource=resource,
-            logger=logger,
-            patch=patch,
-            memo=memory.user_data,
-        )
-        await process_resource_watching_cause(
-            lifecycle=lifecycles.all_at_once,
-            registry=registry,
-            memory=memory,
-            cause=resource_watching_cause,
-        )
-
-    # Object patch accumulator. Populated by the methods. Applied in the end of the handler.
-    # Detect the cause and handle it (or at least log this happened).
-    if registry.has_resource_changing_handlers(resource=resource):
-        extra_fields = registry.get_extra_fields(resource=resource)
-        old, new, diff = lastseen.get_essential_diffs(body=body, extra_fields=extra_fields)
-        resource_changing_cause = causation.detect_resource_changing_cause(
-            event=event,
-            resource=resource,
-            logger=logger,
-            patch=patch,
-            old=old,
-            new=new,
-            diff=diff,
-            memo=memory.user_data,
-            initial=memory.noticed_by_listing and not memory.fully_handled_once,
-        )
-        delay = await process_resource_changing_cause(
-            lifecycle=lifecycle,
-            registry=registry,
-            memory=memory,
-            cause=resource_changing_cause,
-        )
-
-    # Whatever was done, apply the accumulated changes to the object.
-    # But only once, to reduce the number of API calls and the generated irrelevant events.
-    if patch:
-        logger.debug("Patching with: %r", patch)
-        await patching.patch_obj(resource=resource, patch=patch, body=body)
-
-    # Sleep strictly after patching, never before -- to keep the status proper.
-    # The patching above, if done, interrupts the sleep instantly, so we skip it at all.
-    # Note: a zero-second or negative sleep is still a sleep, it will trigger a dummy patch.
-    if delay and patch:
-        logger.debug(f"Sleeping was skipped because of the patch, {delay} seconds left.")
-    elif delay is None and not patch:
-        logger.debug(f"Handling cycle is finished, waiting for new changes since now.")
-    elif delay is not None:
-        if delay > 0:
-            logger.debug(f"Sleeping for {delay} seconds for the delayed handlers.")
-            limited_delay = min(delay, WAITING_KEEPALIVE_INTERVAL)
-            unslept_delay = await sleeping.sleep_or_wait(limited_delay, replenished)
-        else:
-            unslept_delay = None  # no need to sleep? means: slept in full.
-
-        if unslept_delay is not None:
-            logger.debug(f"Sleeping was interrupted by new changes, {unslept_delay} seconds left.")
-        else:
-            # Any unique always-changing value will work; not necessary a timestamp.
-            dummy_value = datetime.datetime.utcnow().isoformat()
-            dummy_patch = patches.Patch({'status': {'kopf': {'dummy': dummy_value}}})
-            logger.debug("Provoking reaction with: %r", dummy_patch)
-            await patching.patch_obj(resource=resource, patch=dummy_patch, body=body)
-
-
-async def process_resource_watching_cause(
-        lifecycle: lifecycles.LifeCycleFn,
-        registry: registries.OperatorRegistry,
-        memory: containers.ResourceMemory,
-        cause: causation.ResourceWatchingCause,
-) -> None:
-    """
-    Handle a received event, log but ignore all errors.
-
-    This is a lightweight version of the cause handling, but for the raw events,
-    without any progress persistence. Multi-step calls are also not supported.
-    If the handler fails, it fails and is never retried.
-
-    Note: K8s-event posting is skipped for `kopf.on.event` handlers,
-    as they should be silent. Still, the messages are logged normally.
-    """
-    handlers = registry.get_resource_watching_handlers(cause=cause)
-    outcomes = await execute_handlers_once(
-        lifecycle=lifecycle,
-        handlers=handlers,
-        cause=cause,
-        state=states.State.from_scratch(handlers=handlers),
-        default_errors=registries.ErrorsMode.IGNORED,
-    )
-
-    # Store the results, but not the handlers' progress.
-    states.deliver_results(outcomes=outcomes, patch=cause.patch)
-
-
-async def process_resource_changing_cause(
-        lifecycle: lifecycles.LifeCycleFn,
-        registry: registries.OperatorRegistry,
-        memory: containers.ResourceMemory,
-        cause: causation.ResourceChangingCause,
-) -> Optional[float]:
-    """
-    Handle a detected cause, as part of the bigger handler routine.
-    """
-    logger = cause.logger
-    patch = cause.patch  # TODO get rid of this alias
-    body = cause.body  # TODO get rid of this alias
-    delay = None
-    done = None
-    skip = None
-
-    requires_finalizer = registry.requires_finalizer(resource=cause.resource, cause=cause)
-    has_finalizer = finalizers.has_finalizers(body=cause.body)
-
-    if requires_finalizer and not has_finalizer:
-        logger.debug("Adding the finalizer, thus preventing the actual deletion.")
-        finalizers.append_finalizers(body=body, patch=patch)
-        return None
-
-    if not requires_finalizer and has_finalizer:
-        logger.debug("Removing the finalizer, as there are no handlers requiring it.")
-        finalizers.remove_finalizers(body=body, patch=patch)
-        return None
-
-    # Regular causes invoke the handlers.
-    if cause.reason in causation.HANDLER_REASONS:
-        title = causation.TITLES.get(cause.reason, repr(cause.reason))
-        logger.debug(f"{title.capitalize()} event: %r", body)
-        if cause.diff and cause.old is not None and cause.new is not None:
-            logger.debug(f"{title.capitalize()} diff: %r", cause.diff)
-
-        handlers = registry.get_resource_changing_handlers(cause=cause)
-        state = states.State.from_body(body=cause.body, handlers=handlers)
-        if handlers:
-            outcomes = await execute_handlers_once(
-                lifecycle=lifecycle,
-                handlers=handlers,
-                cause=cause,
-                state=state,
-            )
-            state = state.with_outcomes(outcomes)
-            state.store(patch=cause.patch)
-            states.deliver_results(outcomes=outcomes, patch=cause.patch)
-
-            if state.done:
-                logger.info(f"All handlers succeeded for {title}.")
-                state.purge(patch=cause.patch, body=cause.body)
-
-            done = state.done
-            delay = state.delay
-        else:
-            skip = True
-
-    # Regular causes also do some implicit post-handling when all handlers are done.
-    if done or skip:
-        extra_fields = registry.get_extra_fields(resource=cause.resource)
-        lastseen.refresh_essence(body=body, patch=patch, extra_fields=extra_fields)
-        if cause.reason == causation.Reason.DELETE:
-            logger.debug("Removing the finalizer, thus allowing the actual deletion.")
-            finalizers.remove_finalizers(body=body, patch=patch)
-
-        # Once all handlers have succeeded at least once for any reason, or if there were none,
-        # prevent further resume-handlers (which otherwise happens on each watch-stream re-listing).
-        memory.fully_handled_once = True
-
-    # Informational causes just print the log lines.
-    if cause.reason == causation.Reason.GONE:
-        logger.debug("Deleted, really deleted, and we are notified.")
-
-    if cause.reason == causation.Reason.FREE:
-        logger.debug("Deletion event, but we are done with it, and we do not care.")
-
-    if cause.reason == causation.Reason.NOOP:
-        logger.debug("Something has changed, but we are not interested (the essence is the same).")
-
-    # The delay is then consumed by the main handling routine (in different ways).
-    return delay
 
 
 async def execute(

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -95,7 +95,7 @@ handler_var: ContextVar[registries.BaseHandler] = ContextVar('handler_var')
 cause_var: ContextVar[causation.BaseCause] = ContextVar('cause_var')
 
 
-async def activity_trigger(
+async def run_activity(
         *,
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.OperatorRegistry,

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -15,6 +15,7 @@ from typing import Optional, Union, Iterable, Collection, Mapping, MutableMappin
 
 from kopf.engines import logging as logging_engine
 from kopf.engines import sleeping
+from kopf.reactor import callbacks
 from kopf.reactor import causation
 from kopf.reactor import invocation
 from kopf.reactor import lifecycles
@@ -320,7 +321,7 @@ async def invoke_handler(
         cause: causation.BaseCause,
         lifecycle: lifecycles.LifeCycleFn,
         **kwargs: Any,
-) -> Optional[registries.HandlerResult]:
+) -> Optional[callbacks.HandlerResult]:
     """
     Invoke one handler only, according to the calling conventions.
 
@@ -364,4 +365,4 @@ async def invoke_handler(
             await execute()
 
         # Since we know that we invoked the handler, we cast "any" result to a handler result.
-        return registries.HandlerResult(result)
+        return callbacks.HandlerResult(result)

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -520,7 +520,7 @@ async def _execute_handler(
         if handler.retries is not None and state.retries >= handler.retries:
             raise HandlerRetriesError(f"Handler {handler.id!r} has exceeded {state.retries} retries.")
 
-        result = await _call_handler(
+        result = await invoke_handler(
             handler,
             cause=cause,
             retry=state.retries,
@@ -572,7 +572,7 @@ async def _execute_handler(
         return states.HandlerOutcome(final=True, result=result)
 
 
-async def _call_handler(
+async def invoke_handler(
         handler: registries.BaseHandler,
         *args: Any,
         cause: causation.BaseCause,

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -144,7 +144,7 @@ async def activity_trigger(
     return results
 
 
-async def resource_handler(
+async def process_resource_event(
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.OperatorRegistry,
         memories: containers.ResourceMemories,
@@ -186,7 +186,7 @@ async def resource_handler(
             patch=patch,
             memo=memory.user_data,
         )
-        await handle_resource_watching_cause(
+        await process_resource_watching_cause(
             lifecycle=lifecycles.all_at_once,
             registry=registry,
             memory=memory,
@@ -209,7 +209,7 @@ async def resource_handler(
             memo=memory.user_data,
             initial=memory.noticed_by_listing and not memory.fully_handled_once,
         )
-        delay = await handle_resource_changing_cause(
+        delay = await process_resource_changing_cause(
             lifecycle=lifecycle,
             registry=registry,
             memory=memory,
@@ -247,7 +247,7 @@ async def resource_handler(
             await patching.patch_obj(resource=resource, patch=dummy_patch, body=body)
 
 
-async def handle_resource_watching_cause(
+async def process_resource_watching_cause(
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.OperatorRegistry,
         memory: containers.ResourceMemory,
@@ -276,7 +276,7 @@ async def handle_resource_watching_cause(
     states.deliver_results(outcomes=outcomes, patch=cause.patch)
 
 
-async def handle_resource_changing_cause(
+async def process_resource_changing_cause(
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.OperatorRegistry,
         memory: containers.ResourceMemory,

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -12,15 +12,15 @@ import functools
 from typing import Optional, Any, Union, List, Iterable, Iterator, Tuple, Dict
 
 from kopf import config
+from kopf.reactor import callbacks
 from kopf.reactor import causation
 from kopf.reactor import lifecycles
-from kopf.reactor import registries
 from kopf.structs import dicts
 
 Invokable = Union[
     lifecycles.LifeCycleFn,
-    registries.ActivityHandlerFn,
-    registries.ResourceHandlerFn,
+    callbacks.ActivityHandlerFn,
+    callbacks.ResourceHandlerFn,
 ]
 
 

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -14,12 +14,12 @@ from typing import Sequence, Any, Optional
 
 from typing_extensions import Protocol
 
-from kopf.reactor import registries
+from kopf.reactor import handlers as handlers_
 from kopf.reactor import states
 
 logger = logging.getLogger(__name__)
 
-Handlers = Sequence[registries.BaseHandler]
+Handlers = Sequence[handlers_.BaseHandler]
 
 
 class LifeCycleFn(Protocol):
@@ -62,7 +62,7 @@ def shuffled(handlers: Handlers, **kwargs: Any) -> Handlers:
 def asap(handlers: Handlers, *, state: states.State, **kwargs: Any) -> Handlers:
     """ Execute one handler at a time, skip on failure, try the next one, retry after the full cycle. """
 
-    def keyfn(handler: registries.BaseHandler) -> int:
+    def keyfn(handler: handlers_.BaseHandler) -> int:
         return state[handler.id].retries or 0
 
     return sorted(handlers, key=keyfn)[:1]

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -1,0 +1,250 @@
+"""
+Conversion of low-level events to high-level causes, and handling them.
+
+These functions are invoked from the queueing module `kopf.reactor.queueing`,
+which are the actual event loop of the operator process.
+
+The conversion of the low-level events to the high-level causes is done by
+checking the object's state and comparing it to the preserved last-seen state.
+
+The framework itself makes the necessary changes to the object, -- such as the
+finalizers attachment, last-seen state updates, and handler status tracking, --
+thus provoking the low-level watch-events and additional queueing calls.
+But these internal changes are filtered out from the cause detection
+and therefore do not trigger the user-defined handlers.
+"""
+import asyncio
+import datetime
+from typing import Optional
+
+from kopf.clients import patching
+from kopf.engines import logging as logging_engine
+from kopf.engines import posting
+from kopf.engines import sleeping
+from kopf.reactor import causation
+from kopf.reactor import handling
+from kopf.reactor import lifecycles
+from kopf.reactor import registries
+from kopf.reactor import states
+from kopf.structs import bodies
+from kopf.structs import containers
+from kopf.structs import finalizers
+from kopf.structs import lastseen
+from kopf.structs import patches
+from kopf.structs import resources
+
+
+async def process_resource_event(
+        lifecycle: lifecycles.LifeCycleFn,
+        registry: registries.OperatorRegistry,
+        memories: containers.ResourceMemories,
+        resource: resources.Resource,
+        event: bodies.Event,
+        replenished: asyncio.Event,
+        event_queue: posting.K8sEventQueue,
+) -> None:
+    """
+    Handle a single custom object low-level watch-event.
+
+    Convert the low-level events, as provided by the watching/queueing tasks,
+    to the high-level causes, and then call the cause-handling logic.
+
+    All the internally provoked changes are intercepted, do not create causes,
+    and therefore do not call the handling logic.
+    """
+    body: bodies.Body = event['object']
+    patch: patches.Patch = patches.Patch()
+    delay: Optional[float] = None
+
+    # Each object has its own prefixed logger, to distinguish parallel handling.
+    logger = logging_engine.ObjectLogger(body=body)
+    posting.event_queue_loop_var.set(asyncio.get_running_loop())
+    posting.event_queue_var.set(event_queue)  # till the end of this object's task.
+
+    # Recall what is stored about that object. Share it in little portions with the consumers.
+    # And immediately forget it if the object is deleted from the cluster (but keep in memory).
+    memory = await memories.recall(body, noticed_by_listing=event['type'] is None)
+    if event['type'] == 'DELETED':
+        await memories.forget(body)
+
+    # Invoke all silent spies. No causation, no progress storage is performed.
+    if registry.has_resource_watching_handlers(resource=resource):
+        resource_watching_cause = causation.detect_resource_watching_cause(
+            event=event,
+            resource=resource,
+            logger=logger,
+            patch=patch,
+            memo=memory.user_data,
+        )
+        await process_resource_watching_cause(
+            lifecycle=lifecycles.all_at_once,
+            registry=registry,
+            memory=memory,
+            cause=resource_watching_cause,
+        )
+
+    # Object patch accumulator. Populated by the methods. Applied in the end of the handler.
+    # Detect the cause and handle it (or at least log this happened).
+    if registry.has_resource_changing_handlers(resource=resource):
+        extra_fields = registry.get_extra_fields(resource=resource)
+        old, new, diff = lastseen.get_essential_diffs(body=body, extra_fields=extra_fields)
+        resource_changing_cause = causation.detect_resource_changing_cause(
+            event=event,
+            resource=resource,
+            logger=logger,
+            patch=patch,
+            old=old,
+            new=new,
+            diff=diff,
+            memo=memory.user_data,
+            initial=memory.noticed_by_listing and not memory.fully_handled_once,
+        )
+        delay = await process_resource_changing_cause(
+            lifecycle=lifecycle,
+            registry=registry,
+            memory=memory,
+            cause=resource_changing_cause,
+        )
+
+    # Whatever was done, apply the accumulated changes to the object.
+    # But only once, to reduce the number of API calls and the generated irrelevant events.
+    if patch:
+        logger.debug("Patching with: %r", patch)
+        await patching.patch_obj(resource=resource, patch=patch, body=body)
+
+    # Sleep strictly after patching, never before -- to keep the status proper.
+    # The patching above, if done, interrupts the sleep instantly, so we skip it at all.
+    # Note: a zero-second or negative sleep is still a sleep, it will trigger a dummy patch.
+    if delay and patch:
+        logger.debug(f"Sleeping was skipped because of the patch, {delay} seconds left.")
+    elif delay is None and not patch:
+        logger.debug(f"Handling cycle is finished, waiting for new changes since now.")
+    elif delay is not None:
+        if delay > 0:
+            logger.debug(f"Sleeping for {delay} seconds for the delayed handlers.")
+            limited_delay = min(delay, handling.WAITING_KEEPALIVE_INTERVAL)
+            unslept_delay = await sleeping.sleep_or_wait(limited_delay, replenished)
+        else:
+            unslept_delay = None  # no need to sleep? means: slept in full.
+
+        if unslept_delay is not None:
+            logger.debug(f"Sleeping was interrupted by new changes, {unslept_delay} seconds left.")
+        else:
+            # Any unique always-changing value will work; not necessary a timestamp.
+            dummy_value = datetime.datetime.utcnow().isoformat()
+            dummy_patch = patches.Patch({'status': {'kopf': {'dummy': dummy_value}}})
+            logger.debug("Provoking reaction with: %r", dummy_patch)
+            await patching.patch_obj(resource=resource, patch=dummy_patch, body=body)
+
+
+async def process_resource_watching_cause(
+        lifecycle: lifecycles.LifeCycleFn,
+        registry: registries.OperatorRegistry,
+        memory: containers.ResourceMemory,
+        cause: causation.ResourceWatchingCause,
+) -> None:
+    """
+    Handle a received event, log but ignore all errors.
+
+    This is a lightweight version of the cause handling, but for the raw events,
+    without any progress persistence. Multi-step calls are also not supported.
+    If the handler fails, it fails and is never retried.
+
+    Note: K8s-event posting is skipped for `kopf.on.event` handlers,
+    as they should be silent. Still, the messages are logged normally.
+    """
+    handlers = registry.get_resource_watching_handlers(cause=cause)
+    outcomes = await handling.execute_handlers_once(
+        lifecycle=lifecycle,
+        handlers=handlers,
+        cause=cause,
+        state=states.State.from_scratch(handlers=handlers),
+        default_errors=registries.ErrorsMode.IGNORED,
+    )
+
+    # Store the results, but not the handlers' progress.
+    states.deliver_results(outcomes=outcomes, patch=cause.patch)
+
+
+async def process_resource_changing_cause(
+        lifecycle: lifecycles.LifeCycleFn,
+        registry: registries.OperatorRegistry,
+        memory: containers.ResourceMemory,
+        cause: causation.ResourceChangingCause,
+) -> Optional[float]:
+    """
+    Handle a detected cause, as part of the bigger handler routine.
+    """
+    logger = cause.logger
+    patch = cause.patch  # TODO get rid of this alias
+    body = cause.body  # TODO get rid of this alias
+    delay = None
+    done = None
+    skip = None
+
+    requires_finalizer = registry.requires_finalizer(resource=cause.resource, cause=cause)
+    has_finalizer = finalizers.has_finalizers(body=cause.body)
+
+    if requires_finalizer and not has_finalizer:
+        logger.debug("Adding the finalizer, thus preventing the actual deletion.")
+        finalizers.append_finalizers(body=body, patch=patch)
+        return None
+
+    if not requires_finalizer and has_finalizer:
+        logger.debug("Removing the finalizer, as there are no handlers requiring it.")
+        finalizers.remove_finalizers(body=body, patch=patch)
+        return None
+
+    # Regular causes invoke the handlers.
+    if cause.reason in causation.HANDLER_REASONS:
+        title = causation.TITLES.get(cause.reason, repr(cause.reason))
+        logger.debug(f"{title.capitalize()} event: %r", body)
+        if cause.diff and cause.old is not None and cause.new is not None:
+            logger.debug(f"{title.capitalize()} diff: %r", cause.diff)
+
+        handlers = registry.get_resource_changing_handlers(cause=cause)
+        state = states.State.from_body(body=cause.body, handlers=handlers)
+        if handlers:
+            outcomes = await handling.execute_handlers_once(
+                lifecycle=lifecycle,
+                handlers=handlers,
+                cause=cause,
+                state=state,
+            )
+            state = state.with_outcomes(outcomes)
+            state.store(patch=cause.patch)
+            states.deliver_results(outcomes=outcomes, patch=cause.patch)
+
+            if state.done:
+                logger.info(f"All handlers succeeded for {title}.")
+                state.purge(patch=cause.patch, body=cause.body)
+
+            done = state.done
+            delay = state.delay
+        else:
+            skip = True
+
+    # Regular causes also do some implicit post-handling when all handlers are done.
+    if done or skip:
+        extra_fields = registry.get_extra_fields(resource=cause.resource)
+        lastseen.refresh_essence(body=body, patch=patch, extra_fields=extra_fields)
+        if cause.reason == causation.Reason.DELETE:
+            logger.debug("Removing the finalizer, thus allowing the actual deletion.")
+            finalizers.remove_finalizers(body=body, patch=patch)
+
+        # Once all handlers have succeeded at least once for any reason, or if there were none,
+        # prevent further resume-handlers (which otherwise happens on each watch-stream re-listing).
+        memory.fully_handled_once = True
+
+    # Informational causes just print the log lines.
+    if cause.reason == causation.Reason.GONE:
+        logger.debug("Deleted, really deleted, and we are notified.")
+
+    if cause.reason == causation.Reason.FREE:
+        logger.debug("Deletion event, but we are done with it, and we do not care.")
+
+    if cause.reason == causation.Reason.NOOP:
+        logger.debug("Something has changed, but we are not interested (the essence is the same).")
+
+    # The delay is then consumed by the main handling routine (in different ways).
+    return delay

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -22,6 +22,7 @@ from kopf.engines import logging as logging_engine
 from kopf.engines import posting
 from kopf.engines import sleeping
 from kopf.reactor import causation
+from kopf.reactor import errors
 from kopf.reactor import handling
 from kopf.reactor import lifecycles
 from kopf.reactor import registries
@@ -159,7 +160,7 @@ async def process_resource_watching_cause(
         handlers=handlers,
         cause=cause,
         state=states.State.from_scratch(handlers=handlers),
-        default_errors=registries.ErrorsMode.IGNORED,
+        default_errors=errors.ErrorsMode.IGNORED,
     )
 
     # Store the results, but not the handlers' progress.

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -14,7 +14,6 @@ of the handlers to be executed on each reaction cycle.
 import abc
 import collections
 import dataclasses
-import enum
 import functools
 import warnings
 from types import FunctionType, MethodType
@@ -23,6 +22,7 @@ from typing import (Any, MutableMapping, Optional, Sequence, Collection, Iterabl
 
 from kopf.reactor import callbacks
 from kopf.reactor import causation
+from kopf.reactor import errors as errors_
 from kopf.reactor import invocation
 from kopf.structs import bodies
 from kopf.structs import dicts
@@ -34,13 +34,6 @@ from kopf.utilities import piggybacking
 HandlerId = NewType('HandlerId', str)
 
 
-class ErrorsMode(enum.Enum):
-    """ How arbitrary (non-temporary/non-permanent) exceptions are treated. """
-    IGNORED = enum.auto()
-    TEMPORARY = enum.auto()
-    PERMANENT = enum.auto()
-
-
 # A registered handler (function + meta info).
 # FIXME: Must be frozen, but mypy fails in _call_handler() with a cryptic error:
 # FIXME:    Argument 1 to "invoke" has incompatible type "Optional[HandlerResult]";
@@ -49,7 +42,7 @@ class ErrorsMode(enum.Enum):
 class BaseHandler:
     id: HandlerId
     fn: Callable[..., Optional[callbacks.HandlerResult]]
-    errors: Optional[ErrorsMode]
+    errors: Optional[errors_.ErrorsMode]
     timeout: Optional[float]
     retries: Optional[int]
     backoff: Optional[float]
@@ -126,7 +119,7 @@ class ActivityRegistry(GenericRegistry[ActivityHandler, callbacks.ActivityHandle
             fn: callbacks.ActivityHandlerFn,
             *,
             id: Optional[str] = None,
-            errors: Optional[ErrorsMode] = None,
+            errors: Optional[errors_.ErrorsMode] = None,
             timeout: Optional[float] = None,
             retries: Optional[int] = None,
             backoff: Optional[float] = None,
@@ -179,7 +172,7 @@ class ResourceRegistry(GenericRegistry[ResourceHandler, callbacks.ResourceHandle
             reason: Optional[causation.Reason] = None,
             event: Optional[str] = None,  # deprecated, use `reason`
             field: Optional[dicts.FieldSpec] = None,
-            errors: Optional[ErrorsMode] = None,
+            errors: Optional[errors_.ErrorsMode] = None,
             timeout: Optional[float] = None,
             retries: Optional[int] = None,
             backoff: Optional[float] = None,
@@ -298,7 +291,7 @@ class OperatorRegistry:
             fn: callbacks.ActivityHandlerFn,
             *,
             id: Optional[str] = None,
-            errors: Optional[ErrorsMode] = None,
+            errors: Optional[errors_.ErrorsMode] = None,
             timeout: Optional[float] = None,
             retries: Optional[int] = None,
             backoff: Optional[float] = None,
@@ -342,7 +335,7 @@ class OperatorRegistry:
             reason: Optional[causation.Reason] = None,
             event: Optional[str] = None,  # deprecated, use `reason`
             field: Optional[dicts.FieldSpec] = None,
-            errors: Optional[ErrorsMode] = None,
+            errors: Optional[errors_.ErrorsMode] = None,
             timeout: Optional[float] = None,
             retries: Optional[int] = None,
             backoff: Optional[float] = None,
@@ -469,7 +462,7 @@ class SmartOperatorRegistry(OperatorRegistry):
                 id='login_via_pykube',
                 fn=cast(callbacks.ActivityHandlerFn, piggybacking.login_via_pykube),
                 activity=causation.Activity.AUTHENTICATION,
-                errors=ErrorsMode.IGNORED,
+                errors=errors_.ErrorsMode.IGNORED,
                 _fallback=True,
             )
 
@@ -482,7 +475,7 @@ class SmartOperatorRegistry(OperatorRegistry):
                 id='login_via_client',
                 fn=cast(callbacks.ActivityHandlerFn, piggybacking.login_via_client),
                 activity=causation.Activity.AUTHENTICATION,
-                errors=ErrorsMode.IGNORED,
+                errors=errors_.ErrorsMode.IGNORED,
                 _fallback=True,
             )
 

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -66,7 +66,7 @@ def login(
         ))
     except asyncio.CancelledError:
         pass
-    except handling.ActivityError as e:
+    except activities.ActivityError as e:
         # Detect and re-raise the original LoginErrors, not the general activity error.
         # This is only needed for the legacy one-shot login, not for a background job.
         for outcome in e.outcomes.values():
@@ -478,7 +478,7 @@ async def _startup_cleanup_activities(
 
     # Execute the startup activity before any root task starts running (due to readiness flag).
     try:
-        await handling.run_activity(
+        await activities.run_activity(
             lifecycle=lifecycles.all_at_once,
             registry=registry,
             activity=causation.Activity.STARTUP,
@@ -508,7 +508,7 @@ async def _startup_cleanup_activities(
 
     # Execute the cleanup activity after all other root tasks are presumably done.
     try:
-        await handling.run_activity(
+        await activities.run_activity(
             lifecycle=lifecycles.all_at_once,
             registry=registry,
             activity=causation.Activity.CLEANUP,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -478,7 +478,7 @@ async def _startup_cleanup_activities(
 
     # Execute the startup activity before any root task starts running (due to readiness flag).
     try:
-        await handling.activity_trigger(
+        await handling.run_activity(
             lifecycle=lifecycles.all_at_once,
             registry=registry,
             activity=causation.Activity.STARTUP,
@@ -508,7 +508,7 @@ async def _startup_cleanup_activities(
 
     # Execute the cleanup activity after all other root tasks are presumably done.
     try:
-        await handling.activity_trigger(
+        await handling.run_activity(
             lifecycle=lifecycles.all_at_once,
             registry=registry,
             activity=causation.Activity.CLEANUP,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -13,8 +13,8 @@ from kopf.engines import posting
 from kopf.engines import probing
 from kopf.reactor import activities
 from kopf.reactor import causation
-from kopf.reactor import handling
 from kopf.reactor import lifecycles
+from kopf.reactor import processing
 from kopf.reactor import queueing
 from kopf.reactor import registries
 from kopf.structs import containers
@@ -260,7 +260,7 @@ async def spawn_tasks(
                     namespace=namespace,
                     resource=resource,
                     freeze_mode=freeze_mode,
-                    processor=functools.partial(handling.process_resource_event,
+                    processor=functools.partial(processing.process_resource_event,
                                                 lifecycle=lifecycle,
                                                 registry=registry,
                                                 memories=memories,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -246,9 +246,9 @@ async def spawn_tasks(
                 coro=queueing.watcher(
                     namespace=namespace,
                     resource=ourselves.resource,
-                    handler=functools.partial(peering.peers_handler,
-                                              ourselves=ourselves,
-                                              freeze_mode=freeze_mode)))),
+                    processor=functools.partial(peering.process_peering_event,
+                                                ourselves=ourselves,
+                                                freeze_mode=freeze_mode)))),
         ])
 
     # Resource event handling, only once for every known resource (de-duplicated).
@@ -260,12 +260,12 @@ async def spawn_tasks(
                     namespace=namespace,
                     resource=resource,
                     freeze_mode=freeze_mode,
-                    handler=functools.partial(handling.resource_handler,
-                                              lifecycle=lifecycle,
-                                              registry=registry,
-                                              memories=memories,
-                                              resource=resource,
-                                              event_queue=event_queue)))),
+                    processor=functools.partial(handling.process_resource_event,
+                                                lifecycle=lifecycle,
+                                                registry=registry,
+                                                memories=memories,
+                                                resource=resource,
+                                                event_queue=event_queue)))),
         ])
 
     # On Ctrl+C or pod termination, cancel all tasks gracefully.

--- a/kopf/reactor/states.py
+++ b/kopf/reactor/states.py
@@ -56,7 +56,7 @@ import datetime
 from typing import Any, Optional, Mapping, Dict, Collection, Iterator, cast, overload
 
 from kopf.reactor import callbacks
-from kopf.reactor import handlers
+from kopf.reactor import handlers as handlers_
 from kopf.structs import bodies
 from kopf.structs import patches
 
@@ -167,7 +167,7 @@ class HandlerState:
         return now - (self.started if self.started else now)
 
 
-class State(Mapping[handlers.HandlerId, HandlerState]):
+class State(Mapping[handlers_.HandlerId, HandlerState]):
     """
     A state of selected handlers, as persisted in the object's status.
 
@@ -178,11 +178,11 @@ class State(Mapping[handlers.HandlerId, HandlerState]):
     reflect the changes in the object's status. A new state is created every
     time some changes/outcomes are merged into the current state.
     """
-    _states: Mapping[handlers.HandlerId, HandlerState]
+    _states: Mapping[handlers_.HandlerId, HandlerState]
 
     def __init__(
             self,
-            __src: Mapping[handlers.HandlerId, HandlerState],
+            __src: Mapping[handlers_.HandlerId, HandlerState],
     ):
         super().__init__()
         self._states = dict(__src)
@@ -191,7 +191,7 @@ class State(Mapping[handlers.HandlerId, HandlerState]):
     def from_scratch(
             cls,
             *,
-            handlers: Collection[handlers.BaseHandler],
+            handlers: Collection[handlers_.BaseHandler],
     ) -> "State":
         return cls.from_body(cast(bodies.Body, {}), handlers=handlers)
 
@@ -200,7 +200,7 @@ class State(Mapping[handlers.HandlerId, HandlerState]):
             cls,
             body: bodies.Body,
             *,
-            handlers: Collection[handlers.BaseHandler],
+            handlers: Collection[handlers_.BaseHandler],
     ) -> "State":
         storage = body.get('status', {}).get('kopf', {})
         progress = storage.get('progress', {})
@@ -214,7 +214,7 @@ class State(Mapping[handlers.HandlerId, HandlerState]):
 
     def with_outcomes(
             self,
-            outcomes: Mapping[handlers.HandlerId, HandlerOutcome],
+            outcomes: Mapping[handlers_.HandlerId, HandlerOutcome],
     ) -> "State":
         unknown_ids = [handler_id for handler_id in outcomes if handler_id not in self]
         if unknown_ids:
@@ -251,10 +251,10 @@ class State(Mapping[handlers.HandlerId, HandlerState]):
     def __len__(self) -> int:
         return len(self._states)
 
-    def __iter__(self) -> Iterator[handlers.HandlerId]:
+    def __iter__(self) -> Iterator[handlers_.HandlerId]:
         return iter(self._states)
 
-    def __getitem__(self, item: handlers.HandlerId) -> HandlerState:
+    def __getitem__(self, item: handlers_.HandlerId) -> HandlerState:
         return self._states[item]
 
     @property
@@ -277,7 +277,7 @@ class State(Mapping[handlers.HandlerId, HandlerState]):
 
 def deliver_results(
         *,
-        outcomes: Mapping[handlers.HandlerId, HandlerOutcome],
+        outcomes: Mapping[handlers_.HandlerId, HandlerOutcome],
         patch: patches.Patch,
 ) -> None:
     """

--- a/kopf/reactor/states.py
+++ b/kopf/reactor/states.py
@@ -53,7 +53,7 @@ import collections.abc
 import copy
 import dataclasses
 import datetime
-from typing import Any, Optional, Mapping, Dict, Sequence, Iterator, cast, overload
+from typing import Any, Optional, Mapping, Dict, Collection, Iterator, cast, overload
 
 from kopf.reactor import registries
 from kopf.structs import bodies
@@ -190,7 +190,7 @@ class State(Mapping[registries.HandlerId, HandlerState]):
     def from_scratch(
             cls,
             *,
-            handlers: Sequence[registries.BaseHandler],
+            handlers: Collection[registries.BaseHandler],
     ) -> "State":
         return cls.from_body(cast(bodies.Body, {}), handlers=handlers)
 
@@ -199,7 +199,7 @@ class State(Mapping[registries.HandlerId, HandlerState]):
             cls,
             body: bodies.Body,
             *,
-            handlers: Sequence[registries.BaseHandler],
+            handlers: Collection[registries.BaseHandler],
     ) -> "State":
         storage = body.get('status', {}).get('kopf', {})
         progress = storage.get('progress', {})

--- a/kopf/reactor/states.py
+++ b/kopf/reactor/states.py
@@ -56,7 +56,7 @@ import datetime
 from typing import Any, Optional, Mapping, Dict, Collection, Iterator, cast, overload
 
 from kopf.reactor import callbacks
-from kopf.reactor import registries
+from kopf.reactor import handlers
 from kopf.structs import bodies
 from kopf.structs import patches
 
@@ -167,7 +167,7 @@ class HandlerState:
         return now - (self.started if self.started else now)
 
 
-class State(Mapping[registries.HandlerId, HandlerState]):
+class State(Mapping[handlers.HandlerId, HandlerState]):
     """
     A state of selected handlers, as persisted in the object's status.
 
@@ -178,11 +178,11 @@ class State(Mapping[registries.HandlerId, HandlerState]):
     reflect the changes in the object's status. A new state is created every
     time some changes/outcomes are merged into the current state.
     """
-    _states: Mapping[registries.HandlerId, HandlerState]
+    _states: Mapping[handlers.HandlerId, HandlerState]
 
     def __init__(
             self,
-            __src: Mapping[registries.HandlerId, HandlerState],
+            __src: Mapping[handlers.HandlerId, HandlerState],
     ):
         super().__init__()
         self._states = dict(__src)
@@ -191,7 +191,7 @@ class State(Mapping[registries.HandlerId, HandlerState]):
     def from_scratch(
             cls,
             *,
-            handlers: Collection[registries.BaseHandler],
+            handlers: Collection[handlers.BaseHandler],
     ) -> "State":
         return cls.from_body(cast(bodies.Body, {}), handlers=handlers)
 
@@ -200,7 +200,7 @@ class State(Mapping[registries.HandlerId, HandlerState]):
             cls,
             body: bodies.Body,
             *,
-            handlers: Collection[registries.BaseHandler],
+            handlers: Collection[handlers.BaseHandler],
     ) -> "State":
         storage = body.get('status', {}).get('kopf', {})
         progress = storage.get('progress', {})
@@ -214,7 +214,7 @@ class State(Mapping[registries.HandlerId, HandlerState]):
 
     def with_outcomes(
             self,
-            outcomes: Mapping[registries.HandlerId, HandlerOutcome],
+            outcomes: Mapping[handlers.HandlerId, HandlerOutcome],
     ) -> "State":
         unknown_ids = [handler_id for handler_id in outcomes if handler_id not in self]
         if unknown_ids:
@@ -251,10 +251,10 @@ class State(Mapping[registries.HandlerId, HandlerState]):
     def __len__(self) -> int:
         return len(self._states)
 
-    def __iter__(self) -> Iterator[registries.HandlerId]:
+    def __iter__(self) -> Iterator[handlers.HandlerId]:
         return iter(self._states)
 
-    def __getitem__(self, item: registries.HandlerId) -> HandlerState:
+    def __getitem__(self, item: handlers.HandlerId) -> HandlerState:
         return self._states[item]
 
     @property
@@ -277,7 +277,7 @@ class State(Mapping[registries.HandlerId, HandlerState]):
 
 def deliver_results(
         *,
-        outcomes: Mapping[registries.HandlerId, HandlerOutcome],
+        outcomes: Mapping[handlers.HandlerId, HandlerOutcome],
         patch: patches.Patch,
 ) -> None:
     """

--- a/kopf/reactor/states.py
+++ b/kopf/reactor/states.py
@@ -55,6 +55,7 @@ import dataclasses
 import datetime
 from typing import Any, Optional, Mapping, Dict, Collection, Iterator, cast, overload
 
+from kopf.reactor import callbacks
 from kopf.reactor import registries
 from kopf.structs import bodies
 from kopf.structs import patches
@@ -75,7 +76,7 @@ class HandlerOutcome:
     """
     final: bool
     delay: Optional[float] = None
-    result: Optional[registries.HandlerResult] = None
+    result: Optional[callbacks.HandlerResult] = None
     exception: Optional[Exception] = None
 
 

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -10,6 +10,7 @@ import warnings
 from typing import Any, Union, Sequence, Iterator
 
 from kopf.reactor import causation
+from kopf.reactor import handlers
 from kopf.reactor import registries
 from kopf.structs import bodies
 from kopf.structs import patches
@@ -30,14 +31,14 @@ class BaseRegistry(metaclass=abc.ABCMeta):
             self,
             resource: resources_.Resource,
             event: bodies.Event,
-    ) -> Sequence[registries.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceHandler]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def get_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Sequence[registries.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceHandler]:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -45,14 +46,14 @@ class BaseRegistry(metaclass=abc.ABCMeta):
             self,
             resource: resources_.Resource,
             event: bodies.Event,
-    ) -> Iterator[registries.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceHandler]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def iter_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Iterator[registries.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceHandler]:
         raise NotImplementedError
 
 
@@ -68,14 +69,14 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
     def iter_handlers(
             self,
             cause: AnyCause,
-    ) -> Iterator[registries.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceHandler]:
         yield from self._handlers
 
     def get_event_handlers(
             self,
             resource: resources_.Resource,
             event: bodies.Event,
-    ) -> Sequence[registries.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceHandler]:
         warnings.warn("SimpleRegistry.get_event_handlers() is deprecated; use "
                       "ResourceWatchingRegistry.get_handlers().", DeprecationWarning)
         return list(registries._deduplicated(self.iter_event_handlers(
@@ -84,7 +85,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
     def get_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Sequence[registries.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceHandler]:
         warnings.warn("SimpleRegistry.get_cause_handlers() is deprecated; use "
                       "ResourceChangingRegistry.get_handlers().", DeprecationWarning)
         return list(registries._deduplicated(self.iter_cause_handlers(cause=cause)))
@@ -93,7 +94,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
             self,
             resource: resources_.Resource,
             event: bodies.Event,
-    ) -> Iterator[registries.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceHandler]:
         warnings.warn("SimpleRegistry.iter_event_handlers() is deprecated; use "
                       "ResourceWatchingRegistry.iter_handlers().", DeprecationWarning)
 
@@ -105,7 +106,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
     def iter_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Iterator[registries.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceHandler]:
         warnings.warn("SimpleRegistry.iter_cause_handlers() is deprecated; use "
                       "ResourceChangingRegistry.iter_handlers().", DeprecationWarning)
 
@@ -150,7 +151,7 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
             self,
             resource: resources_.Resource,
             event: bodies.Event,
-    ) -> Sequence[registries.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceHandler]:
         warnings.warn("GlobalRegistry.get_event_handlers() is deprecated; use "
                       "OperatorRegistry.get_resource_watching_handlers().", DeprecationWarning)
         cause = _create_watching_cause(resource=resource, event=event)
@@ -159,7 +160,7 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
     def get_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Sequence[registries.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceHandler]:
         warnings.warn("GlobalRegistry.get_cause_handlers() is deprecated; use "
                       "OperatorRegistry.get_resource_changing_handlers().", DeprecationWarning)
         return self.get_resource_changing_handlers(cause=cause)
@@ -168,7 +169,7 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
             self,
             resource: resources_.Resource,
             event: bodies.Event,
-    ) -> Iterator[registries.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceHandler]:
         warnings.warn("GlobalRegistry.iter_event_handlers() is deprecated; use "
                       "OperatorRegistry.iter_resource_watching_handlers().", DeprecationWarning)
         cause = _create_watching_cause(resource=resource, event=event)
@@ -177,7 +178,7 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
     def iter_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Iterator[registries.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceHandler]:
         warnings.warn("GlobalRegistry.iter_cause_handlers() is deprecated; use "
                       "OperatorRegistry.iter_resource_changing_handlers().", DeprecationWarning)
         yield from self.iter_resource_changing_handlers(cause=cause)

--- a/tests/basic-structs/test_handlers.py
+++ b/tests/basic-structs/test_handlers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kopf.reactor.registries import ActivityHandler, ResourceHandler
+from kopf.reactor.handlers import ActivityHandler, ResourceHandler
 
 
 @pytest.mark.parametrize('cls', [ActivityHandler, ResourceHandler])

--- a/tests/basic-structs/test_handlers_deprecated_cooldown.py
+++ b/tests/basic-structs/test_handlers_deprecated_cooldown.py
@@ -1,5 +1,5 @@
 # Original test-file: tests/basic-structs/test_handlers.py
-from kopf.reactor.registries import ActivityHandler, ResourceHandler
+from kopf.reactor.handlers import ActivityHandler, ResourceHandler
 
 
 def test_activity_handler_with_deprecated_cooldown_instead_of_backoff(mocker):

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -3,8 +3,9 @@ from typing import Mapping
 import freezegun
 import pytest
 
+from kopf.reactor.activities import ActivityError, run_activity
 from kopf.reactor.causation import Activity
-from kopf.reactor.handling import ActivityError, PermanentError, TemporaryError, run_activity
+from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.registries import HandlerId, OperatorRegistry
 from kopf.reactor.states import HandlerOutcome

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -4,7 +4,7 @@ import freezegun
 import pytest
 
 from kopf.reactor.causation import Activity
-from kopf.reactor.handling import ActivityError, PermanentError, TemporaryError, activity_trigger
+from kopf.reactor.handling import ActivityError, PermanentError, TemporaryError, run_activity
 from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.registries import HandlerId, OperatorRegistry
 from kopf.reactor.states import HandlerOutcome
@@ -32,7 +32,7 @@ async def test_results_are_returned_on_success(activity):
     registry.register_activity_handler(fn=sample_fn1, id='id1', activity=activity)
     registry.register_activity_handler(fn=sample_fn2, id='id2', activity=activity)
 
-    results = await activity_trigger(
+    results = await run_activity(
         registry=registry,
         activity=activity,
         lifecycle=all_at_once,
@@ -57,7 +57,7 @@ async def test_errors_are_raised_aggregated(activity):
     registry.register_activity_handler(fn=sample_fn2, id='id2', activity=activity)
 
     with pytest.raises(ActivityError) as e:
-        await activity_trigger(
+        await run_activity(
             registry=registry,
             activity=activity,
             lifecycle=all_at_once,
@@ -86,7 +86,7 @@ async def test_errors_are_cascaded_from_one_of_the_originals(activity):
     registry.register_activity_handler(fn=sample_fn, id='id', activity=activity)
 
     with pytest.raises(ActivityError) as e:
-        await activity_trigger(
+        await run_activity(
             registry=registry,
             activity=activity,
             lifecycle=all_at_once,
@@ -109,7 +109,7 @@ async def test_retries_are_simulated(activity, mocker):
     registry.register_activity_handler(fn=sample_fn, id='id', activity=activity, retries=3)
 
     with pytest.raises(ActivityError) as e:
-        await activity_trigger(
+        await run_activity(
             registry=registry,
             activity=activity,
             lifecycle=all_at_once,
@@ -137,7 +137,7 @@ async def test_delays_are_simulated(activity, mocker):
                                      wraps=sleep_or_wait_substitute)
 
         with pytest.raises(ActivityError) as e:
-            await activity_trigger(
+            await run_activity(
                 registry=registry,
                 activity=activity,
                 lifecycle=all_at_once,

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -5,9 +5,10 @@ import pytest
 
 from kopf.reactor.activities import ActivityError, run_activity
 from kopf.reactor.causation import Activity
+from kopf.reactor.handlers import HandlerId
 from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.lifecycles import all_at_once
-from kopf.reactor.registries import HandlerId, OperatorRegistry
+from kopf.reactor.registries import OperatorRegistry
 from kopf.reactor.states import HandlerOutcome
 
 

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import Reason
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
@@ -20,7 +20,7 @@ async def test_create(registry, handlers, resource, cause_mock, event_type,
     cause_mock.reason = Reason.CREATE
 
     event_queue = asyncio.Queue()
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -61,7 +61,7 @@ async def test_update(registry, handlers, resource, cause_mock, event_type,
     cause_mock.reason = Reason.UPDATE
 
     event_queue = asyncio.Queue()
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -102,7 +102,7 @@ async def test_delete(registry, handlers, resource, cause_mock, event_type,
     cause_mock.reason = Reason.DELETE
 
     event_queue = asyncio.Queue()
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -145,7 +145,7 @@ async def test_gone(registry, handlers, resource, cause_mock, event_type,
     cause_mock.reason = Reason.GONE
 
     event_queue = asyncio.Queue()
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -176,7 +176,7 @@ async def test_free(registry, handlers, resource, cause_mock, event_type,
     cause_mock.reason = Reason.FREE
 
     event_queue = asyncio.Queue()
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -207,7 +207,7 @@ async def test_noop(registry, handlers, resource, cause_mock, event_type,
     cause_mock.reason = Reason.NOOP
 
     event_queue = asyncio.Queue()
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import Reason
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.finalizers import FINALIZER
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import ALL_REASONS, HANDLER_REASONS, Reason
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import ALL_REASONS, HANDLER_REASONS, Reason
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 
@@ -15,7 +15,7 @@ async def test_all_logs_are_prefixed(registry, resource, handlers,
     event_type = None if cause_type == Reason.RESUME else 'irrelevant'
     cause_mock.reason = cause_type
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -44,7 +44,7 @@ async def test_diffs_logged_if_present(registry, resource, handlers, cause_type,
     cause_mock.new = object()  # checked for `not None`
     cause_mock.old = object()  # checked for `not None`
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -73,7 +73,7 @@ async def test_diffs_not_logged_if_absent(registry, resource, handlers, cause_ty
     cause_mock.reason = cause_type
     cause_mock.diff = diff
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -9,7 +9,7 @@ import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import TemporaryError
 from kopf.reactor.handling import WAITING_KEEPALIVE_INTERVAL
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.reactor.states import HandlerState
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.finalizers import FINALIZER

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -9,7 +9,7 @@ import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import TemporaryError
 from kopf.reactor.handling import WAITING_KEEPALIVE_INTERVAL
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.reactor.states import HandlerState
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.finalizers import FINALIZER
@@ -33,7 +33,7 @@ async def test_delayed_handlers_progress(
     cause_mock.reason = cause_reason
 
     with freezegun.freeze_time(now):
-        await resource_handler(
+        await process_resource_event(
             lifecycle=kopf.lifecycles.all_at_once,
             registry=registry,
             resource=resource,
@@ -88,7 +88,7 @@ async def test_delayed_handlers_sleep(
     cause_mock.body.setdefault('metadata', {})['finalizers'] = [FINALIZER]
 
     with freezegun.freeze_time(now):
-        await resource_handler(
+        await process_resource_event(
             lifecycle=kopf.lifecycles.all_at_once,
             registry=registry,
             resource=resource,

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -6,7 +6,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import PermanentError, TemporaryError
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 
@@ -25,7 +25,7 @@ async def test_fatal_error_stops_handler(
     handlers.delete_mock.side_effect = PermanentError("oops")
     handlers.resume_mock.side_effect = PermanentError("oops")
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,
@@ -68,7 +68,7 @@ async def test_retry_error_delays_handler(
     handlers.delete_mock.side_effect = TemporaryError("oops")
     handlers.resume_mock.side_effect = TemporaryError("oops")
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,
@@ -112,7 +112,7 @@ async def test_arbitrary_error_delays_handler(
     handlers.delete_mock.side_effect = Exception("oops")
     handlers.resume_mock.side_effect = Exception("oops")
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -6,7 +6,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
 from kopf.reactor.handling import PermanentError, TemporaryError
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import ALL_REASONS
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 
@@ -16,7 +16,7 @@ async def test_handlers_called_always(
     caplog.set_level(logging.DEBUG)
     cause_mock.reason = cause_type
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,
@@ -51,7 +51,7 @@ async def test_errors_are_ignored(
     cause_mock.reason = cause_type
     handlers.event_mock.side_effect = Exception("oops")
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import ALL_REASONS
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -4,7 +4,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -4,7 +4,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import Reason, HANDLER_REASONS
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 
@@ -18,7 +18,7 @@ async def test_1st_step_stores_progress_by_patching(
     event_type = None if cause_type == Reason.RESUME else 'irrelevant'
     cause_mock.reason = cause_type
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.asap,
         registry=registry,
         resource=resource,
@@ -67,7 +67,7 @@ async def test_2nd_step_finishes_the_handlers(caplog,
         }}}
     })
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 
@@ -28,7 +28,7 @@ async def test_skipped_with_no_handlers(
     )
     assert registry.has_resource_changing_handlers(resource=resource)  # prerequisite
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
 

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -6,7 +6,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS, Reason
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 
@@ -34,7 +34,7 @@ async def test_timed_out_handler_fails(
     })
 
     with freezegun.freeze_time(now):
-        await resource_handler(
+        await process_resource_event(
             lifecycle=kopf.lifecycles.one_by_one,
             registry=registry,
             resource=resource,
@@ -82,7 +82,7 @@ async def test_retries_limited_handler_fails(
         }}}
     })
 
-    await resource_handler(
+    await process_resource_event(
         lifecycle=kopf.lifecycles.one_by_one,
         registry=registry,
         resource=resource,

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -6,7 +6,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS, Reason
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -4,7 +4,7 @@ import datetime
 import freezegun
 
 import kopf
-from kopf.reactor.handling import process_resource_event
+from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -4,7 +4,7 @@ import datetime
 import freezegun
 
 import kopf
-from kopf.reactor.handling import resource_handler
+from kopf.reactor.handling import process_resource_event
 from kopf.structs.containers import ResourceMemories
 
 
@@ -55,7 +55,7 @@ async def test_consistent_awakening(registry, resource, k8s_mocked, mocker):
     # Another way (same effect): handle_resource_changing_cause() and its result.
     with freezegun.freeze_time(tsA_triggered) as frozen_dt:
         assert datetime.datetime.utcnow() < ts0  # extra precaution
-        await resource_handler(
+        await process_resource_event(
             lifecycle=kopf.lifecycles.all_at_once,
             registry=registry,
             resource=resource,

--- a/tests/persistence/test_outcomes.py
+++ b/tests/persistence/test_outcomes.py
@@ -1,4 +1,4 @@
-from kopf.reactor.registries import HandlerResult
+from kopf.reactor.callbacks import HandlerResult
 from kopf.reactor.states import HandlerOutcome
 
 

--- a/tests/reactor/conftest.py
+++ b/tests/reactor/conftest.py
@@ -14,8 +14,8 @@ def _autouse_resp_mocker(resp_mocker):
 
 
 @pytest.fixture()
-def handler():
-    """ A mock for handler -- to be checked if the handler has been called. """
+def processor():
+    """ A mock for processor -- to be checked if the handler has been called. """
     return CoroutineMock()
 
 
@@ -42,7 +42,7 @@ def watcher_limited(mocker):
 def watcher_in_background(resource, event_loop, worker_spy, stream):
 
     # Prevent remembering the streaming objects in the mocks.
-    async def no_op_handler(*args, **kwargs):
+    async def do_nothing(*args, **kwargs):
         pass
 
     # Prevent any real streaming for the very beginning, before it even starts.
@@ -52,7 +52,7 @@ def watcher_in_background(resource, event_loop, worker_spy, stream):
     coro = watcher(
         namespace=None,
         resource=resource,
-        handler=no_op_handler,
+        processor=do_nothing,
     )
     task = event_loop.create_task(coro)
 

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -2,8 +2,9 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import Reason, Activity, HANDLER_REASONS
+from kopf.reactor.errors import ErrorsMode
 from kopf.reactor.handling import subregistry_var
-from kopf.reactor.registries import ErrorsMode, OperatorRegistry, ResourceChangingRegistry
+from kopf.reactor.registries import OperatorRegistry, ResourceChangingRegistry
 from kopf.structs.resources import Resource
 
 


### PR DESCRIPTION
## What do these changes do?

Move classes and functions across the modules, extract new modules — in order to reduce the complexity and prepare the codebase for adding even more code. 

The behaviour is not changed, only the imports.


## Description

<!-- What was the previous behaviour before the PR is merged? -->

Before this PR, some modules were too large, up to 1k of lines, containing too many aspects and topics — as it has historically happened when new features were added. For example, _activity_ execution was part of `handling.py`, as it was nearly a clone of _handler_ execution. Similarly, event processing and handler invocation were there too (in `handling.py`) — since the times they were short and simple.

<!-- What will be the new behaviour after the PR is merged? -->

With this PR, some huge modules are split into smaller ones, and classes/functions are moved all around. For example, watch-event handling is now renamed to processing and moved to `processing.py` — as per [event processing of the event-driven design](https://en.wikipedia.org/wiki/Event-driven_architecture#Event_processing_engine), which it is by its nature — this releases the term _handling_ to the callback functions, which are currently called _handlers_.

This is needed to make more space for adding more code (e.g. for daemons and timers) without exploding the modules beyond understanding.

---

See the list of commits for individual changes (they are all atomic). Briefly:

* Rename watch-event "handling" routines to "processing" routines.
* Extract the in-memory multi-step handling cycle to a reusable routine _(used in activities, will be used in daemons/timers)_.
* Split `handling.py` -> `handling.py` + `processing.py` +  `activities.py`
* Split `registries.py` -> `registries.py` + `handlers.py` + `callbacks.py` + `errors.py`

The latter split also removes the cyclic imports as detected by LGTM (all 16 alarms at once) — this cycle is broken by moving `BaseHandler` away from `registries`:

* → `registries`
  * → `invocation` (for `get_kwargs()`, needed for matching callbacks)
    * → `lifecycles` (for `LifeCycleFn`, needed for `Invokable` definition)
      * → `registries` (for `BaseHandler`, needed for `handlers` kwarg)

Replaced with a regular dependency tree:

* → `registries`
  * → `invocation` (for `get_kwargs()`, needed for matching callbacks)
    * → `lifecycles` (for `LifeCycleFn`, needed for `Invokable` definition)
      * → `handlers` (for `BaseHandler`, needed for `handlers` kwarg)
  * → `handlers` (for all handlers dataclasses, previously located in `registries`)

<!-- A code snippet showing the new features added (if any)? -->

---

<!-- Does the change affect the end users or is it internal? -->

The users should not be affected, as these are the internal changes only — unless they monkey-patch some of the Kopf's internals.

<!-- Why have you decided to solve the problem this way? What were the trade-offs? (If appropriate.) -->


<!-- Are there any breaking or risky changes? -->


## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

> Issues: #19 

> Related:


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
