### PR TITLE
Add a warning if patch doesn't succeed

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ For the detailed information on who did what, see [GitHub Contributors](https://
 - [Daniel Middlecote](https://github.com/dlmiddlecote)
 - [Henning Jacobs](https://github.com/hjacobs)
 - [Ismail Kaboubi](https://github.com/smileisak)
+- [Michael Narodovitch](https://github.com/michaelnarodovitch)
 - [Sergey Vasilyev](https://github.com/nolar)
 - [Soroosh Sarabadani](https://github.com/psycho-ir)
 - [Trond Hindenes](https://github.com/trondhindenes)

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -29,7 +29,8 @@ from kopf.reactor import lifecycles
 from kopf.reactor import registries
 from kopf.storage import finalizers
 from kopf.storage import states
-from kopf.structs import bodies, dicts
+from kopf.structs import bodies
+from kopf.structs import dicts
 from kopf.structs import configuration
 from kopf.structs import containers
 from kopf.structs import diffs
@@ -129,11 +130,13 @@ async def process_resource_event(
     deletion_is_ongoing = finalizers.is_deletion_ongoing(body=body)
     deletion_is_blocked = finalizers.is_deletion_blocked(body=body)
     deletion_must_be_blocked = (
-        (resource_spawning_cause is not None and
-         registry.resource_spawning_handlers[resource].requires_finalizer(resource_spawning_cause))
-        or
-        (resource_changing_cause is not None and
-         registry.resource_changing_handlers[resource].requires_finalizer(resource_changing_cause)))
+            (resource_spawning_cause is not None and
+             registry.resource_spawning_handlers[resource].requires_finalizer(
+                 resource_spawning_cause))
+            or
+            (resource_changing_cause is not None and
+             registry.resource_changing_handlers[resource].requires_finalizer(
+                 resource_changing_cause)))
 
     if deletion_must_be_blocked and not deletion_is_blocked and not deletion_is_ongoing:
         logger.debug("Adding the finalizer, thus preventing the actual deletion.")

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -16,7 +16,6 @@ and therefore do not trigger the user-defined handlers.
 import asyncio
 import datetime
 import time
-
 from typing import Collection, Optional, Dict, Any, List
 
 from kopf.clients import patching
@@ -131,11 +130,11 @@ async def process_resource_event(
     deletion_is_ongoing = finalizers.is_deletion_ongoing(body=body)
     deletion_is_blocked = finalizers.is_deletion_blocked(body=body)
     deletion_must_be_blocked = (
-            (resource_spawning_cause is not None and
-             registry.resource_spawning_handlers[resource].requires_finalizer(resource_spawning_cause))
-            or
-            (resource_changing_cause is not None and
-             registry.resource_changing_handlers[resource].requires_finalizer(resource_changing_cause)))
+        (resource_spawning_cause is not None and
+         registry.resource_spawning_handlers[resource].requires_finalizer(resource_spawning_cause))
+        or
+        (resource_changing_cause is not None and
+         registry.resource_changing_handlers[resource].requires_finalizer(resource_changing_cause)))
 
     if deletion_must_be_blocked and not deletion_is_blocked and not deletion_is_ongoing:
         logger.debug("Adding the finalizer, thus preventing the actual deletion.")

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -194,6 +194,33 @@ def walk(
         yield objs  # NB: not a mapping, no nested sub-fields.
 
 
+def flatten(
+        obj: Optional[Mapping],
+) -> Iterator[Tuple[FieldPath, Union[str, int, float, List]]]:
+    """
+    Iterate over all literal and Array type fields of a JSON object.
+
+    For the output, it yields the path and the value in a flat iterable suitable for::
+
+        for path, value in walk(objs):
+            pass
+    """
+
+    if not obj:
+        return
+    
+    def _flatten(obj, root=[]):
+        if isinstance(obj, collections.abc.Mapping):
+            for key, value in obj.items():
+                leaf = root.copy()
+                leaf.append(key)
+                yield from _flatten(value, root=leaf)
+        else:
+            yield root, obj
+
+    yield from _flatten(obj)
+
+
 class MappingView(Generic[_K, _V], Mapping[_K, _V]):
     """
     A lazy resolver for the "on-demand" dict keys.

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -202,7 +202,7 @@ def flatten(
 
     For the output, it yields the path and the value in a flat iterable suitable for::
 
-        for path, value in walk(objs):
+        for path, value in flatten(objs):
             pass
     """
 

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -195,8 +195,8 @@ def walk(
 
 
 def flatten(
-        obj: Optional[Mapping],
-) -> Iterator[Tuple[FieldPath, Union[str, int, float, List]]]:
+        obj: Optional[Mapping[str, Any]],
+) -> Iterator[Any]:
     """
     Iterate over all literal and Array type fields of a JSON object.
 
@@ -208,15 +208,17 @@ def flatten(
 
     if not obj:
         return
-    
-    def _flatten(obj, root=[]):
-        if isinstance(obj, collections.abc.Mapping):
-            for key, value in obj.items():
+
+    def _flatten(
+            obj_: Any, root: List[str] = []
+    ) -> Union[Iterator[Tuple[FieldPath, Any]], Tuple[FieldPath, Any]]:
+        if isinstance(obj_, collections.abc.Mapping):
+            for key, value in obj_.items():
                 leaf = root.copy()
                 leaf.append(key)
                 yield from _flatten(value, root=leaf)
         else:
-            yield root, obj
+            yield root, obj_
 
     yield from _flatten(obj)
 

--- a/tests/dicts/test_flattening.py
+++ b/tests/dicts/test_flattening.py
@@ -3,7 +3,7 @@ import pytest
 from kopf.structs import dicts
 
 
-@pytest.mark.parametrize('obj,paths', [
+@pytest.mark.parametrize('obj,expected', [
     pytest.param({'k1': {'k2': {'k3': 'leaf'}}},
                  [(['k1', 'k2', 'k3'], 'leaf')]),
     pytest.param({'k1': {'k2': {'k3': 1, 'l3': 1.2}}},
@@ -12,5 +12,5 @@ from kopf.structs import dicts
                  [(['k1'], 'leaf'), (['l3', 'k3'], None)]),
     pytest.param(None, []),
 ])
-def test_flattening(obj, paths):
-    assert sorted(list(dicts.flatten(obj))) == sorted(paths)
+def test_flattening(obj, expected):
+    assert sorted(list(dicts.flatten(obj))) == sorted(expected)

--- a/tests/dicts/test_flattening.py
+++ b/tests/dicts/test_flattening.py
@@ -1,0 +1,16 @@
+import pytest
+
+from kopf.structs import dicts
+
+
+@pytest.mark.parametrize('obj,paths', [
+    pytest.param({'k1': {'k2': {'k3': 'leaf'}}},
+                 [(['k1', 'k2', 'k3'], 'leaf')]),
+    pytest.param({'k1': {'k2': {'k3': 1, 'l3': 1.2}}},
+                 [(['k1', 'k2', 'k3'], 1), (['k1', 'k2', 'l3'], 1.2)]),
+    pytest.param({'k1': 'leaf', 'l3': {'k3': None}},
+                 [(['k1'], 'leaf'), (['l3', 'k3'], None)]),
+    pytest.param(None, []),
+])
+def test_flattening(obj, paths):
+    assert sorted(list(dicts.flatten(obj))) == sorted(paths)

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -54,7 +54,7 @@ class K8sMocks:
 def k8s_mocked(mocker, resp_mocker):
     # We mock on the level of our own K8s API wrappers, not the K8s client.
     return K8sMocks(
-        patch_obj=mocker.patch('kopf.clients.patching.patch_obj'),
+        patch_obj=mocker.patch('kopf.clients.patching.patch_obj', return_value=None),
         post_event=mocker.patch('kopf.clients.events.post_event'),
         sleep_or_wait=mocker.patch('kopf.engines.sleeping.sleep_or_wait', return_value=None),
     )

--- a/tests/reactor/conftest.py
+++ b/tests/reactor/conftest.py
@@ -37,6 +37,10 @@ def watcher_limited(mocker):
     """ Make event streaming finite, watcher exits after depletion. """
     mocker.patch('kopf.clients.watching.infinite_watch', new=streaming_watch)
 
+@pytest.fixture()
+def patcher_mock(mocker):
+    """ Mock of the patcher client"""
+    return mocker.patch('kopf.clients.patching.patch_obj', )
 
 @pytest.fixture()
 def watcher_in_background(settings, resource, event_loop, worker_spy, stream):

--- a/tests/reactor/test_processing.py
+++ b/tests/reactor/test_processing.py
@@ -1,0 +1,61 @@
+from unittest.mock import Mock
+import logging as logging_
+import pytest
+
+from kopf.engines import logging
+from kopf.reactor import processing
+from kopf.structs import bodies
+from kopf.structs import patches
+
+
+@pytest.fixture()
+def logger(settings):
+    settings.posting.level = logging_.DEBUG
+    return logging.ObjectLogger(
+        body=bodies.Body({
+            'apiVersion': 'group1/version1',
+            'kind': 'Kind1',
+            'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}}),
+        settings=settings)
+
+
+@pytest.mark.parametrize('patch,new_body,mismatch', [
+    pytest.param({'status': {'akey': 'avalue'}}, {},
+                 [{'path': 'status.akey', 'got': None, 'expected': 'avalue'}]),
+    pytest.param({'status': {'akey': {'bkey': 'avalue'}}}, {},
+                 [{'path': 'status.akey.bkey', 'got': None, 'expected': 'avalue'}]),
+    pytest.param({'status': {'akey': {'bkey': {'ckey': 'avalue'}}}}, {},
+                 [{'path': 'status.akey.bkey.ckey', 'got': None, 'expected': 'avalue'}]),
+    pytest.param({'status': {'akey': 'avalue'}}, {'status': {'akey': 'bvalue'}},
+                 [{'path': 'status.akey', 'got': 'bvalue', 'expected': 'avalue'}]),
+    pytest.param({'status': {'akey': None}}, {'status': {'akey': 'avalue'}},
+                 [{'path': 'status.akey', 'got': 'avalue', 'expected': None}]),
+    pytest.param({'status': {'akey': 'avalue'}}, {'status': {'akey': 'bvalue', 'bkey': 'cvalue'}},
+                 [{'path': 'status.akey', 'got': 'bvalue', 'expected': 'avalue'}]),
+])
+async def test_apply_reaction_outcomes_mismatch(patch: patches.Patch,
+                                                new_body: bodies.Body,
+                                                mismatch: dict,
+                                                resource,
+                                                patcher_mock,
+                                                logger,
+                                                caplog):
+    caplog.set_level(logging_.DEBUG)
+    body = bodies.Body({})
+    delays = []
+    replenished = Mock()
+    patcher_mock.return_value = new_body
+
+    await processing.apply_reaction_outcomes(
+        resource=resource,
+        body=body,
+        patch=patch,
+        delays=delays,
+        logger=logger,
+        replenished=replenished
+    )
+
+    assert caplog.messages == [
+        f'Patching with: {patch}',
+        f'Patched body does not match with patch: {mismatch}'
+    ]


### PR DESCRIPTION
## What do these changes do?

The situation
- kopf submits a `merge-patch+json` patch
- kubernetes API doesn't apply the `merge-patch+json` patch but responds `200 OK`

leads to bugs and confusion, when testing operators.

With this change, kopf will check, if the `merge-patch+json` patch was merged and be verbose, if the patch was not exactly successful.

## Description

<!-- What was the previous behaviour before the PR is merged? -->
**Before:** When a patch wasn't merged, then kopf didn't report anything.

<!-- What will be the new behaviour after the PR is merged? -->
**After:** When a patch wasn't merged, then kopf will report if ran in `--verbose` mode.

<!-- A code snippet showing the new features added (if any)? -->

<!-- Does the change affect the end users or is it internal? -->
This will help users to debug their operators. Especially, when they use OpenAPI schemas in their CRDs.

<!-- Why have you decided to solve the problem this way? What were the trade-offs? (If appropriate.) -->
Not sure if the check is in the right place and the logger is setup appropriately.

<!-- Are there any breaking or risky changes? -->
No risky changes.

## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

If a patch is not merged, then it is usually because of a schema mismatch of the CRD. For this reason it was discussed to move the internal kopf `status` to the annotations.  #308 #321


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
