### PR TITLE
Run daemons only as long as they match the filtering criteria

### DIFF
--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -252,6 +252,9 @@ To simulate restarting, raise `kopf.TemporaryError` with a delay set.
 
 Same as with regular error handling, a delay of ``None`` means instant restart.
 
+See also: :ref:`never-again-filters` to prevent daemons from spawning across
+operator restarts.
+
 
 Deletion prevention
 ===================

--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -363,6 +363,23 @@ to only spawn daemons for specific resources:
 
 Other (non-matching) resources of that kind will be ignored.
 
+The daemons will be executed only while the filtering criteria are met.
+Both the resource's state and the criteria can be highly dynamic (e.g.
+due to ``when=`` callable filters or labels/annotations value callbacks).
+
+Once the daemon stops matching the criteria (either because the resource
+or the criteria have been changed (e.g. for `when=` callbacks)),
+the daemon is stopped. Once it matches the criteria again, it is re-spawned.
+
+The checking is done only when the resource changes (any watch-event arrives).
+The criteria themselves are not re-evaluated if nothing changes.
+
+.. warning::
+
+    A daemon that is being terminated is considered as still running, therefore
+    it will not be re-spawned until the termination ends. It will be re-spawned
+    the next time a watch-event arrives after the daemon has truly exited.
+
 
 System resources
 ================

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -59,6 +59,9 @@ is no need to retry over time, as it will not become better::
         if valid_until <= datetime.datetime.utcnow():
             raise kopf.PermanentError("The object is not valid anymore.")
 
+See also: :ref:`never-again-filters` to prevent handlers from being invoked
+for the future change-sets even after operator restarts.
+
 
 Regular errors
 ==============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ Kopf: Kubernetes Operators Framework
    continuity
    idempotence
    reconciliation
+   tips-and-tricks
    troubleshooting
 
 .. toctree::

--- a/docs/tips-and-tricks.rst
+++ b/docs/tips-and-tricks.rst
@@ -1,0 +1,40 @@
+=============
+Tips & Tricks
+=============
+
+
+.. _never-again-filters:
+
+Excluding handlers forever
+==========================
+
+Both successful executions and permanent errors of change-detecting handlers
+only exclude these handlers from the current handling cycle, which is scoped
+to the current change-set (i.e. one diff of an object).
+On the next change, the handlers will be invoked again, regardless of their
+previous permanent error.
+
+The same is valid for the daemons: they will be spawned on the next operator
+restart (assuming that one operator process is one handling cycle for daemons).
+
+To prevent handlers or daemons from being invoked for a specific resource
+ever again, even after the operator restarts, use annotations and filters
+(or the same for labels or arbitrary fields with `when=` callback filtering):
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples',
+                    annotations={'update-fn-never-again': kopf.ABSENT})
+    def update_fn(patch, **_):
+        patch.metadata.annotations['update-fn-never-again'] = 'yes'
+        raise kopf.PermanentError("Never call update-fn again.")
+
+    @kopf.daemon('zalando.org', 'v1', 'kopfexamples',
+                 annotations={'monitor-never-again': kopf.ABSENT})
+    async def monitor_kex(patch, **kwargs):
+        patch.metadata.annotations['monitor-never-again'] = 'yes'
+
+Such a never-again exclusion might be implemented as a feature of Kopf one day,
+but it is not available now -- if not done explicitly as shown above.

--- a/examples/14-daemons/example.py
+++ b/examples/14-daemons/example.py
@@ -23,7 +23,8 @@ def background_sync(spec, stopped, logger, retry, patch, **_):
 # Async daemons do not need the `stopped` signal, they can rely on `asyncio.CancelledError` raised.
 # This daemon runs forever (until stopped, i.e. cancelled). Yet fails to start for 3 first times.
 @kopf.daemon('zalando.org', 'v1', 'kopfexamples', backoff=3,
-             cancellation_backoff=1.0, cancellation_timeout=0.5)
+             cancellation_backoff=1.0, cancellation_timeout=0.5,
+             annotations={'someannotation': 'somevalue'})
 async def background_async(spec, logger, retry, **_):
     if retry < 3:
         raise kopf.TemporaryError("Simulated failure.", delay=1)

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -11,7 +11,7 @@ import asyncio
 import dataclasses
 import logging
 import time
-from typing import MutableMapping, Dict, Any, Iterator, Optional, Union, NewType, TYPE_CHECKING
+from typing import MutableMapping, Dict, Set, Any, Iterator, Optional, Union, NewType, TYPE_CHECKING
 
 from kopf.structs import bodies
 from kopf.structs import handlers
@@ -69,8 +69,8 @@ class ResourceMemory:
     # For background and timed threads/tasks (invoked with the kwargs of the last-seen body).
     live_fresh_body: Optional[bodies.Body] = None
     idle_reset_time: float = dataclasses.field(default_factory=time.monotonic)
+    forever_stopped: Set[handlers.HandlerId] = dataclasses.field(default_factory=set)
     daemons: Dict[DaemonId, Daemon] = dataclasses.field(default_factory=dict)
-    fully_spawned: bool = False
 
 
 class ResourceMemories:

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -138,6 +138,7 @@ class DaemonStoppingReason(enum.Flag):
     """
     NONE = 0
     DONE = enum.auto()  # whatever the reason and the status, the asyncio task has exited.
+    FILTERS_MISMATCH = enum.auto()  # the resource does not match the filters anymore.
     RESOURCE_DELETED = enum.auto()  # the resource was deleted, the asyncio task is still awaited.
     OPERATOR_EXITING = enum.auto()  # the operator is exiting, the asyncio task is still awaited.
     DAEMON_SIGNALLED = enum.auto()  # the stopper flag was set, the asyncio task is still awaited.
@@ -225,6 +226,10 @@ class DaemonStopperChecker:
 
     def is_set(self) -> bool:
         return self._stopper.is_set()
+
+    @property
+    def reason(self) -> DaemonStoppingReason:
+        return self._stopper.reason
 
 
 class SyncDaemonStopperChecker(DaemonStopperChecker):

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -7,7 +7,7 @@ with an incompatible class hierarchy and method signatures.
 """
 import abc
 import warnings
-from typing import Any, Union, Sequence, Iterator, Optional
+from typing import Any, Union, Sequence, Iterator, Container, Optional
 
 from kopf.reactor import causation
 from kopf.reactor import registries
@@ -125,6 +125,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
     def iter_handlers(
             self,
             cause: AnyCause,
+            excluded: Container[handlers.HandlerId] = frozenset(),  # only for signature matching
     ) -> Iterator[AnyHandler]:
         yield from self._handlers
 

--- a/tests/handling/daemons/test_daemon_rematching.py
+++ b/tests/handling/daemons/test_daemon_rematching.py
@@ -1,0 +1,36 @@
+import logging
+
+import kopf
+from kopf.structs.primitives import DaemonStoppingReason
+
+
+async def test_running_daemon_is_stopped_when_mismatches(
+        registry, resource, dummy, timer, mocker,
+        caplog, assert_logs, k8s_mocked, simulate_cycle):
+    caplog.set_level(logging.DEBUG)
+
+    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+                 when=lambda **_: is_matching)
+    async def fn(**kwargs):
+        dummy.mock()
+        dummy.kwargs = kwargs
+        dummy.steps['called'].set()
+        await kwargs['stopped'].wait()
+
+    # Ensure it is spawned while it is matching. (The same as the spawning tests.)
+    mocker.resetall()
+    is_matching = True
+    await simulate_cycle({})
+    await dummy.steps['called'].wait()
+    assert dummy.mock.call_count == 1
+
+    # Ensure it is stopped once it stops matching. (The same as the termination tests.)
+    mocker.resetall()
+    is_matching = False
+    await simulate_cycle({})
+    with timer:
+        await dummy.wait_for_daemon_done()
+
+    assert timer.seconds < 0.01  # near-instantly
+    stopped = dummy.kwargs['stopped']
+    assert DaemonStoppingReason.FILTERS_MISMATCH in stopped.reason


### PR DESCRIPTION
## What do these changes do?

Run daemons only as long as they match the filtering criteria, making the daemon's filters continuously evaluated. Stop and re-spawn the daemons as soon as they stop or start matching the criteria (any number of times).


## Description

While implementing an operator for EphemeralVolumeClaim resource (which is also Kopf's tutorial) with Kopf 0.27rc1, it has become clear that the newly introduced daemons (#330) have ambiguous behaviour when combined with filters: they were spawned only on the resource creation or operator startup, and never re-evaluated even when the criteria changes or the resource stops matching the criteria.

This problem didn't exist with the regular short-run handlers, as they were selected each time the changes/events happened, and never existed for long time.

This PR brings the daemons & timers with filters to clear and consistent behaviour:

* Once the resource stops matching the daemon's criteria, the daemon is stopped too.
* Once the resource starts matching the daemon's criteria again, the daemon is started again too.

Semantically, the _daemon's filters define when the daemon should be running **on a continuous basis**_, not only when it should be spawned on creation/restart (and then ignored afterwards).

The spawning/stopping can happen both due to the resource changes or the criteria changes (but triggered only on the resource changes).

---

For example, consider an operator:

```python
import asyncio
import kopf

def should_daemon_run(spec, **_):
    return spec.get('field', '').startswith('value')

@kopf.daemon('zalando.org', 'v1', 'kopfexamples', when=should_daemon_run, cancellation_timeout=1.0)
async def my_daemon(logger, **_):
    while True:
        await asyncio.sleep(5.0)
        logger.info("==> ping")
```

Once created with an example object (which has `spec.field == "value"`), it will be instantly spawned.

```
[2020-04-06 21:53:19,192] kopf.objects         [DEBUG   ] [default/kopf-example-1] Adding the finalizer, thus preventing the actual deletion.
[2020-04-06 21:53:19,194] kopf.objects         [DEBUG   ] [default/kopf-example-1] Patching with: {'metadata': {'finalizers': ['kopf.zalando.org/KopfFinalizerMarker']}}
[2020-04-06 21:53:19,199] kopf.objects         [DEBUG   ] [default/kopf-example-1] Daemon 'my_daemon' is invoked.
[2020-04-06 21:53:19,319] kopf.objects         [DEBUG   ] [default/kopf-example-1] Handling cycle is finished, waiting for new changes since now.
[2020-04-06 21:53:24,205] kopf.objects         [INFO    ] [default/kopf-example-1] ==> ping
[2020-04-06 21:53:29,210] kopf.objects         [INFO    ] [default/kopf-example-1] ==> ping
```

Then, we can modify the object so that it mismatches the criteria (or we could modify the criteria and trigger an event on the resource):

```bash
kubectl patch -f examples/obj.yaml --type merge -p '{"spec": {"field": "other-value"}}'
```

The daemon will be stopped, as it mismatches the criteria now.

```
[2020-04-06 21:54:09,241] kopf.objects         [INFO    ] [default/kopf-example-1] ==> ping
[2020-04-06 21:54:12,023] kopf.objects         [DEBUG   ] [default/kopf-example-1] Removing the finalizer, as there are no handlers requiring it.
[2020-04-06 21:54:12,024] kopf.objects         [DEBUG   ] [default/kopf-example-1] Daemon 'my_daemon' is signalled to exit by force.
[2020-04-06 21:54:12,024] kopf.objects         [DEBUG   ] [default/kopf-example-1] Patching with: {'metadata': {'finalizers': []}}
[2020-04-06 21:54:12,027] kopf.objects         [WARNING ] [default/kopf-example-1] Daemon 'my_daemon' is cancelled. Will escalate.
[2020-04-06 21:54:12,038] kopf.objects         [DEBUG   ] [default/kopf-example-1] Sleeping was skipped because of the patch, 1.0 seconds left.
[2020-04-06 21:54:12,145] kopf.objects         [DEBUG   ] [default/kopf-example-1] Handling cycle is finished, waiting for new changes since now.
```

Then, we can revert the change:

```bash
kubectl patch -f examples/obj.yaml --type merge -p '{"spec": {"field": "value-123"}}'
```

The daemon will be spawned again, because it matches the criteria again:

```
[2020-04-06 21:55:05,378] kopf.objects         [DEBUG   ] [default/kopf-example-1] Adding the finalizer, thus preventing the actual deletion.
[2020-04-06 21:55:05,379] kopf.objects         [DEBUG   ] [default/kopf-example-1] Patching with: {'metadata': {'finalizers': ['kopf.zalando.org/KopfFinalizerMarker']}}
[2020-04-06 21:55:05,381] kopf.objects         [DEBUG   ] [default/kopf-example-1] Daemon 'my_daemon' is invoked.
[2020-04-06 21:55:05,503] kopf.objects         [DEBUG   ] [default/kopf-example-1] Handling cycle is finished, waiting for new changes since now.
[2020-04-06 21:55:10,382] kopf.objects         [INFO    ] [default/kopf-example-1] ==> ping
[2020-04-06 21:55:15,387] kopf.objects         [INFO    ] [default/kopf-example-1] ==> ping
```

And so on.

Please also notice how the finalizer is added and removed to keep the resource blocked from deletion as long as any daemons are running, and free for deletion if not running (this was part of the original implementation, which is now adjusted to fit into this highly dynamic filtering).

---

A little note: once the daemon exits on its own accord, i.e. without being terminated by the framework, it is considered as intentional termination, and the daemon will never be spawned again within the current operator process. 

For cross-restart prevention, there is currently no syntax feature available, but there is a simple trick to achieve it in 2 extra lines of code (documented in this PR too).



## Issues/PRs

> Issues: #19 

> Related: #330  #150 #271 #317 #122


## Type of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
