### PR TITLE
Split handers & callbacks types for resource-related handlers

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -25,8 +25,9 @@ from kopf.structs import dicts
 from kopf.structs import filters
 from kopf.structs import resources
 
-ResourceHandlerDecorator = Callable[[callbacks.ResourceHandlerFn], callbacks.ResourceHandlerFn]
-ActivityHandlerDecorator = Callable[[callbacks.ActivityHandlerFn], callbacks.ActivityHandlerFn]
+ActivityDecorator = Callable[[callbacks.ActivityFn], callbacks.ActivityFn]
+ResourceWatchingDecorator = Callable[[callbacks.ResourceWatchingFn], callbacks.ResourceWatchingFn]
+ResourceChangingDecorator = Callable[[callbacks.ResourceChangingFn], callbacks.ResourceChangingFn]
 
 
 def startup(  # lgtm[py/similar-function]
@@ -38,8 +39,8 @@ def startup(  # lgtm[py/similar-function]
         backoff: Optional[float] = None,
         cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ActivityHandlerDecorator:
-    def decorator(fn: callbacks.ActivityHandlerFn) -> callbacks.ActivityHandlerFn:
+) -> ActivityDecorator:
+    def decorator(fn: callbacks.ActivityFn) -> callbacks.ActivityFn:
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
@@ -61,8 +62,8 @@ def cleanup(  # lgtm[py/similar-function]
         backoff: Optional[float] = None,
         cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ActivityHandlerDecorator:
-    def decorator(fn: callbacks.ActivityHandlerFn) -> callbacks.ActivityHandlerFn:
+) -> ActivityDecorator:
+    def decorator(fn: callbacks.ActivityFn) -> callbacks.ActivityFn:
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
@@ -84,9 +85,9 @@ def login(  # lgtm[py/similar-function]
         backoff: Optional[float] = None,
         cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ActivityHandlerDecorator:
+) -> ActivityDecorator:
     """ ``@kopf.on.login()`` handler for custom (re-)authentication. """
-    def decorator(fn: callbacks.ActivityHandlerFn) -> callbacks.ActivityHandlerFn:
+    def decorator(fn: callbacks.ActivityFn) -> callbacks.ActivityFn:
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
@@ -108,9 +109,9 @@ def probe(  # lgtm[py/similar-function]
         backoff: Optional[float] = None,
         cooldown: Optional[float] = None,  # deprecated, use `backoff`
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ActivityHandlerDecorator:
+) -> ActivityDecorator:
     """ ``@kopf.on.probe()`` handler for arbitrary liveness metrics. """
-    def decorator(fn: callbacks.ActivityHandlerFn) -> callbacks.ActivityHandlerFn:
+    def decorator(fn: callbacks.ActivityFn) -> callbacks.ActivityFn:
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
@@ -137,9 +138,9 @@ def resume(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> ResourceHandlerDecorator:
+) -> ResourceChangingDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
-    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceChangingFn) -> callbacks.ResourceChangingFn:
         _warn_deprecated_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
@@ -169,9 +170,9 @@ def create(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> ResourceHandlerDecorator:
+) -> ResourceChangingDecorator:
     """ ``@kopf.on.create()`` handler for the object creation. """
-    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceChangingFn) -> callbacks.ResourceChangingFn:
         _warn_deprecated_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
@@ -201,9 +202,9 @@ def update(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> ResourceHandlerDecorator:
+) -> ResourceChangingDecorator:
     """ ``@kopf.on.update()`` handler for the object update or change. """
-    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceChangingFn) -> callbacks.ResourceChangingFn:
         _warn_deprecated_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
@@ -234,9 +235,9 @@ def delete(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> ResourceHandlerDecorator:
+) -> ResourceChangingDecorator:
     """ ``@kopf.on.delete()`` handler for the object deletion. """
-    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceChangingFn) -> callbacks.ResourceChangingFn:
         _warn_deprecated_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
@@ -267,9 +268,9 @@ def field(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> ResourceHandlerDecorator:
+) -> ResourceChangingDecorator:
     """ ``@kopf.on.field()`` handler for the individual field changes. """
-    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceChangingFn) -> callbacks.ResourceChangingFn:
         _warn_deprecated_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
@@ -295,9 +296,9 @@ def event(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> ResourceHandlerDecorator:
+) -> ResourceWatchingDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
-    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceWatchingFn) -> callbacks.ResourceWatchingFn:
         _warn_deprecated_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
@@ -328,7 +329,7 @@ def this(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> ResourceHandlerDecorator:
+) -> ResourceChangingDecorator:
     """
     ``@kopf.on.this()`` decorator for the dynamically generated sub-handlers.
 
@@ -358,7 +359,7 @@ def this(  # lgtm[py/similar-function]
     Note: ``task=task`` is needed to freeze the closure variable, so that every
     create function will have its own value, not the latest in the for-cycle.
     """
-    def decorator(fn: callbacks.ResourceHandlerFn) -> callbacks.ResourceHandlerFn:
+    def decorator(fn: callbacks.ResourceChangingFn) -> callbacks.ResourceChangingFn:
         _warn_deprecated_filters(labels, annotations)
         parent_handler = handling.handler_var.get()
         real_registry = registry if registry is not None else handling.subregistry_var.get()
@@ -377,7 +378,7 @@ def this(  # lgtm[py/similar-function]
 
 
 def register(  # lgtm[py/similar-function]
-        fn: callbacks.ResourceHandlerFn,
+        fn: callbacks.ResourceChangingFn,
         *,
         id: Optional[str] = None,
         errors: Optional[errors_.ErrorsMode] = None,
@@ -389,7 +390,7 @@ def register(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> callbacks.ResourceHandlerFn:
+) -> callbacks.ResourceChangingFn:
     """
     Register a function as a sub-handler of the currently executed handler.
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -145,7 +145,7 @@ def resume(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
         real_id = registries.generate_id(fn=fn, id=id)
-        handler = handlers.ResourceHandler(
+        handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id, field=None,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
@@ -177,7 +177,7 @@ def create(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
         real_id = registries.generate_id(fn=fn, id=id)
-        handler = handlers.ResourceHandler(
+        handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id, field=None,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
@@ -209,7 +209,7 @@ def update(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
         real_id = registries.generate_id(fn=fn, id=id)
-        handler = handlers.ResourceHandler(
+        handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id, field=None,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
@@ -242,7 +242,7 @@ def delete(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
         real_id = registries.generate_id(fn=fn, id=id)
-        handler = handlers.ResourceHandler(
+        handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id, field=None,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
@@ -276,7 +276,7 @@ def field(  # lgtm[py/similar-function]
         real_resource = resources.Resource(group, version, plural)
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
-        handler = handlers.ResourceHandler(
+        handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id, field=real_field,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
@@ -303,12 +303,10 @@ def event(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
         real_id = registries.generate_id(fn=fn, id=id)
-        handler = handlers.ResourceHandler(
-            fn=fn, id=real_id, field=None,
+        handler = handlers.ResourceWatchingHandler(
+            fn=fn, id=real_id,
             errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
             labels=labels, annotations=annotations, when=when,
-            initial=None, deleted=None, requires_finalizer=None,
-            reason=None,
         )
         real_registry.resource_watching_handlers[real_resource].append(handler)
         return fn
@@ -365,7 +363,7 @@ def this(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else handling.subregistry_var.get()
         real_id = registries.generate_id(fn=fn, id=id,
                                          prefix=parent_handler.id if parent_handler else None)
-        handler = handlers.ResourceHandler(
+        handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id, field=None,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,

--- a/kopf/reactor/handlers.py
+++ b/kopf/reactor/handlers.py
@@ -1,6 +1,6 @@
 import dataclasses
 import warnings
-from typing import NewType, Callable, Optional, Any
+from typing import NewType, Callable, Optional, Union, Any
 
 from kopf.reactor import causation
 from kopf.reactor import errors as errors_
@@ -45,14 +45,14 @@ class BaseHandler:
 
 @dataclasses.dataclass
 class ActivityHandler(BaseHandler):
-    fn: callbacks.ActivityHandlerFn  # type clarification
+    fn: callbacks.ActivityFn  # type clarification
     activity: Optional[causation.Activity]
     _fallback: bool = False  # non-public!
 
 
 @dataclasses.dataclass
 class ResourceHandler(BaseHandler):
-    fn: callbacks.ResourceHandlerFn  # type clarification
+    fn: Union[callbacks.ResourceWatchingFn, callbacks.ResourceChangingFn]  # type clarification
     reason: Optional[causation.Reason]
     field: Optional[dicts.FieldPath]
     initial: Optional[bool]

--- a/kopf/reactor/handlers.py
+++ b/kopf/reactor/handlers.py
@@ -52,14 +52,23 @@ class ActivityHandler(BaseHandler):
 
 @dataclasses.dataclass
 class ResourceHandler(BaseHandler):
-    fn: Union[callbacks.ResourceWatchingFn, callbacks.ResourceChangingFn]  # type clarification
+    labels: Optional[filters.MetaFilter]
+    annotations: Optional[filters.MetaFilter]
+    when: Optional[callbacks.WhenFilterFn]
+
+
+@dataclasses.dataclass
+class ResourceWatchingHandler(ResourceHandler):
+    fn: callbacks.ResourceWatchingFn  # type clarification
+
+
+@dataclasses.dataclass
+class ResourceChangingHandler(ResourceHandler):
+    fn: callbacks.ResourceChangingFn  # type clarification
     reason: Optional[causation.Reason]
     field: Optional[dicts.FieldPath]
     initial: Optional[bool]
     deleted: Optional[bool]  # used for mixed-in (initial==True) @on.resume handlers only.
-    labels: Optional[filters.MetaFilter]
-    annotations: Optional[filters.MetaFilter]
-    when: Optional[callbacks.WhenFilterFn]
     requires_finalizer: Optional[bool]
 
     @property

--- a/kopf/reactor/handlers.py
+++ b/kopf/reactor/handlers.py
@@ -1,6 +1,6 @@
 import dataclasses
 import warnings
-from typing import NewType, Callable, Optional, Union, Any
+from typing import NewType, Optional, Any
 
 from kopf.reactor import causation
 from kopf.reactor import errors as errors_
@@ -20,7 +20,7 @@ HandlerId = NewType('HandlerId', str)
 @dataclasses.dataclass
 class BaseHandler:
     id: HandlerId
-    fn: Callable[..., Optional[callbacks.Result]]
+    fn: callbacks.BaseFn
     errors: Optional[errors_.ErrorsMode]
     timeout: Optional[float]
     retries: Optional[int]

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -71,7 +71,7 @@ cause_var: ContextVar[causation.BaseCause] = ContextVar('cause_var')
 
 async def execute(
         *,
-        fns: Optional[Iterable[invocation.Invokable]] = None,
+        fns: Optional[Iterable[callbacks.ResourceChangingFn]] = None,
         handlers: Optional[Iterable[handlers_.ResourceChangingHandler]] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -72,7 +72,7 @@ cause_var: ContextVar[causation.BaseCause] = ContextVar('cause_var')
 async def execute(
         *,
         fns: Optional[Iterable[invocation.Invokable]] = None,
-        handlers: Optional[Iterable[handlers_.ResourceHandler]] = None,
+        handlers: Optional[Iterable[handlers_.ResourceChangingHandler]] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
         cause: Optional[causation.BaseCause] = None,
@@ -107,7 +107,7 @@ async def execute(
         subregistry = registries.ResourceChangingRegistry()
         for id, fn in fns.items():
             real_id = registries.generate_id(fn=fn, id=id, prefix=parent_prefix)
-            handler = handlers_.ResourceHandler(
+            handler = handlers_.ResourceChangingHandler(
                 fn=fn, id=real_id,
                 errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
                 labels=None, annotations=None, when=None,
@@ -120,7 +120,7 @@ async def execute(
         subregistry = registries.ResourceChangingRegistry()
         for fn in fns:
             real_id = registries.generate_id(fn=fn, id=None, prefix=parent_prefix)
-            handler = handlers_.ResourceHandler(
+            handler = handlers_.ResourceChangingHandler(
                 fn=fn, id=real_id,
                 errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
                 labels=None, annotations=None, when=None,

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -21,8 +21,9 @@ else:
     asyncio_Future = asyncio.Future
 
 Invokable = Union[
-    callbacks.ActivityHandlerFn,
-    callbacks.ResourceHandlerFn,
+    callbacks.ActivityFn,
+    callbacks.ResourceWatchingFn,
+    callbacks.ResourceChangingFn,
 ]
 
 

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -9,7 +9,7 @@ import asyncio
 import contextlib
 import contextvars
 import functools
-from typing import Optional, Any, Union, List, Iterable, Iterator, Tuple, Dict, cast, TYPE_CHECKING
+from typing import Optional, Any, List, Iterable, Iterator, Tuple, Dict, cast, TYPE_CHECKING
 
 from kopf import config
 from kopf.reactor import causation
@@ -19,12 +19,6 @@ if TYPE_CHECKING:
     asyncio_Future = asyncio.Future[Any]
 else:
     asyncio_Future = asyncio.Future
-
-Invokable = Union[
-    callbacks.ActivityFn,
-    callbacks.ResourceWatchingFn,
-    callbacks.ResourceChangingFn,
-]
 
 
 @contextlib.contextmanager
@@ -97,7 +91,7 @@ def build_kwargs(
 
 
 async def invoke(
-        fn: Invokable,
+        fn: callbacks.BaseFn,
         *args: Any,
         cause: Optional[causation.BaseCause] = None,
         **kwargs: Any,
@@ -153,7 +147,7 @@ async def invoke(
 
 
 def is_async_fn(
-        fn: Optional[Invokable],
+        fn: Optional[callbacks.BaseFn],
 ) -> bool:
     if fn is None:
         return False

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -17,7 +17,7 @@ import functools
 import warnings
 from types import FunctionType, MethodType
 from typing import (Any, MutableMapping, Optional, Sequence, Collection, Iterable, Iterator,
-                    List, Set, FrozenSet, Mapping, Callable, cast, Generic, TypeVar)
+                    List, Set, FrozenSet, Mapping, Callable, cast, Generic, TypeVar, Union)
 
 from kopf.reactor import causation
 from kopf.reactor import errors as errors_
@@ -30,7 +30,11 @@ from kopf.structs import resources as resources_
 from kopf.utilities import piggybacking
 
 # We only type-check for known classes of handlers/callbacks, and ignore any custom subclasses.
-HandlerFnT = TypeVar('HandlerFnT', callbacks.ActivityHandlerFn, callbacks.ResourceHandlerFn)
+HandlerFnT = TypeVar('HandlerFnT',
+                     callbacks.ActivityFn,
+                     callbacks.ResourceWatchingFn,
+                     callbacks.ResourceChangingFn,
+                     Union[callbacks.ResourceWatchingFn, callbacks.ResourceChangingFn])  # DEPRECATED: for legacy_registries
 HandlerT = TypeVar('HandlerT', handlers.ActivityHandler, handlers.ResourceHandler)
 CauseT = TypeVar('CauseT', bound=causation.BaseCause)
 
@@ -50,12 +54,13 @@ class GenericRegistry(Generic[HandlerT, HandlerFnT]):
         self._handlers.append(handler)
 
 
-class ActivityRegistry(GenericRegistry[handlers.ActivityHandler, callbacks.ActivityHandlerFn]):
-    """ An actual registry of activity handlers. """
+class ActivityRegistry(GenericRegistry[
+        handlers.ActivityHandler,
+        callbacks.ActivityFn]):
 
     def register(
             self,
-            fn: callbacks.ActivityHandlerFn,
+            fn: callbacks.ActivityFn,
             *,
             id: Optional[str] = None,
             errors: Optional[errors_.ErrorsMode] = None,
@@ -65,7 +70,7 @@ class ActivityRegistry(GenericRegistry[handlers.ActivityHandler, callbacks.Activ
             cooldown: Optional[float] = None,  # deprecated, use `backoff`
             activity: Optional[causation.Activity] = None,
             _fallback: bool = False,
-    ) -> callbacks.ActivityHandlerFn:
+    ) -> callbacks.ActivityFn:
         warnings.warn("registry.register() is deprecated; "
                       "use @kopf.on... decorators with registry= kwarg.",
                       DeprecationWarning)
@@ -103,47 +108,9 @@ class ActivityRegistry(GenericRegistry[handlers.ActivityHandler, callbacks.Activ
                     yield handler
 
 
-class ResourceRegistry(GenericRegistry[handlers.ResourceHandler, callbacks.ResourceHandlerFn], Generic[CauseT]):
-    """ An actual registry of resource handlers. """
-
-    def register(
-            self,
-            fn: callbacks.ResourceHandlerFn,
-            *,
-            id: Optional[str] = None,
-            reason: Optional[causation.Reason] = None,
-            event: Optional[str] = None,  # deprecated, use `reason`
-            field: Optional[dicts.FieldSpec] = None,
-            errors: Optional[errors_.ErrorsMode] = None,
-            timeout: Optional[float] = None,
-            retries: Optional[int] = None,
-            backoff: Optional[float] = None,
-            cooldown: Optional[float] = None,  # deprecated, use `backoff`
-            initial: Optional[bool] = None,
-            deleted: Optional[bool] = None,
-            requires_finalizer: bool = False,
-            labels: Optional[filters.MetaFilter] = None,
-            annotations: Optional[filters.MetaFilter] = None,
-            when: Optional[callbacks.WhenFilterFn] = None,
-    ) -> callbacks.ResourceHandlerFn:
-        warnings.warn("registry.register() is deprecated; "
-                      "use @kopf.on... decorators with registry= kwarg.",
-                      DeprecationWarning)
-
-        if reason is None and event is not None:
-            reason = causation.Reason(event)
-
-        real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
-        real_id = generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
-        handler = handlers.ResourceHandler(
-            id=real_id, fn=fn, reason=reason, field=real_field,
-            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
-            labels=labels, annotations=annotations, when=when,
-        )
-
-        self.append(handler)
-        return fn
+class ResourceRegistry(
+    Generic[CauseT, HandlerFnT],
+    GenericRegistry[handlers.ResourceHandler, HandlerFnT]):
 
     def get_handlers(
             self,
@@ -185,7 +152,37 @@ class ResourceRegistry(GenericRegistry[handlers.ResourceHandler, callbacks.Resou
         return False
 
 
-class ResourceWatchingRegistry(ResourceRegistry[causation.ResourceWatchingCause]):
+class ResourceWatchingRegistry(ResourceRegistry[
+        causation.ResourceWatchingCause,
+        callbacks.ResourceWatchingFn]):
+
+    def register(
+            self,
+            fn: callbacks.ResourceWatchingFn,
+            *,
+            id: Optional[str] = None,
+            errors: Optional[errors_.ErrorsMode] = None,
+            timeout: Optional[float] = None,
+            retries: Optional[int] = None,
+            backoff: Optional[float] = None,
+            cooldown: Optional[float] = None,  # deprecated, use `backoff`
+            labels: Optional[filters.MetaFilter] = None,
+            annotations: Optional[filters.MetaFilter] = None,
+            when: Optional[callbacks.WhenFilterFn] = None,
+    ) -> callbacks.ResourceWatchingFn:
+        warnings.warn("registry.register() is deprecated; "
+                      "use @kopf.on... decorators with registry= kwarg.",
+                      DeprecationWarning)
+
+        real_id = generate_id(fn=fn, id=id)
+        handler = handlers.ResourceHandler(
+            id=real_id, fn=fn, reason=None, field=None,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
+            initial=None, deleted=None, requires_finalizer=None,
+            labels=labels, annotations=annotations, when=when,
+        )
+        self.append(handler)
+        return fn
 
     def iter_handlers(
             self,
@@ -196,7 +193,48 @@ class ResourceWatchingRegistry(ResourceRegistry[causation.ResourceWatchingCause]
                 yield handler
 
 
-class ResourceChangingRegistry(ResourceRegistry[causation.ResourceChangingCause]):
+class ResourceChangingRegistry(ResourceRegistry[
+        causation.ResourceChangingCause,
+        callbacks.ResourceChangingFn]):
+
+    def register(
+            self,
+            fn: callbacks.ResourceChangingFn,
+            *,
+            id: Optional[str] = None,
+            reason: Optional[causation.Reason] = None,
+            event: Optional[str] = None,  # deprecated, use `reason`
+            field: Optional[dicts.FieldSpec] = None,
+            errors: Optional[errors_.ErrorsMode] = None,
+            timeout: Optional[float] = None,
+            retries: Optional[int] = None,
+            backoff: Optional[float] = None,
+            cooldown: Optional[float] = None,  # deprecated, use `backoff`
+            initial: Optional[bool] = None,
+            deleted: Optional[bool] = None,
+            requires_finalizer: bool = False,
+            labels: Optional[filters.MetaFilter] = None,
+            annotations: Optional[filters.MetaFilter] = None,
+            when: Optional[callbacks.WhenFilterFn] = None,
+    ) -> callbacks.ResourceChangingFn:
+        warnings.warn("registry.register() is deprecated; "
+                      "use @kopf.on... decorators with registry= kwarg.",
+                      DeprecationWarning)
+
+        if reason is None and event is not None:
+            reason = causation.Reason(event)
+
+        real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
+        real_id = generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
+        handler = handlers.ResourceHandler(
+            id=real_id, fn=fn, reason=reason, field=real_field,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
+            initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
+            labels=labels, annotations=annotations, when=when,
+        )
+
+        self.append(handler)
+        return fn
 
     def iter_handlers(
             self,
@@ -242,7 +280,7 @@ class OperatorRegistry:
 
     def register_activity_handler(
             self,
-            fn: callbacks.ActivityHandlerFn,
+            fn: callbacks.ActivityFn,
             *,
             id: Optional[str] = None,
             errors: Optional[errors_.ErrorsMode] = None,
@@ -252,7 +290,7 @@ class OperatorRegistry:
             cooldown: Optional[float] = None,  # deprecated, use `backoff`
             activity: Optional[causation.Activity] = None,
             _fallback: bool = False,
-    ) -> callbacks.ActivityHandlerFn:
+    ) -> callbacks.ActivityFn:
         warnings.warn("registry.register_activity_handler() is deprecated; "
                       "use @kopf.on... decorators with registry= kwarg.",
                       DeprecationWarning)
@@ -267,12 +305,12 @@ class OperatorRegistry:
             group: str,
             version: str,
             plural: str,
-            fn: callbacks.ResourceHandlerFn,
+            fn: callbacks.ResourceWatchingFn,
             id: Optional[str] = None,
             labels: Optional[filters.MetaFilter] = None,
             annotations: Optional[filters.MetaFilter] = None,
             when: Optional[callbacks.WhenFilterFn] = None,
-    ) -> callbacks.ResourceHandlerFn:
+    ) -> callbacks.ResourceWatchingFn:
         """
         Register an additional handler function for low-level events.
         """
@@ -290,7 +328,7 @@ class OperatorRegistry:
             group: str,
             version: str,
             plural: str,
-            fn: callbacks.ResourceHandlerFn,
+            fn: callbacks.ResourceChangingFn,
             id: Optional[str] = None,
             reason: Optional[causation.Reason] = None,
             event: Optional[str] = None,  # deprecated, use `reason`
@@ -306,7 +344,7 @@ class OperatorRegistry:
             labels: Optional[filters.MetaFilter] = None,
             annotations: Optional[filters.MetaFilter] = None,
             when: Optional[callbacks.WhenFilterFn] = None,
-    ) -> callbacks.ResourceHandlerFn:
+    ) -> callbacks.ResourceChangingFn:
         """
         Register an additional handler function for the specific resource and specific reason.
         """
@@ -453,7 +491,7 @@ class SmartOperatorRegistry(OperatorRegistry):
         else:
             self.activity_handlers.append(handlers.ActivityHandler(
                 id=handlers.HandlerId('login_via_pykube'),
-                fn=cast(callbacks.ActivityHandlerFn, piggybacking.login_via_pykube),
+                fn=cast(callbacks.ActivityFn, piggybacking.login_via_pykube),
                 activity=causation.Activity.AUTHENTICATION,
                 errors=errors_.ErrorsMode.IGNORED,
                 timeout=None, retries=None, backoff=None, cooldown=None,
@@ -466,7 +504,7 @@ class SmartOperatorRegistry(OperatorRegistry):
         else:
             self.activity_handlers.append(handlers.ActivityHandler(
                 id=handlers.HandlerId('login_via_client'),
-                fn=cast(callbacks.ActivityHandlerFn, piggybacking.login_via_client),
+                fn=cast(callbacks.ActivityFn, piggybacking.login_via_client),
                 activity=causation.Activity.AUTHENTICATION,
                 errors=errors_.ErrorsMode.IGNORED,
                 timeout=None, retries=None, backoff=None, cooldown=None,

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -18,7 +18,7 @@ from kopf.structs import patches
 Result = NewType('Result', object)
 
 
-class ActivityHandlerFn(Protocol):
+class ActivityFn(Protocol):
     def __call__(  # lgtm[py/similar-function]
             self,
             *args: Any,
@@ -27,12 +27,30 @@ class ActivityHandlerFn(Protocol):
     ) -> Optional[Result]: ...
 
 
-class ResourceHandlerFn(Protocol):
+class ResourceWatchingFn(Protocol):
     def __call__(  # lgtm[py/similar-function]
             self,
             *args: Any,
             type: str,
-            event: Union[str, bodies.RawEvent],
+            event: bodies.RawEvent,
+            body: bodies.Body,
+            meta: bodies.Meta,
+            spec: bodies.Spec,
+            status: bodies.Status,
+            uid: str,
+            name: str,
+            namespace: Optional[str],
+            patch: patches.Patch,
+            logger: Union[logging.Logger, logging.LoggerAdapter],
+            **kwargs: Any,
+    ) -> Optional[Result]: ...
+
+
+class ResourceChangingFn(Protocol):
+    def __call__(  # lgtm[py/similar-function]
+            self,
+            *args: Any,
+            event: str,  # DEPRECATED
             body: bodies.Body,
             meta: bodies.Meta,
             spec: bodies.Spec,

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -7,17 +7,31 @@ with an incompatible class hierarchy and method signatures.
 """
 import abc
 import warnings
-from typing import Any, Union, Sequence, Iterator
+from typing import Any, Union, Sequence, Iterator, Optional
 
 from kopf.reactor import causation
+from kopf.reactor import errors as errors_
 from kopf.reactor import handlers
 from kopf.reactor import registries
 from kopf.structs import bodies
 from kopf.structs import callbacks
+from kopf.structs import dicts
+from kopf.structs import filters
 from kopf.structs import patches
 from kopf.structs import resources as resources_
 
 AnyCause = Union[causation.ResourceWatchingCause, causation.ResourceChangingCause]
+AnyHandler = Union[handlers.ResourceWatchingHandler, handlers.ResourceChangingHandler]
+AnyHandlerFn = Union[callbacks.ResourceWatchingFn, callbacks.ResourceChangingFn]
+
+
+# A frankenclass to match both watching- & changing handlers for signatures & typing.
+# An equivalent of the all-purpose ResourceHandler before it was split to specialised sub-classes.
+class LegacyAllPurposeResourcerHandler(
+    handlers.ResourceChangingHandler,
+    handlers.ResourceWatchingHandler,
+):
+    fn: AnyHandlerFn  # type: ignore
 
 
 class BaseRegistry(metaclass=abc.ABCMeta):
@@ -32,14 +46,14 @@ class BaseRegistry(metaclass=abc.ABCMeta):
             self,
             resource: resources_.Resource,
             event: bodies.RawEvent,
-    ) -> Sequence[handlers.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceWatchingHandler]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def get_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Sequence[handlers.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceChangingHandler]:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -47,40 +61,79 @@ class BaseRegistry(metaclass=abc.ABCMeta):
             self,
             resource: resources_.Resource,
             event: bodies.RawEvent,
-    ) -> Iterator[handlers.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceWatchingHandler]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def iter_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Iterator[handlers.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceChangingHandler]:
         raise NotImplementedError
 
 
 class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
         AnyCause,
-        Union[callbacks.ResourceWatchingFn, callbacks.ResourceChangingFn],
-        handlers.ResourceHandler]):
+        AnyHandlerFn,
+        AnyHandler]):
     """
     .. deprecated: 1.0
 
         Replaced with `ResourceWatchingRegistry` and `ResourceChangingRegistry`.
     """
 
+    def register(
+            self,
+            fn: AnyHandlerFn,
+            *,
+            id: Optional[str] = None,
+            reason: Optional[causation.Reason] = None,
+            event: Optional[str] = None,  # deprecated, use `reason`
+            field: Optional[dicts.FieldSpec] = None,
+            errors: Optional[errors_.ErrorsMode] = None,
+            timeout: Optional[float] = None,
+            retries: Optional[int] = None,
+            backoff: Optional[float] = None,
+            cooldown: Optional[float] = None,  # deprecated, use `backoff`
+            initial: Optional[bool] = None,
+            deleted: Optional[bool] = None,
+            requires_finalizer: bool = False,
+            labels: Optional[filters.MetaFilter] = None,
+            annotations: Optional[filters.MetaFilter] = None,
+            when: Optional[callbacks.WhenFilterFn] = None,
+    ) -> AnyHandlerFn:
+        warnings.warn("registry.register() is deprecated; "
+                      "use @kopf.on... decorators with registry= kwarg.",
+                      DeprecationWarning)
+
+        if reason is None and event is not None:
+            reason = causation.Reason(event)
+
+        real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
+        real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
+        handler = LegacyAllPurposeResourcerHandler(
+            id=real_id, fn=fn,  # type: ignore
+            reason=reason, field=real_field,
+            errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
+            initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
+            labels=labels, annotations=annotations, when=when,
+        )
+        self.append(handler)
+        return fn
+
     # A dummy to avoid ABCMeta restrictions, and for rudimentary class testing.
     # Yield/return everything unconditionally -- it was not used previously anyway.
     def iter_handlers(
             self,
             cause: AnyCause,
-    ) -> Iterator[handlers.ResourceHandler]:
+    ) -> Iterator[AnyHandler]:
         yield from self._handlers
 
     def get_event_handlers(
             self,
             resource: resources_.Resource,
             event: bodies.RawEvent,
-    ) -> Sequence[handlers.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceWatchingHandler]:
         warnings.warn("SimpleRegistry.get_event_handlers() is deprecated; use "
                       "ResourceWatchingRegistry.get_handlers().", DeprecationWarning)
         return list(registries._deduplicated(self.iter_event_handlers(
@@ -89,7 +142,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
     def get_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Sequence[handlers.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceChangingHandler]:
         warnings.warn("SimpleRegistry.get_cause_handlers() is deprecated; use "
                       "ResourceChangingRegistry.get_handlers().", DeprecationWarning)
         return list(registries._deduplicated(self.iter_cause_handlers(cause=cause)))
@@ -98,25 +151,29 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
             self,
             resource: resources_.Resource,
             event: bodies.RawEvent,
-    ) -> Iterator[handlers.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceWatchingHandler]:
         warnings.warn("SimpleRegistry.iter_event_handlers() is deprecated; use "
                       "ResourceWatchingRegistry.iter_handlers().", DeprecationWarning)
 
         cause = _create_watching_cause(resource, event)
         for handler in self._handlers:
-            if registries.match(handler=handler, cause=cause, ignore_fields=True):
+            if not isinstance(handler, handlers.ResourceWatchingHandler):
+                pass
+            elif registries.match(handler=handler, cause=cause, ignore_fields=True):
                 yield handler
 
     def iter_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Iterator[handlers.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceChangingHandler]:
         warnings.warn("SimpleRegistry.iter_cause_handlers() is deprecated; use "
                       "ResourceChangingRegistry.iter_handlers().", DeprecationWarning)
 
         changed_fields = frozenset(field for _, field, _, _ in cause.diff or [])
         for handler in self._handlers:
-            if handler.reason is None or handler.reason == cause.reason:
+            if not isinstance(handler, handlers.ResourceChangingHandler):
+                pass
+            elif handler.reason is None or handler.reason == cause.reason:
                 if handler.initial and not cause.initial:
                     pass  # ignore initial handlers in non-initial causes.
                 elif registries.match(handler=handler, cause=cause,
@@ -155,7 +212,7 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
             self,
             resource: resources_.Resource,
             event: bodies.RawEvent,
-    ) -> Sequence[handlers.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceWatchingHandler]:
         warnings.warn("GlobalRegistry.get_event_handlers() is deprecated; use "
                       "OperatorRegistry.get_resource_watching_handlers().", DeprecationWarning)
         cause = _create_watching_cause(resource=resource, event=event)
@@ -164,7 +221,7 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
     def get_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Sequence[handlers.ResourceHandler]:
+    ) -> Sequence[handlers.ResourceChangingHandler]:
         warnings.warn("GlobalRegistry.get_cause_handlers() is deprecated; use "
                       "OperatorRegistry.get_resource_changing_handlers().", DeprecationWarning)
         return self.get_resource_changing_handlers(cause=cause)
@@ -173,7 +230,7 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
             self,
             resource: resources_.Resource,
             event: bodies.RawEvent,
-    ) -> Iterator[handlers.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceWatchingHandler]:
         warnings.warn("GlobalRegistry.iter_event_handlers() is deprecated; use "
                       "OperatorRegistry.iter_resource_watching_handlers().", DeprecationWarning)
         cause = _create_watching_cause(resource=resource, event=event)
@@ -182,7 +239,7 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
     def iter_cause_handlers(
             self,
             cause: causation.ResourceChangingCause,
-    ) -> Iterator[handlers.ResourceHandler]:
+    ) -> Iterator[handlers.ResourceChangingHandler]:
         warnings.warn("GlobalRegistry.iter_cause_handlers() is deprecated; use "
                       "OperatorRegistry.iter_resource_changing_handlers().", DeprecationWarning)
         yield from self.iter_resource_changing_handlers(cause=cause)

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -13,6 +13,7 @@ from kopf.reactor import causation
 from kopf.reactor import handlers
 from kopf.reactor import registries
 from kopf.structs import bodies
+from kopf.structs import callbacks
 from kopf.structs import patches
 from kopf.structs import resources as resources_
 
@@ -57,7 +58,9 @@ class BaseRegistry(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
-class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[AnyCause]):
+class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
+        AnyCause,
+        Union[callbacks.ResourceWatchingFn, callbacks.ResourceChangingFn]]):
     """
     .. deprecated: 1.0
 

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -60,7 +60,8 @@ class BaseRegistry(metaclass=abc.ABCMeta):
 
 class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
         AnyCause,
-        Union[callbacks.ResourceWatchingFn, callbacks.ResourceChangingFn]]):
+        Union[callbacks.ResourceWatchingFn, callbacks.ResourceChangingFn],
+        handlers.ResourceHandler]):
     """
     .. deprecated: 1.0
 

--- a/tests/basic-structs/test_handlers.py
+++ b/tests/basic-structs/test_handlers.py
@@ -1,9 +1,9 @@
 import pytest
 
-from kopf.reactor.handlers import ActivityHandler, ResourceHandler
+from kopf.reactor.handlers import ActivityHandler, ResourceChangingHandler
 
 
-@pytest.mark.parametrize('cls', [ActivityHandler, ResourceHandler])
+@pytest.mark.parametrize('cls', [ActivityHandler, ResourceChangingHandler])
 def test_handler_with_no_args(cls):
     with pytest.raises(TypeError):
         cls()
@@ -51,7 +51,7 @@ def test_resource_handler_with_all_args(mocker):
     annotations = mocker.Mock()
     when = mocker.Mock()
     requires_finalizer = mocker.Mock()
-    handler = ResourceHandler(
+    handler = ResourceChangingHandler(
         fn=fn,
         id=id,
         reason=reason,

--- a/tests/basic-structs/test_handlers_deprecated_cooldown.py
+++ b/tests/basic-structs/test_handlers_deprecated_cooldown.py
@@ -1,7 +1,7 @@
 # Original test-file: tests/basic-structs/test_handlers.py
 import pytest
 
-from kopf.reactor.handlers import ActivityHandler, ResourceHandler
+from kopf.reactor.handlers import ActivityHandler, ResourceChangingHandler
 
 
 def test_activity_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
@@ -54,7 +54,7 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     requires_finalizer = mocker.Mock()
 
     with pytest.deprecated_call(match=r"use backoff="):
-        handler = ResourceHandler(
+        handler = ResourceChangingHandler(
             fn=fn,
             id=id,
             reason=reason,

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -5,7 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS
-from kopf.reactor.handlers import ResourceHandler
+from kopf.reactor.handlers import ResourceChangingHandler
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.lastseen import LAST_SEEN_ANNOTATION
@@ -22,7 +22,7 @@ async def test_skipped_with_no_handlers(
     cause_mock.reason = cause_type
 
     assert not registry.resource_changing_handlers[resource]  # prerequisite
-    registry.resource_changing_handlers[resource].append(ResourceHandler(
+    registry.resource_changing_handlers[resource].append(ResourceChangingHandler(
         reason='a-non-existent-cause-type',
         fn=lambda **_: None, id='id',
         errors=None, timeout=None, retries=None, backoff=None, cooldown=None,

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -4,7 +4,7 @@ from kopf import ActivityRegistry
 from kopf import OperatorRegistry
 from kopf import ResourceWatchingRegistry, ResourceChangingRegistry
 from kopf import SimpleRegistry, GlobalRegistry  # deprecated, but tested
-from kopf.reactor.handlers import HandlerId, ResourceHandler
+from kopf.reactor.handlers import HandlerId, ResourceChangingHandler
 
 
 @pytest.fixture(params=[
@@ -47,7 +47,7 @@ def parent_handler():
     def parent_fn(**_):
         pass
 
-    return ResourceHandler(
+    return ResourceChangingHandler(
         fn=parent_fn, id=HandlerId('parent_fn'),
         errors=None, retries=None, timeout=None, backoff=None, cooldown=None,
         labels=None, annotations=None, when=None,

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -5,7 +5,7 @@ import pytest
 import kopf
 from kopf import OperatorRegistry
 from kopf.reactor.causation import ResourceChangingCause, Reason, ALL_REASONS
-from kopf.reactor.handlers import ResourceHandler
+from kopf.reactor.handlers import ResourceChangingHandler
 from kopf.structs.bodies import Body
 from kopf.structs.dicts import parse_field
 from kopf.structs.filters import MetaFilterToken
@@ -54,7 +54,7 @@ def registry():
 @pytest.fixture()
 def handler_factory(registry, resource):
     def factory(**kwargs):
-        handler = ResourceHandler(**dict(dict(
+        handler = ResourceChangingHandler(**dict(dict(
             fn=some_fn, id='a',
             errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
             initial=None, deleted=None, requires_finalizer=None,


### PR DESCRIPTION
## What do these changes do?

Move the code around and rename some types & classes for callbacks & handlers.
No user-facing changes.

## Description

This is the last preparing PR before the daemons & timers PR (#330).

Here, we just move the code around and rename classes. It would be messy to have these in the daemons & timers PR, so it goes separately.

Specifically, the resource-related handlers are split into resource-changing & resource-watching — same as it is already done for registries. These handlers & callbacks are de factor different anyway, but were declared as the same for laziness reasons. In the daemons & timers PR, also resource-spawning handlers & daemon/timer callbacks will be added with their own signatures.

No behavioural changes, no user-facing changes.


## Issues/PRs

> Issues: #19 


## Type of changes

- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
