### PR TITLE
Publish types for kwargs/classes exposed to the user-side

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -19,6 +19,8 @@ from kopf.config import (
 )
 from kopf.engines.logging import (
     configure,
+    ObjectLogger,
+    LocalObjectLogger,
 )
 from kopf.engines.posting import (
     event,
@@ -71,6 +73,7 @@ from kopf.storage.diffbase import (
     MultiDiffBaseStorage,
 )
 from kopf.storage.progress import (
+    ProgressRecord,
     ProgressStorage,
     AnnotationsProgressStorage,
     StatusProgressStorage,
@@ -78,25 +81,57 @@ from kopf.storage.progress import (
     SmartProgressStorage,
 )
 from kopf.structs.bodies import (
+    RawEventType,
+    RawEvent,
+    RawBody,
+    Status,
+    Spec,
+    Meta,
+    Body,
+    BodyEssence,
+    OwnerReference,
+    ObjectReference,
     build_object_reference,
     build_owner_reference,
 )
 from kopf.structs.configuration import (
     OperatorSettings,
 )
+from kopf.structs.containers import (
+    Memo,
+)
 from kopf.structs.credentials import (
     LoginError,
     ConnectionInfo,
+)
+from kopf.structs.dicts import (
+    FieldSpec,
+    FieldPath,
+)
+from kopf.structs.diffs import (
+    Diff,
+    DiffItem,
+    DiffOperation,
 )
 from kopf.structs.filters import (
     ABSENT,
     PRESENT,
 )
 from kopf.structs.handlers import (
+    HandlerId,
     ErrorsMode,
+    Reason,
+)
+from kopf.structs.patches import (
+    Patch,
 )
 from kopf.structs.primitives import (
     DaemonStoppingReason,
+    SyncDaemonStopperChecker,
+    AsyncDaemonStopperChecker,
+)
+from kopf.structs.resources import (
+    Resource,
 )
 from kopf.toolkits.hierarchies import (
     adopt,
@@ -151,10 +186,35 @@ __all__ = [
     'AnnotationsDiffBaseStorage',
     'StatusDiffBaseStorage',
     'MultiDiffBaseStorage',
+    'ProgressRecord',
     'ProgressStorage',
     'AnnotationsProgressStorage',
     'StatusProgressStorage',
     'MultiProgressStorage',
     'SmartProgressStorage',
     'DaemonStoppingReason',
+    'RawEventType',
+    'RawEvent',
+    'RawBody',
+    'Status',
+    'Spec',
+    'Meta',
+    'Body',
+    'BodyEssence',
+    'ObjectReference',
+    'OwnerReference',
+    'Memo',
+    'ObjectLogger',
+    'LocalObjectLogger',
+    'FieldSpec',
+    'FieldPath',
+    'Diff',
+    'DiffItem',
+    'DiffOperation',
+    'HandlerId',
+    'Reason',
+    'Patch',
+    'SyncDaemonStopperChecker',
+    'AsyncDaemonStopperChecker',
+    'Resource',
 ]

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -51,7 +51,7 @@ class ResourceCause(BaseCause):
     resource: resources.Resource
     patch: patches.Patch
     body: bodies.Body
-    memo: containers.ObjectDict
+    memo: containers.Memo
 
 
 @dataclasses.dataclass

--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -66,7 +66,7 @@ async def spawn_resource_daemons(
                 resource=cause.resource,
                 logger=cause.logger,
                 body=memory.live_fresh_body,
-                memo=memory.user_data,
+                memo=memory.memo,
                 patch=patches.Patch(),  # not the same as the one-shot spawning patch!
                 stopper=stopper,  # for checking (passed to kwargs)
             )

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -97,7 +97,7 @@ async def process_resource_event(
         logger=logger,
         patch=patch,
         body=body,
-        memo=memory.user_data,
+        memo=memory.memo,
     ) if registry.resource_watching_handlers[resource] else None
 
     resource_spawning_cause = causation.detect_resource_spawning_cause(
@@ -105,7 +105,7 @@ async def process_resource_event(
         logger=logger,
         patch=patch,
         body=body,
-        memo=memory.user_data,
+        memo=memory.memo,
         reset=bool(diff),  # only essential changes reset idling, not every event
     ) if registry.resource_spawning_handlers[resource] else None
 
@@ -118,7 +118,7 @@ async def process_resource_event(
         old=old,
         new=new,
         diff=diff,
-        memo=memory.user_data,
+        memo=memory.memo,
         initial=memory.noticed_by_listing and not memory.fully_handled_once,
     ) if registry.resource_changing_handlers[resource] else None
 

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -36,7 +36,7 @@ class Daemon:
     stopper: primitives.DaemonStopper  # a signaller for the termination and its reason.
 
 
-class ObjectDict(Dict[Any, Any]):
+class Memo(Dict[Any, Any]):
     """ A container to hold arbitrary keys-fields assigned by the users. """
 
     def __setattr__(self, key: str, value: Any) -> None:
@@ -60,7 +60,7 @@ class ResourceMemory:
     """ A system memo about a single resource/object. Usually stored in `Memories`. """
 
     # For arbitrary user data to be stored in memory, passed as `memo` to all the handlers.
-    user_data: ObjectDict = dataclasses.field(default_factory=ObjectDict)
+    memo: Memo = dataclasses.field(default_factory=Memo)
 
     # For resuming handlers tracking and deciding on should they be called or not.
     noticed_by_listing: bool = False

--- a/tests/basic-structs/test_containers.py
+++ b/tests/basic-structs/test_containers.py
@@ -3,7 +3,7 @@ import collections.abc
 import pytest
 
 from kopf.structs.bodies import Body
-from kopf.structs.containers import ResourceMemory, ResourceMemories, ObjectDict
+from kopf.structs.containers import ResourceMemory, ResourceMemories, Memo
 
 BODY: Body = {
     'metadata': {
@@ -45,55 +45,55 @@ async def test_forgetting_ignores_when_absent():
 
 
 def test_object_dict_creation():
-    obj = ObjectDict()
+    obj = Memo()
     assert isinstance(obj, collections.abc.MutableMapping)
 
 
 def test_object_dict_fields_are_keys():
-    obj = ObjectDict()
+    obj = Memo()
     obj.xyz = 100
     assert obj['xyz'] == 100
 
 
 def test_object_dict_keys_are_fields():
-    obj = ObjectDict()
+    obj = Memo()
     obj['xyz'] = 100
     assert obj.xyz == 100
 
 
 def test_object_dict_keys_deleted():
-    obj = ObjectDict()
+    obj = Memo()
     obj['xyz'] = 100
     del obj['xyz']
     assert obj == {}
 
 
 def test_object_dict_fields_deleted():
-    obj = ObjectDict()
+    obj = Memo()
     obj.xyz = 100
     del obj.xyz
     assert obj == {}
 
 
 def test_object_dict_raises_key_errors_on_get():
-    obj = ObjectDict()
+    obj = Memo()
     with pytest.raises(KeyError):
         obj['unexistent']
 
 
 def test_object_dict_raises_attribute_errors_on_get():
-    obj = ObjectDict()
+    obj = Memo()
     with pytest.raises(AttributeError):
         obj.unexistent
 
 
 def test_object_dict_raises_key_errors_on_del():
-    obj = ObjectDict()
+    obj = Memo()
     with pytest.raises(KeyError):
         del obj['unexistent']
 
 
 def test_object_dict_raises_attribute_errors_on_del():
-    obj = ObjectDict()
+    obj = Memo()
     with pytest.raises(AttributeError):
         del obj.unexistent

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -7,7 +7,7 @@ from kopf.reactor.causation import ResourceChangingCause, ResourceWatchingCause
 from kopf.reactor.handling import cause_var
 from kopf.reactor.invocation import context
 from kopf.structs.bodies import RawBody, RawMeta, RawEvent, Body
-from kopf.structs.containers import ObjectDict
+from kopf.structs.containers import Memo
 from kopf.structs.handlers import Reason
 from kopf.structs.patches import Patch
 
@@ -36,7 +36,7 @@ def owner(request, resource):
             logger=logging.getLogger('kopf.test.fake.logger'),
             resource=resource,
             patch=Patch(),
-            memo=ObjectDict(),
+            memo=Memo(),
             body=Body(OWNER),
             initial=False,
             reason=Reason.NOOP,
@@ -48,7 +48,7 @@ def owner(request, resource):
             logger=logging.getLogger('kopf.test.fake.logger'),
             resource=resource,
             patch=Patch(),
-            memo=ObjectDict(),
+            memo=Memo(),
             body=Body(OWNER),
             type='irrelevant',
             raw=RawEvent(type='irrelevant', object=OWNER),

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -7,7 +7,7 @@ from kopf.reactor.causation import ResourceChangingCause
 from kopf.reactor.invocation import invoke
 from kopf.storage.states import State
 from kopf.structs.bodies import Body
-from kopf.structs.containers import ObjectDict
+from kopf.structs.containers import Memo
 from kopf.structs.handlers import Reason
 from kopf.structs.patches import Patch
 
@@ -30,7 +30,7 @@ async def test_protocol_invocation(lifecycle, resource):
         logger=logging.getLogger('kopf.test.fake.logger'),
         resource=resource,
         patch=Patch(),
-        memo=ObjectDict(),
+        memo=Memo(),
         body=Body({}),
         initial=False,
         reason=Reason.NOOP,


### PR DESCRIPTION
## What do these changes do?

Publishes all object types which are exposed to the user-side: as handlers' kwargs or as overridable classes.


## Description

This was actually promised in #194, but not actually implemented.

With these types exposed, the users can type-annotate the kwargs, making them friendly in the IDEs, or or to type-check their operators. It is more wordy than in the examples/docs, but this is how type annotations generally work:

```python
from typing import Any
import kopf

@kopf.on.create('zalando.org', 'v1', 'ephemeralvolumeclaims')
def create_fn(
        spec: kopf.Spec, name: str, namespace: str, patch: kopf.Patch,
        logger: kopf.ObjectLogger, **_: Any):
    ...
```

Another group of classes exposed are those supposed to be used in the overridden/inherited classes, such as persistence storage classes: the storage classes were exposed, but the types of their arguments were not. This is now fixed.

There are no changes in the behaviour.

The `UserDict` class is renamed to `Memo` to make it more clear what kind of an object it is (not only a dict, but also free-named field container). The kwargs remains the same: `memo`.


## Issues/PRs

> Issues:  #194 #200


## Type of changes

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
