### PR TITLE
Allow for custom timeout in watch request

### DIFF
--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -201,7 +201,7 @@ async def watch_objs(
     # Talk to the API and initiate a streaming response.
     response = await context.session.get(
         url=resource.get_url(server=context.server, namespace=namespace, params=params),
-        timeout=aiohttp.ClientTimeout(total=None),
+        timeout=aiohttp.ClientTimeout(total=config.WatchersConfig.session_timeout),
     )
     response.raise_for_status()
 

--- a/kopf/config.py
+++ b/kopf/config.py
@@ -121,3 +121,6 @@ class WatchersConfig:
 
     watcher_retry_delay: float = 0.1
     """ How long should a pause be between watch requests (to prevent flooding). """
+
+    session_timeout: Optional[float] = None
+    """ The http session timeout to use in watch request. """


### PR DESCRIPTION
## What do these changes do?
allow to set a custom timeout when making the `GET ..?watch=true` request to Kubernetes API if needed.

<!-- Please give a short brief about these changes (1-3 sentences). -->


## Description

Currently the timeout is always None, which we find to be a reason for issues like #204 .
With this patch controller authors may override the timeout passed by kopf to the underlying aiohttp session request by doing something like this in their controller code:
```
import kopf

kopf.config.WatchersConfig.session_timeout = 10.0

@kopf.on(..)
def handler(*):
    ....
```
The default behavior is not changed.

## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

Issues: #204 


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] The code addresses only the mentioned problem, and this problem only
- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
