### PR TITLE
Switch to py38 as the primary CI version, keep py37 tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,20 @@ env:
 #    - KUBERNETES_VERSION=v1.11.10  # Minikube fails on CRI preflight checks
 #    - KUBERNETES_VERSION=v1.10.13  # CRDs require spec.version, which fails on 1.14
 
+# Only one Python version is tested with all supported K8s versions: to check for API compatibility.
+# Other Python versions are tested with only one K8s version: if it works for one, it works for all.
+# One look-ahead Python dev version is tested for preview, but is optional.
 python:
-  - "3.7"
+  - "3.8"
 matrix:
   include:
-    - python: "3.8-dev"
+    - python: "3.7"
+      env: KUBERNETES_VERSION=latest CLIENT=yes
+    - python: "3.7"
+      env: KUBERNETES_VERSION=latest CLIENT=no
+    - python: "3.9-dev"
   allow_failures:
-    - python: "3.8-dev"
+    - python: "3.9-dev"
 
 before_script:
   - tools/minikube-for-travis.sh

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -180,9 +180,9 @@ async def spawn_tasks(
     memories = memories if memories is not None else containers.ResourceMemories()
     vault = vault if vault is not None else global_vault
     vault = vault if vault is not None else credentials.Vault()
-    event_queue: posting.K8sEventQueue = asyncio.Queue(loop=loop)
-    freeze_mode: primitives.Toggle = primitives.Toggle(loop=loop)
-    signal_flag: asyncio_Future = asyncio.Future(loop=loop)
+    event_queue: posting.K8sEventQueue = asyncio.Queue()
+    freeze_mode: primitives.Toggle = primitives.Toggle()
+    signal_flag: asyncio_Future = asyncio.Future()
     ready_flag = ready_flag if ready_flag is not None else asyncio.Event()
     tasks: MutableSequence[asyncio_Task] = []
 

--- a/kopf/structs/credentials.py
+++ b/kopf/structs/credentials.py
@@ -112,20 +112,18 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
     def __init__(
             self,
             __src: Optional[Mapping[str, object]] = None,
-            *,
-            loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         super().__init__()
         self._current = {}
         self._invalid = collections.defaultdict(list)
-        self._lock = asyncio.Lock(loop=loop)
+        self._lock = asyncio.Lock()
 
         if __src is not None:
             self._update_converted(__src)
 
         # Mark a pre-populated vault to be usable instantly,
         # or trigger the initial authentication for an empty vault.
-        self._ready = primitives.Toggle(bool(self), loop=loop)
+        self._ready = primitives.Toggle(bool(self))
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}: {self._current!r}>'

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -71,16 +71,10 @@ class Toggle:
     def __init__(
             self,
             __val: bool = False,
-            *,
-            loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         super().__init__()
-        self._condition = asyncio.Condition(loop=loop)
+        self._condition = asyncio.Condition()
         self._state: bool = bool(__val)
-
-    @property
-    def loop(self) -> asyncio.AbstractEventLoop:
-        return self._condition._loop
 
     def __bool__(self) -> bool:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,7 +314,7 @@ def clean_kubernetes_client():
 
 
 @pytest.fixture()
-def fake_vault(event_loop, mocker, hostname):
+def fake_vault(mocker, hostname):
     """
     Provide a freshly created and populated authentication vault for every test.
 
@@ -328,7 +328,7 @@ def fake_vault(event_loop, mocker, hostname):
 
     key = VaultKey('fixture')
     info = ConnectionInfo(server=f'https://{hostname}')
-    vault = Vault({key: info}, loop=event_loop)
+    vault = Vault({key: info})
     token = auth.vault_var.set(vault)
     mocker.patch.object(vault._ready, 'wait_for_on')
     mocker.patch.object(vault._ready, 'wait_for_off')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,12 @@ def pytest_configure(config):
     # Unexpected warnings should fail the tests. Use `-Wignore` to explicitly disable it.
     config.addinivalue_line('filterwarnings', 'error')
 
+    # Warnings from the testing tools out of our control should not fail the tests.
+    config.addinivalue_line('filterwarnings', 'ignore:"@coroutine":DeprecationWarning:asynctest.mock')
+    config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:aiohttp')
+    config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:aiojobs')
+    config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:asyncio.queues')  # aiojobs
+
 
 def pytest_addoption(parser):
     parser.addoption("--only-e2e", action="store_true", help="Execute end-to-end tests only.")

--- a/tests/posting/conftest.py
+++ b/tests/posting/conftest.py
@@ -15,8 +15,8 @@ def event_queue_loop(event_loop):
 
 
 @pytest.fixture()
-def event_queue(event_loop):
-    queue = asyncio.Queue(loop=event_loop)
+def event_queue():
+    queue = asyncio.Queue()
     token = event_queue_var.set(queue)
     try:
         yield queue

--- a/tests/primitives/test_toggles.py
+++ b/tests/primitives/test_toggles.py
@@ -1,22 +1,8 @@
 import asyncio
-import contextlib
 
 import pytest
 
 from kopf.structs.primitives import Toggle
-
-
-async def test_creation_with_default_loop():
-    loop = asyncio.get_running_loop()
-    toggle = Toggle()
-    assert toggle.loop is loop
-
-
-async def test_creation_with_explicit_loop():
-    loop = asyncio.new_event_loop()
-    with contextlib.closing(loop):
-        toggle = Toggle(loop=loop)
-        assert toggle.loop is loop
 
 
 async def test_created_as_off():


### PR DESCRIPTION
## What do these changes do?

Switch from Python 3.7 to 3.8 as the primary testing environment in Travis, and resolve few issues/warnings with 3.8. Python 3.7 compatibility is still tested and ensured.


## Description

The testing is now organised this way:

* The latest Python — with all supported Kubernetes versions.
* The latest Kubernetes — with all supported Python versions (3.7 & 3.8 & optionally 3.9-dev).

We assume that if something breaks, it either breaks in the language (and one K8s version is enough to detect it), or in Kubernetes API (and one Python version is enough to detect it) — there is no need to test a real matrix "all Pythons vs. all K8ses".

Travis CI has a limit of 5 builds running in parallel (for us), so more than 5 or 10 builds delays the build results. Currently, we have 10 — and so it will be with the new grid (for a while).


## Issues/PRs

> Issues: #13 


## Type of changes

- Mostly CI/CD automation, contribution experience


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
