### PR TITLE
Prevent thread leakage on exiting

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -228,7 +228,7 @@ async def execute_handlers_once(
 
     # Filter and select the handlers to be executed right now, on this event reaction cycle.
     handlers_todo = [h for h in handlers if state[h.id].awakened]
-    handlers_plan = await invocation.invoke(lifecycle, handlers_todo, cause=cause, state=state)
+    handlers_plan = lifecycle(handlers_todo, **invocation.build_kwargs(cause=cause, state=state))
 
     # Execute all planned (selected) handlers in one event reaction cycle, even if there are few.
     outcomes: MutableMapping[handlers_.HandlerId, states.HandlerOutcome] = {}

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -602,7 +602,7 @@ def _matches_filter_callback(
 ) -> bool:
     if not handler.when:
         return True
-    return handler.when(**invocation.get_invoke_arguments(cause=cause))
+    return handler.when(**invocation.build_kwargs(cause=cause))
 
 
 _default_registry: Optional[OperatorRegistry] = None

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -426,7 +426,7 @@ async def _root_task_checker(
         logger.debug(f"Root task {name!r} is cancelled.")
         raise
     except Exception as e:
-        logger.error(f"Root task {name!r} is failed: %s", e)
+        logger.exception(f"Root task {name!r} is failed: %s", e)
         raise  # fail the process and its exit status
     else:
         logger.warning(f"Root task {name!r} is finished unexpectedly.")


### PR DESCRIPTION
## What do these changes do?

Prevent leakage of OS resources (threads) on operator existing, which can make it irresponsive after the main function is finished and no logging is happening (if a sync-handler hangs).

## Description

All sync-handlers (declared with `def`, not `async def`) are executed in thread pools. The operator itself is fully asynchronous. Whenever operator is exiting or is being cancelled, it also cancels all its coroutines. However, if a coroutine is cancelled at `loop.run_in_executor()`, the coroutine indeed exits, but the thread it used continues running — until finished. As a result, some threads can continue running even after the operator is kind-of-exited normally.

This becomes critical as long-running handlers are coming into play (i.e. daemons). But it is a change of its own value even now — hence, it is extracted for easier reviewing.

Instead, with this PR, the operator will wait for such threads to finish (potentially forever or until SIGKILL'ed, as Kubernetes does after 30s). And while waiting, it will log the status of the operator's tasks and what exactly it waits for. So, it becomes visible in the logs which handler hangs or prevents operator from exiting properly. In case everything exits instantly, there is nothing to wait, nothing to log, so it exits as usually.

**In addition,** the lifecycle functions (which select the handlers to be processed) are now called directly to avoid using thread pools. We know in advance that the lifecycle functions are safe and fast (instant), so there is no need to overcomplicate them.


## Issues/PRs

> Issues: #19 


## Type of changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
