### PR TITLE
Fix on-field handler selection when a field is longer/equal to a diff

### DIFF
--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -621,7 +621,9 @@ def _matches_field(
     return (ignore_fields or
             not isinstance(handler, handlers.ResourceChangingHandler) or
             not handler.field or
-            any(field[:len(handler.field)] == handler.field for field in changed_fields))
+            any(changed_field[:len(handler.field)] == handler.field or  # a.b.c -vs- a.b => ignore c
+                changed_field == handler.field[:len(changed_field)]     # a.b -vs- a.b.c => ignore c
+                for changed_field in changed_fields))
 
 
 def _matches_labels(


### PR DESCRIPTION
## What do these changes do?

Fix an issue with not calling the field-handlers if the change is too big/generic (regression).


## Description

This issue was once fixed in #191. Since then, the handler selection was moved to other functions and places, and that logic was not reproduced.

The issue happens when there is a handler for a field, and a diff is too big and generic, not specific to sub-fields. For example:

```python
import kopf

@kopf.on.field(..., field='metadata.labels')
def propagate_labels(diff, **_):
    pass
```

And the diff is:

```python
[('add', ('metadata', 'labels'), None, {'x': 'y'}))]
```

This can happen when the labels are added to an object which previously had no labels. If it had any other labels, it is all fine, since the diff becomes specific only to the new labels:

```python
[('add', ('metadata', 'labels', 'x'), None, 'y'))]
```

This PR fixes that issue for on-field handler selection. The same or similar-purpose code already exists in `kopf.structs.diffs.reduce_iter()`.


## Issues/PRs


> Issues:  #190

> Related: regression of #191 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
