### PR TITLE
Update the Dockerfile to fix the handlers.py path inside container

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ into a docker image with CI/CD tool of your preference.
 FROM python:3.7
 ADD . /src
 RUN pip install kopf
-CMD kopf run handlers.py
+CMD kopf run /src/handlers.py
 ```
 
 Where `handlers.py` is your Python script with the handlers


### PR DESCRIPTION
When the Dockerfile mentioned here is copied as is, it does not run the container as the path inside the container is incorrect. Fixing that

## What do these changes do?

Reflects the correct Dockerfile doc to be used


## Description

<!-- What was the previous behaviour before the PR is merged? -->
Incorrect path in README.doc

<!-- What will be the new behaviour after the PR is merged? -->
Enhanced UX

<!-- A code snippet showing the new features added (if any)? -->
N/A

<!-- Does the change affect the end users or is it internal? -->
End-users

<!-- Why have you decided to solve the problem this way? What were the trade-offs? (If appropriate.) -->
N/A

<!-- Are there any breaking or risky changes? -->
No

## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Mostly documentation and examples (no code changes)


## Checklist

- [ ] The code addresses only the mentioned problem, and this problem only

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
