### PR TITLE
[305] Hide authorisation headers of exceptions' reprs

### DIFF
--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -84,6 +84,6 @@ async def post_event(
     except aiohttp.ClientResponseError as e:
         # Events are helpful but auxiliary, they should not fail the handling cycle.
         # Yet we want to notice that something went wrong (in logs).
-        logger.warning("Failed to post an event. Ignoring and continuing. "
-                       f"Error: {e!r}. "
+        logger.warning(f"Failed to post an event. Ignoring and continuing. "
+                       f"Status: {e.status}. Message: {e.message}. "
                        f"Event: type={type!r}, reason={reason!r}, message={message!r}.")

--- a/kopf/reactor/callbacks.py
+++ b/kopf/reactor/callbacks.py
@@ -19,7 +19,7 @@ HandlerResult = NewType('HandlerResult', object)
 
 
 class ActivityHandlerFn(Protocol):
-    def __call__(
+    def __call__(  # lgtm[py/similar-function]
             self,
             *args: Any,
             logger: Union[logging.Logger, logging.LoggerAdapter],
@@ -28,7 +28,7 @@ class ActivityHandlerFn(Protocol):
 
 
 class ResourceHandlerFn(Protocol):
-    def __call__(
+    def __call__(  # lgtm[py/similar-function]
             self,
             *args: Any,
             type: str,
@@ -50,7 +50,7 @@ class ResourceHandlerFn(Protocol):
 
 
 class WhenHandlerFn(Protocol):
-    def __call__(
+    def __call__(  # lgtm[py/similar-function]
             self,
             *args: Any,
             type: str,

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -177,7 +177,7 @@ async def worker(
             replenished.clear()
             try:
                 await processor(event=event, replenished=replenished)
-            except Exception as e:
+            except Exception:
                 # TODO: processor is a functools.partial. make the prints a bit nicer by removing it.
                 logger.exception(f"{processor} failed with an exception. Ignoring the event.")
                 # raise

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -420,7 +420,7 @@ async def _root_task_checker(
         logger.debug(f"Root task {name!r} is cancelled.")
         raise
     except Exception as e:
-        logger.error(f"Root task {name!r} is failed: %r", e)
+        logger.error(f"Root task {name!r} is failed: %s", e)
         raise  # fail the process and its exit status
     else:
         logger.warning(f"Root task {name!r} is finished unexpectedly.")

--- a/kopf/reactor/states.py
+++ b/kopf/reactor/states.py
@@ -143,7 +143,7 @@ class HandlerState:
             success=bool(outcome.final and outcome.exception is None),
             failure=bool(outcome.final and outcome.exception is not None),
             retries=(self.retries if self.retries is not None else 0) + 1,
-            message=None if outcome.exception is None else f'{outcome.exception}',
+            message=None if outcome.exception is None else str(outcome.exception),
             _origin=self._origin,
         )
 


### PR DESCRIPTION
## What do these changes do?

Prevent leaking `Authorisation:` and maybe other sensitive headers of the K8s API requests and responses when failing to post an event.

## Description

Previously, Kopf was logging the whole repr of an error in case of failures.  With `aiohttp.ClientResponseError`, this seems to be a problem, as its repr includes all the request headers, including `Authorization: …`. 

When this header is logged, then those who have access to the logs can also get access to the K8s API (especially if the K8s API tokens are not expired, which is the case on its own).

With this change, it will only show string forms of any errors.  For `aiohttp.ClientResponseError`, this means only the HTTP status, message, and an URL. And, as a special case, in K8s-event posting, only the HTTP status and message.

## Issues/PRs

> Issues: fixes #305


## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
