### PR TITLE
Patch status as a sub-resource if defined so

### DIFF
--- a/kopf/clients/auth.py
+++ b/kopf/clients/auth.py
@@ -11,7 +11,6 @@ from typing import Optional, Callable, Any, TypeVar, Dict, Iterator, Mapping, ca
 import aiohttp
 
 from kopf.structs import credentials
-from kopf.structs import resources
 
 # Per-operator storage and exchange point for authentication methods.
 # Used by the client wrappers to retrieve the credentials and report the failures.

--- a/kopf/clients/auth.py
+++ b/kopf/clients/auth.py
@@ -111,7 +111,7 @@ class APIContext:
     # Temporary caches of the information retrieved for and from the environment.
     _tempfiles: "_TempFiles"
     _discovery_lock: asyncio.Lock
-    _discovered_resources: Dict[str, Dict[resources.Resource, Dict[str, object]]]
+    _discovered_resources: Dict[str, Dict[str, Dict[str, object]]]  # ['group/version']['plural']
 
     def __init__(
             self,

--- a/kopf/clients/discovery.py
+++ b/kopf/clients/discovery.py
@@ -28,7 +28,7 @@ async def discover(
                     respdata = await response.json()
 
                     context._discovered_resources[resource.api_version].update({
-                        resources.Resource(resource.group, resource.version, info['name']): info
+                        info['name']: info
                         for info in respdata['resources']
                     })
 
@@ -38,7 +38,7 @@ async def discover(
                     else:
                         raise
 
-    return context._discovered_resources[resource.api_version].get(resource, None)
+    return context._discovered_resources[resource.api_version].get(resource.plural, None)
 
 
 @auth.reauthenticated_request

--- a/kopf/structs/resources.py
+++ b/kopf/structs/resources.py
@@ -23,8 +23,12 @@ class Resource(NamedTuple):
             server: Optional[str] = None,
             namespace: Optional[str] = None,
             name: Optional[str] = None,
+            subresource: Optional[str] = None,
             params: Optional[Mapping[str, str]] = None,
     ) -> str:
+        if subresource is not None and name is None:
+            raise ValueError("Subresources can be used only with specific resources by their name.")
+
         return self._build_url(server, params, [
             '/api' if self.group == '' and self.version == 'v1' else '/apis',
             self.group,
@@ -33,6 +37,7 @@ class Resource(NamedTuple):
             namespace,
             self.plural,
             name,
+            subresource,
         ])
 
     def get_version_url(

--- a/tests/basic-structs/test_resource.py
+++ b/tests/basic-structs/test_resource.py
@@ -106,3 +106,51 @@ def test_url_with_arbitrary_params():
     resource = Resource('group', 'version', 'plural')
     url = resource.get_url(params=dict(watch='true', resourceVersion='abc%def xyz'))
     assert url == '/apis/group/version/plural?watch=true&resourceVersion=abc%25def+xyz'
+
+
+def test_url_of_custom_resource_list_cluster_scoped_with_subresource():
+    resource = Resource('group', 'version', 'plural')
+    with pytest.raises(ValueError):
+        resource.get_url(subresource='status')
+
+
+def test_url_of_custom_resource_list_namespaced_with_subresource():
+    resource = Resource('group', 'version', 'plural')
+    with pytest.raises(ValueError):
+        resource.get_url(namespace='ns-a.b', subresource='status')
+
+
+def test_url_of_custom_resource_item_cluster_scoped_with_subresource():
+    resource = Resource('group', 'version', 'plural')
+    url = resource.get_url(name='name-a.b', subresource='status')
+    assert url == '/apis/group/version/plural/name-a.b/status'
+
+
+def test_url_of_custom_resource_item_namespaced_with_subresource():
+    resource = Resource('group', 'version', 'plural')
+    url = resource.get_url(name='name-a.b', namespace='ns-a.b', subresource='status')
+    assert url == '/apis/group/version/namespaces/ns-a.b/plural/name-a.b/status'
+
+
+def test_url_of_builtin_resource_list_cluster_scoped_with_subresource():
+    resource = Resource('', 'v1', 'plural')
+    with pytest.raises(ValueError):
+        resource.get_url(subresource='status')
+
+
+def test_url_of_builtin_resource_list_namespaced_with_subresource():
+    resource = Resource('', 'v1', 'plural')
+    with pytest.raises(ValueError):
+        resource.get_url(namespace='ns-a.b', subresource='status')
+
+
+def test_url_of_builtin_resource_item_cluster_scoped_with_subresource():
+    resource = Resource('', 'v1', 'plural')
+    url = resource.get_url(name='name-a.b', subresource='status')
+    assert url == '/api/v1/plural/name-a.b/status'
+
+
+def test_url_of_builtin_resource_item_namespaced_with_subresource():
+    resource = Resource('', 'v1', 'plural')
+    url = resource.get_url(name='name-a.b', namespace='ns-a.b', subresource='status')
+    assert url == '/api/v1/namespaces/ns-a.b/plural/name-a.b/status'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,24 @@ def version_api(resp_mocker, aresponses, hostname, resource):
 
 
 @pytest.fixture()
+def version_api_with_substatus(resp_mocker, aresponses, hostname, resource, version_api):
+
+    # TODO: stop auto-using `version_api` in all /k8s/ tests, then such purging will not be needed.
+    # TODO: but it is so convenient for all other /k8s/ tests, that removing it is undesired.
+    aresponses._responses[:] = []
+
+    result = {'resources': [{
+        'name': resource.plural,
+        'namespaced': True,
+    }, {
+        'name': f'{resource.plural}/status',
+        'namespaced': True,
+    }]}
+    list_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
+    aresponses.add(hostname, resource.get_version_url(), 'get', list_mock)
+
+
+@pytest.fixture()
 def stream(fake_vault, resp_mocker, aresponses, hostname, resource, version_api):
     """ A mock for the stream of events as if returned by K8s client. """
 

--- a/tests/k8s/test_patching.py
+++ b/tests/k8s/test_patching.py
@@ -72,6 +72,97 @@ async def test_by_body_namespaced(
     assert data == {'x': 'y'}
 
 
+async def test_status_as_subresource_with_combined_payload(
+        resp_mocker, aresponses, hostname, resource, version_api_with_substatus):
+
+    object_url = resource.get_url(namespace='ns1', name='name1')
+    status_url = resource.get_url(namespace='ns1', name='name1', subresource='status')
+    object_patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    status_patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    aresponses.add(hostname, object_url, 'patch', object_patch_mock)
+    aresponses.add(hostname, status_url, 'patch', status_patch_mock)
+
+    patch = {'spec': {'x': 'y'}, 'status': {'s': 't'}}
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    await patch_obj(resource=resource, body=body, patch=patch)
+
+    assert object_patch_mock.called
+    assert object_patch_mock.call_count == 1
+    assert status_patch_mock.called
+    assert status_patch_mock.call_count == 1
+
+    data = object_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    assert data == {'spec': {'x': 'y'}}
+    data = status_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    assert data == {'status': {'s': 't'}}
+
+
+async def test_status_as_subresource_with_fields_only(
+        resp_mocker, aresponses, hostname, resource, version_api_with_substatus):
+
+    object_url = resource.get_url(namespace='ns1', name='name1')
+    status_url = resource.get_url(namespace='ns1', name='name1', subresource='status')
+    object_patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    status_patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    aresponses.add(hostname, object_url, 'patch', object_patch_mock)
+    aresponses.add(hostname, status_url, 'patch', status_patch_mock)
+
+    patch = {'spec': {'x': 'y'}}
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    await patch_obj(resource=resource, body=body, patch=patch)
+
+    assert object_patch_mock.called
+    assert object_patch_mock.call_count == 1
+    assert not status_patch_mock.called
+
+    data = object_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    assert data == {'spec': {'x': 'y'}}
+
+
+async def test_status_as_subresource_with_status_only(
+        resp_mocker, aresponses, hostname, resource, version_api_with_substatus):
+
+    object_url = resource.get_url(namespace='ns1', name='name1')
+    status_url = resource.get_url(namespace='ns1', name='name1', subresource='status')
+    object_patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    status_patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    aresponses.add(hostname, object_url, 'patch', object_patch_mock)
+    aresponses.add(hostname, status_url, 'patch', status_patch_mock)
+
+    patch = {'status': {'s': 't'}}
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    await patch_obj(resource=resource, body=body, patch=patch)
+
+    assert not object_patch_mock.called
+    assert status_patch_mock.called
+    assert status_patch_mock.call_count == 1
+
+    data = status_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    assert data == {'status': {'s': 't'}}
+
+
+async def test_status_as_body_field(
+        resp_mocker, aresponses, hostname, resource):
+
+    object_url = resource.get_url(namespace='ns1', name='name1')
+    status_url = resource.get_url(namespace='ns1', name='name1', subresource='status')
+    object_patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    status_patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    aresponses.add(hostname, object_url, 'patch', object_patch_mock)
+    aresponses.add(hostname, status_url, 'patch', status_patch_mock)
+
+    patch = {'spec': {'x': 'y'}, 'status': {'s': 't'}}
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    await patch_obj(resource=resource, body=body, patch=patch)
+
+    assert object_patch_mock.called
+    assert object_patch_mock.call_count == 1
+    assert not status_patch_mock.called
+
+    data = object_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    assert data == {'spec': {'x': 'y'}, 'status': {'s': 't'}}
+
+
 async def test_raises_when_body_conflicts_with_namespace(
         resp_mocker, aresponses, hostname, resource):
 


### PR DESCRIPTION
## What do these changes do?

Patch custom/built-in resources with status declared as a sub-resource via a separate URL — instead of being a field of a resource itself.


## Description

<!-- What was the previous behaviour before the PR is merged? -->

Previously, Kopf always assumed that custom resources and built-in resources store status as part of the object (which was the case in early Kubernetes versions).

But this has changed since [sub-resources were introduced](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#subresources). While it was not a big problem for custom resources, where the developers could define the sub-resources and skip "status" there, it became a problem with some built-in resources like "storage.k8s.io/volumeattachments", which have the status defined as a sub-resource and operator developers cannot control it.

As a result, when Kopf was patching the object itself with `{"status": ...}` payload, the status was lost, and the reaction cycle did not continue, so the handlers were skipped.

<!-- What will be the new behaviour after the PR is merged? -->

With this PR, Kopf discovers and respects the status-as-a-subresource both in custom and built-in resources, and patches them accordingly: either as a whole object with a status field (if not a sub-resource), or separately for object & status endpoints (depending on the patch's content). 

The latter aspect can cause for 2 `PATCH` requests to be made when both the body (e.g. metadata) and the status has to be updated — when previously it was only 1 (but did not work with this kind of resources at all).

<!-- A code snippet showing the new features added (if any)? -->

<!-- Does the change affect the end users or is it internal? -->

From the user perspective, a wider set of built-in resources can be handled now, and their custom resources can also have status declared as a sub-resource (if they wish so).

<!-- Why have you decided to solve the problem this way? What were the trade-offs? (If appropriate.) -->

<!-- Are there any breaking or risky changes? -->


## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

> Issues: #308 closes #119 


## Type of changes

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
