### PR TITLE
Install conntrack to pass CI/CD with K8s 1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ matrix:
   allow_failures:
     - python: "3.9-dev"
 
+before_install:
+  - sudo apt-get update -y
+  - sudo apt-get install -y conntrack  # see #334
+
 before_script:
   - tools/minikube-for-travis.sh
   - tools/kubernetes-client.sh


### PR DESCRIPTION
## What do these changes do?

Fix the CI/CD tests with Kubernetes 1.18, which now requires `conntrack`.

## Description

Since Kubernetes 1.18 release ([since 25.03.2020](https://kubernetes.io/blog/2020/03/25/kubernetes-1-18-release-announcement/)), the CI/CD tests are broken:

```
error execution phase preflight: [preflight] Some fatal errors occurred:
	[ERROR FileExisting-conntrack]: conntrack not found in system path
```

This PR fixes it.

## Issues/PRs


> Issues:  fixes #334 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)
- Mostly CI/CD automation, contribution experience


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
