### PR TITLE
Provoke handling cycles even with no arbitrary field preservation

### DIFF
--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -226,7 +226,10 @@ async def apply_reaction_outcomes(
         else:
             unslept_delay = None  # no need to sleep? means: slept in full.
 
-        if unslept_delay is not None:
+        # Exclude cases when touching immediately after patching (including: ``delay == 0``).
+        if patch and not delay:
+            pass
+        elif unslept_delay is not None:
             logger.debug(f"Sleeping was interrupted by new changes, {unslept_delay} seconds left.")
         else:
             # Any unique always-changing value will work; not necessary a timestamp.

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -44,7 +44,6 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
     assert 'metadata' in patch
     assert 'annotations' in patch['metadata']
     assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
-    assert 'status' not in patch  # because only 1 handler, nothing to purge
 
     assert_logs([
         "Creation event:",
@@ -85,7 +84,6 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
     assert 'metadata' in patch
     assert 'annotations' in patch['metadata']
     assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
-    assert 'status' not in patch  # because only 1 handler, nothing to purge
 
     assert_logs([
         "Update event:",
@@ -122,9 +120,6 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
     assert k8s_mocked.sleep_or_wait.call_count == 0
     assert k8s_mocked.patch_obj.call_count == 1
     assert not event_queue.empty()
-
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
-    assert 'status' not in patch  # because only 1 handler, nothing to purge
 
     assert_logs([
         "Deletion event",


### PR DESCRIPTION
## What do these changes do?

Trigger the after-sleep handling cycles via the progress storage, the same way as it is triggered for the no-sleep handlers.

## Description

This aspect was unintentionally forgotten in #331, where the handlers' persistence was made configurable.

If the resource would have no arbitrary field preservation (e.g. for built-in resources), the dummy patching would be silently ignored by K8s API. 

With this PR, the dummy patches are made the same way as the regular handlers are patched, so the handling cycles are always provoked after the sleeps.


## Issues/PRs

> Issues: #308 #23 #283 #321 
> Related: #331 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
