### PR TITLE
Optionally remove the Status handler_id prefix

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@ For the detailed information on who did what, see [GitHub Contributors](https://
 - [Soroosh Sarabadani](https://github.com/psycho-ir)
 - [Trond Hindenes](https://github.com/trondhindenes)
 - [Vennamaneni Sai Narasimha](https://github.com/thevennamaneni)
+- [Jim Ramsay](https://github.com/lack)

--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -321,6 +321,49 @@ with the ids like ``create_fn/item1``, ``create_fn/item2``, etc.
     and generating the dynamic functions of the sub-handlers.
 
 
+Updating Status
+===============
+
+Kopf will take the return value of all state-changing handlers (even
+sub-handlers) and add them to the Status of the corresponding kuberenetes
+object.  By default, this is stored under the handler id (which is the function
+name by default).
+
+So, given the following handler definition::
+
+    import kopf
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
+    def my_handler(spec, **_):
+        return {'field': 'value}
+
+The resulting object will have the following data::
+
+    spec:
+      ...
+    status:
+      my_handler:
+        field: value
+
+In order to remove the handler ID from the result, you may set the optional
+``status_prefix=False`` when defining the handler.
+
+So with the handler definition::
+
+    import kopf
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', status_prefix=False)
+    def my_handler(spec, **_):
+        return {'field': 'value}
+
+The resulting object will have the following data::
+
+    spec:
+      ...
+    status:
+      field: value
+
+
 Filtering
 =========
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -136,6 +136,7 @@ def resume(  # lgtm[py/similar-function]
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
         when: Optional[callbacks.WhenHandlerFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
@@ -148,6 +149,7 @@ def resume(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=True, deleted=deleted, requires_finalizer=None,
             reason=None,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -167,6 +169,7 @@ def create(  # lgtm[py/similar-function]
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
         when: Optional[callbacks.WhenHandlerFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.create()`` handler for the object creation. """
     def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
@@ -179,6 +182,7 @@ def create(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=causation.Reason.CREATE,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -198,6 +202,7 @@ def update(  # lgtm[py/similar-function]
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
         when: Optional[callbacks.WhenHandlerFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.update()`` handler for the object update or change. """
     def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
@@ -210,6 +215,7 @@ def update(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=causation.Reason.UPDATE,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -230,6 +236,7 @@ def delete(  # lgtm[py/similar-function]
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
         when: Optional[callbacks.WhenHandlerFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
@@ -242,6 +249,7 @@ def delete(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=bool(not optional),
             reason=causation.Reason.DELETE,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -262,6 +270,7 @@ def field(  # lgtm[py/similar-function]
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
         when: Optional[callbacks.WhenHandlerFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
@@ -275,6 +284,7 @@ def field(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=None,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -289,6 +299,7 @@ def event(  # lgtm[py/similar-function]
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
         when: Optional[callbacks.WhenHandlerFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceHandlerDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
@@ -301,6 +312,7 @@ def event(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=None,
+            status_prefix=status_prefix,
         )
         real_registry.resource_watching_handlers[real_resource].append(handler)
         return fn
@@ -321,6 +333,7 @@ def this(  # lgtm[py/similar-function]
         labels: Optional[bodies.Labels] = None,
         annotations: Optional[bodies.Annotations] = None,
         when: Optional[callbacks.WhenHandlerFn] = None,
+        status_prefix: Optional[bool] = None,
 ) -> ResourceHandlerDecorator:
     """
     ``@kopf.on.this()`` decorator for the dynamically generated sub-handlers.
@@ -356,12 +369,14 @@ def this(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else handling.subregistry_var.get()
         real_id = registries.generate_id(fn=fn, id=id,
                                          prefix=parent_handler.id if parent_handler else None)
+        handler_status_prefix = status_prefix if status_prefix is not None else parent_handler.status_prefix if parent_handler else True
         handler = handlers.ResourceHandler(
             fn=fn, id=real_id, field=None,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=None,
+            status_prefix=handler_status_prefix,
         )
         real_registry.append(handler)
         return fn

--- a/kopf/reactor/handlers.py
+++ b/kopf/reactor/handlers.py
@@ -46,21 +46,22 @@ class BaseHandler:
 @dataclasses.dataclass
 class ActivityHandler(BaseHandler):
     fn: callbacks.ActivityHandlerFn  # type clarification
-    activity: Optional[causation.Activity]
+    activity: Optional[causation.Activity] = None
     _fallback: bool = False  # non-public!
 
 
 @dataclasses.dataclass
 class ResourceHandler(BaseHandler):
     fn: callbacks.ResourceHandlerFn  # type clarification
-    reason: Optional[causation.Reason]
-    field: Optional[dicts.FieldPath]
-    initial: Optional[bool]
-    deleted: Optional[bool]  # used for mixed-in (initial==True) @on.resume handlers only.
-    labels: Optional[bodies.Labels]
-    annotations: Optional[bodies.Annotations]
-    when: Optional[callbacks.WhenHandlerFn]
-    requires_finalizer: Optional[bool]
+    reason: Optional[causation.Reason] = None
+    field: Optional[dicts.FieldPath] = None
+    initial: Optional[bool] = None
+    deleted: Optional[bool] = None # used for mixed-in (initial==True) @on.resume handlers only.
+    labels: Optional[bodies.Labels] = None
+    annotations: Optional[bodies.Annotations] = None
+    when: Optional[callbacks.WhenHandlerFn] = None
+    requires_finalizer: Optional[bool] = None
+    status_prefix: Optional[bool] = True
 
     @property
     def event(self) -> Optional[causation.Reason]:

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -294,36 +294,36 @@ async def execute_handler_once(
     # Unfinished children cause the regular retry, but with less logging and event reporting.
     except HandlerChildrenRetry as e:
         logger.debug(f"Handler {handler.id!r} has unfinished sub-handlers. Will retry soon.")
-        return states.HandlerOutcome(final=False, exception=e, delay=e.delay)
+        return states.HandlerOutcome(final=False, exception=e, delay=e.delay, handler=handler)
 
     # Definitely a temporary error, regardless of the error strictness.
     except TemporaryError as e:
         logger.error(f"Handler {handler.id!r} failed temporarily: %s", str(e) or repr(e))
-        return states.HandlerOutcome(final=False, exception=e, delay=e.delay)
+        return states.HandlerOutcome(final=False, exception=e, delay=e.delay, handler=handler)
 
     # Same as permanent errors below, but with better logging for our internal cases.
     except HandlerTimeoutError as e:
         logger.error(f"%s", str(e) or repr(e))  # already formatted
-        return states.HandlerOutcome(final=True, exception=e)
+        return states.HandlerOutcome(final=True, exception=e, handler=handler)
         # TODO: report the handling failure somehow (beside logs/events). persistent status?
 
     # Definitely a permanent error, regardless of the error strictness.
     except PermanentError as e:
         logger.error(f"Handler {handler.id!r} failed permanently: %s", str(e) or repr(e))
-        return states.HandlerOutcome(final=True, exception=e)
+        return states.HandlerOutcome(final=True, exception=e, handler=handler)
         # TODO: report the handling failure somehow (beside logs/events). persistent status?
 
     # Regular errors behave as either temporary or permanent depending on the error strictness.
     except Exception as e:
         if errors_mode == errors.ErrorsMode.IGNORED:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will ignore.")
-            return states.HandlerOutcome(final=True)
+            return states.HandlerOutcome(final=True, handler=handler)
         elif errors_mode == errors.ErrorsMode.TEMPORARY:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will retry.")
-            return states.HandlerOutcome(final=False, exception=e, delay=backoff)
+            return states.HandlerOutcome(final=False, exception=e, delay=backoff, handler=handler)
         elif errors_mode == errors.ErrorsMode.PERMANENT:
             logger.exception(f"Handler {handler.id!r} failed with an exception. Will stop.")
-            return states.HandlerOutcome(final=True, exception=e)
+            return states.HandlerOutcome(final=True, exception=e, handler=handler)
             # TODO: report the handling failure somehow (beside logs/events). persistent status?
         else:
             raise RuntimeError(f"Unknown mode for errors: {errors_mode!r}")
@@ -331,7 +331,7 @@ async def execute_handler_once(
     # No errors means the handler should be excluded from future runs in this reaction cycle.
     else:
         logger.info(f"Handler {handler.id!r} succeeded.")
-        return states.HandlerOutcome(final=True, result=result)
+        return states.HandlerOutcome(final=True, result=result, handler=handler)
 
 
 async def invoke_handler(

--- a/kopf/reactor/states.py
+++ b/kopf/reactor/states.py
@@ -74,6 +74,7 @@ class HandlerOutcome:
     possibly after few executions, and consisting of simple data types
     (for YAML/JSON serialisation) rather than the actual in-memory objects.
     """
+    handler: handlers_.BaseHandler
     final: bool
     delay: Optional[float] = None
     result: Optional[callbacks.HandlerResult] = None
@@ -303,9 +304,16 @@ def deliver_results(
             pass
         elif isinstance(outcome.result, collections.abc.Mapping):
             # TODO: merge recursively (patch-merge), do not overwrite the keys if they are present.
-            patch.setdefault('status', {}).setdefault(handler_id, {}).update(outcome.result)
+            if hasattr(outcome.handler, 'status_prefix') and not outcome.handler.status_prefix:
+                base = patch.setdefault('status', {})
+            else:
+                base = patch.setdefault('status', {}).setdefault(handler_id, {})
+            base.update(outcome.result)
         else:
-            patch.setdefault('status', {})[handler_id] = copy.deepcopy(outcome.result)
+            if hasattr(outcome.handler, 'status_prefix') and not outcome.handler.status_prefix:
+                patch.setdefault('status', {})[copy.deepcopy(outcome.result)] = {}
+            else:
+                patch.setdefault('status', {})[handler_id] = copy.deepcopy(outcome.result)
 
 
 @overload

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -1,4 +1,5 @@
 from typing import Mapping
+from unittest.mock import Mock
 
 import freezegun
 import pytest
@@ -12,8 +13,13 @@ from kopf.reactor.registries import OperatorRegistry
 from kopf.reactor.states import HandlerOutcome
 
 
-def test_activity_error_exception():
-    outcome = HandlerOutcome(final=True)
+@pytest.fixture()
+def handler():
+    return Mock(id='some-id', spec_set=['id'])
+
+
+def test_activity_error_exception(handler):
+    outcome = HandlerOutcome(final=True, handler=handler)
     outcomes: Mapping[HandlerId, HandlerOutcome]
     outcomes = {HandlerId('id'): outcome}
     error = ActivityError("message", outcomes=outcomes)

--- a/tests/lifecycles/test_handler_selection.py
+++ b/tests/lifecycles/test_handler_selection.py
@@ -98,9 +98,9 @@ def test_asap_takes_the_least_retried(mocker):
 
     # Set the pre-existing state, and verify that it was set properly.
     state = State.from_scratch(handlers=[handler1, handler2, handler3])
-    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False)})
-    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False)})
-    state = state.with_outcomes({handler3.id: HandlerOutcome(final=False)})
+    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False, handler=handler1)})
+    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False, handler=handler2)})
+    state = state.with_outcomes({handler3.id: HandlerOutcome(final=False, handler=handler3)})
     assert state[handler1.id].retries == 2
     assert state[handler2.id].retries == 0
     assert state[handler3.id].retries == 1

--- a/tests/persistence/test_outcomes.py
+++ b/tests/persistence/test_outcomes.py
@@ -1,37 +1,50 @@
+from unittest.mock import Mock
+
+import pytest
+
 from kopf.reactor.callbacks import HandlerResult
 from kopf.reactor.states import HandlerOutcome
 
 
-def test_creation_for_ignored_handlers():
-    outcome = HandlerOutcome(final=True)
+@pytest.fixture()
+def handler():
+    return Mock(id='some-id', spec_set=['id'])
+
+
+def test_creation_for_ignored_handlers(handler):
+    outcome = HandlerOutcome(final=True, handler=handler)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is None
     assert outcome.exception is None
+    assert outcome.handler is handler
 
 
-def test_creation_for_results():
+def test_creation_for_results(handler):
     result = HandlerResult(object())
-    outcome = HandlerOutcome(final=True, result=result)
+    outcome = HandlerOutcome(final=True, result=result, handler=handler)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is result
     assert outcome.exception is None
+    assert outcome.handler is handler
 
 
-def test_creation_for_permanent_errors():
+def test_creation_for_permanent_errors(handler):
     error = Exception()
-    outcome = HandlerOutcome(final=True, exception=error)
+    outcome = HandlerOutcome(final=True, exception=error, handler=handler)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is None
     assert outcome.exception is error
+    assert outcome.handler is handler
 
 
-def test_creation_for_temporary_errors():
+def test_creation_for_temporary_errors(handler):
     error = Exception()
-    outcome = HandlerOutcome(final=False, exception=error, delay=123)
+    outcome = HandlerOutcome(final=False, exception=error, delay=123, handler=handler)
     assert not outcome.final
     assert outcome.delay == 123
     assert outcome.result is None
     assert outcome.exception is error
+    assert outcome.handler is handler

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -52,5 +52,5 @@ def parent_handler():
         errors=None, retries=None, timeout=None, backoff=None, cooldown=None,
         labels=None, annotations=None, when=None,
         initial=None, deleted=None, requires_finalizer=None,
-        reason=None, field=None,
+        reason=None, field=None, status_prefix=True
     )


### PR DESCRIPTION
## What do these changes do?

As proposed in issue #319, this introduces an optional ``status_prefix`` boolean that can be added to any resource handler definition.  If set to ``True`` (or omitted), status returned by the handler is still placed beneath the handler_id in the resulting object's status subresource.  If set to ``False``, the status returned by the handler is use at the top-level of the status subresource.

## Description

Fully implements the proposal in issue #319.

## Issues/PRs

> Issues: #319


## Type of changes

- New feature (non-breaking change which adds functionality)


## Checklist

- [ ] The code addresses only the mentioned problem, and this problem only
- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

