### PR TITLE
Make finalizer's name configurable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -152,12 +152,37 @@ or disconnects. The default is 0.1 seconds (nearly instant, but not flooding).
 
 .. code-block:: python
 
-    import concurrent.futures
     import kopf
 
     @kopf.on.startup()
     def configure(settings: kopf.OperatorSettings, **_):
         settings.watching.server_timeout = 10 * 60
+
+
+Finalizers
+==========
+
+A resource is blocked from deletion if the framework believes it is safer
+to do so, e.g. if non-optional deletion handlers are present
+or if daemons/timers are running at the moment.
+
+For this, a finalizer_ is added to the object. It is removed when the framework
+believes it is safe to release the object for actual deletion.
+
+.. _finalizer: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#finalizers
+
+The name of the finalizer can be configured:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.finalizer = 'my-operator.example.com/kopf-finalizer'
+
+The default is the one that was hard-coded before:
+``kopf.zalando.org/KopfFinalizerMarker``.
 
 
 .. _progress-storing:

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -146,6 +146,7 @@ def detect_resource_spawning_cause(
 
 def detect_resource_changing_cause(
         *,
+        finalizer: str,
         raw_event: bodies.RawEvent,
         body: bodies.Body,
         old: Optional[bodies.BodyEssence] = None,
@@ -173,10 +174,12 @@ def detect_resource_changing_cause(
         return ResourceChangingCause(reason=handlers.Reason.GONE, **kwargs)
 
     # The finalizer has been just removed. We are fully done.
-    if finalizers.is_deletion_ongoing(body) and not finalizers.is_deletion_blocked(body):
+    deletion_is_ongoing = finalizers.is_deletion_ongoing(body=body)
+    deletion_is_blocked = finalizers.is_deletion_blocked(body=body, finalizer=finalizer)
+    if deletion_is_ongoing and not deletion_is_blocked:
         return ResourceChangingCause(reason=handlers.Reason.FREE, **kwargs)
 
-    if finalizers.is_deletion_ongoing(body):
+    if deletion_is_ongoing:
         return ResourceChangingCause(reason=handlers.Reason.DELETE, **kwargs)
 
     # For an object seen for the first time (i.e. just-created), call the creation handlers,

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -60,6 +60,7 @@ async def process_resource_event(
     All the internally provoked changes are intercepted, do not create causes,
     and therefore do not call the handling logic.
     """
+    finalizer = settings.persistence.finalizer
 
     # Recall what is stored about that object. Share it in little portions with the consumers.
     # And immediately forget it if the object is deleted from the cluster (but keep in memory).
@@ -110,6 +111,7 @@ async def process_resource_event(
     ) if registry.resource_spawning_handlers[resource] else None
 
     resource_changing_cause = causation.detect_resource_changing_cause(
+        finalizer=finalizer,
         raw_event=raw_event,
         resource=resource,
         logger=logger,
@@ -127,7 +129,7 @@ async def process_resource_event(
     # The high-level handlers are prevented if this event cycle is dedicated to the finalizer.
     # The low-level handlers (on-event spying & daemon spawning) are still executed asap.
     deletion_is_ongoing = finalizers.is_deletion_ongoing(body=body)
-    deletion_is_blocked = finalizers.is_deletion_blocked(body=body)
+    deletion_is_blocked = finalizers.is_deletion_blocked(body=body, finalizer=finalizer)
     deletion_must_be_blocked = (
         (resource_spawning_cause is not None and
          registry.resource_spawning_handlers[resource].requires_finalizer(resource_spawning_cause))
@@ -137,12 +139,12 @@ async def process_resource_event(
 
     if deletion_must_be_blocked and not deletion_is_blocked and not deletion_is_ongoing:
         logger.debug("Adding the finalizer, thus preventing the actual deletion.")
-        finalizers.block_deletion(body=body, patch=patch)
+        finalizers.block_deletion(body=body, patch=patch, finalizer=finalizer)
         resource_changing_cause = None  # prevent further high-level processing this time
 
     if not deletion_must_be_blocked and deletion_is_blocked:
         logger.debug("Removing the finalizer, as there are no handlers requiring it.")
-        finalizers.allow_deletion(body=body, patch=patch)
+        finalizers.allow_deletion(body=body, patch=patch, finalizer=finalizer)
         resource_changing_cause = None  # prevent further high-level processing this time
 
     # Invoke all the handlers that should or could be invoked at this processing cycle.
@@ -181,7 +183,7 @@ async def process_resource_event(
             and not resource_spawning_delays \
             and not resource_changing_delays:
         logger.debug("Removing the finalizer, thus allowing the actual deletion.")
-        finalizers.allow_deletion(body=body, patch=patch)
+        finalizers.allow_deletion(body=body, patch=patch, finalizer=finalizer)
 
     # Whatever was done, apply the accumulated changes to the object, or sleep-n-touch for delays.
     # But only once, to reduce the number of API calls and the generated irrelevant events.

--- a/kopf/structs/configuration.py
+++ b/kopf/structs/configuration.py
@@ -166,6 +166,12 @@ class ExecutionSettings:
 @dataclasses.dataclass
 class PersistenceSettings:
 
+    finalizer: str = 'kopf.zalando.org/KopfFinalizerMarker'
+    """
+    A string marker to be put on a list of finalizers to block the object
+    from being deleted without framework's/operator's permission.
+    """
+
     progress_storage: progress.ProgressStorage = dataclasses.field(
         default_factory=progress.SmartProgressStorage)
     """

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -5,9 +5,11 @@ import pytest
 
 from kopf.reactor.causation import detect_resource_changing_cause
 from kopf.storage.diffbase import LAST_SEEN_ANNOTATION
-from kopf.storage.finalizers import FINALIZER
 from kopf.structs.bodies import Body
 from kopf.structs.handlers import Reason
+
+# Same as in the settings by default.
+FINALIZER = 'fin'
 
 # Encoded at runtime, so that we do not make any assumptions on json formatting.
 SPEC_DATA = {'spec': {'field': 'value'}}
@@ -115,6 +117,7 @@ def content():
 @pytest.fixture()
 def kwargs():
     return dict(
+        finalizer=FINALIZER,
         resource=object(),
         logger=object(),
         patch=object(),

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -166,7 +166,7 @@ def extrahandlers(clear_default_registry, handlers):
 
 
 @pytest.fixture()
-def cause_mock(mocker, resource):
+def cause_mock(mocker, settings, resource):
     """
     Mock the resulting _cause_ of the resource change detection logic.
 
@@ -183,12 +183,12 @@ def cause_mock(mocker, resource):
 
     # Use everything from a mock, but use the passed `patch` dict as is.
     # The event handler passes its own accumulator, and checks/applies it later.
-    def new_detect_fn(*, diff, new, old, **kwargs):
+    def new_detect_fn(*, finalizer, diff, new, old, **kwargs):
 
         # For change detection, we ensure that there is no extra cycle of adding a finalizer.
         raw_event = kwargs.pop('raw_event', None)
         raw_body = raw_event['object']
-        raw_body.setdefault('metadata', {}).setdefault('finalizers', ['kopf.zalando.org/KopfFinalizerMarker'])
+        raw_body.setdefault('metadata', {}).setdefault('finalizers', [finalizer])
 
         # Pass through kwargs: resource, logger, patch, diff, old, new.
         # I.e. everything except what we mock -- for them, use the mocked values (if not None).

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -1,11 +1,10 @@
 import logging
 
 import kopf
-from kopf.storage.finalizers import FINALIZER
 
 
 async def test_daemon_stopped_on_permanent_error(
-        registry, resource, dummy, manual_time,
+        registry, settings, resource, dummy, manual_time,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
@@ -17,7 +16,8 @@ async def test_daemon_stopped_on_permanent_error(
         dummy.steps['called'].set()
         raise kopf.PermanentError("boo!")
 
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
 
     await dummy.steps['called'].wait()
@@ -37,7 +37,7 @@ async def test_daemon_stopped_on_permanent_error(
 
 
 async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
-        registry, resource, dummy, manual_time,
+        registry, settings, resource, dummy, manual_time,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
@@ -49,7 +49,8 @@ async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
         dummy.steps['called'].set()
         raise Exception("boo!")
 
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
 
     await dummy.steps['called'].wait()
@@ -83,7 +84,8 @@ async def test_daemon_retried_on_temporary_error(
         else:
             dummy.steps['finish'].set()
 
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
 
     await dummy.steps['called'].wait()
@@ -102,7 +104,7 @@ async def test_daemon_retried_on_temporary_error(
 
 
 async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
-        registry, resource, dummy,
+        registry, settings, resource, dummy,
         caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
@@ -117,7 +119,8 @@ async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
         else:
             dummy.steps['finish'].set()
 
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
 
     await dummy.steps['called'].wait()

--- a/tests/handling/daemons/test_daemon_filtration.py
+++ b/tests/handling/daemons/test_daemon_filtration.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 
 import kopf
-from kopf.storage.finalizers import FINALIZER
 
 
 # We assume that the handler filtering is tested in details elsewhere (for all handlers).
@@ -11,7 +10,7 @@ from kopf.storage.finalizers import FINALIZER
 
 
 async def test_daemon_filtration_satisfied(
-        registry, resource, dummy,
+        registry, settings, resource, dummy,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
@@ -22,9 +21,10 @@ async def test_daemon_filtration_satisfied(
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
 
+    finalizer = settings.persistence.finalizer
     event_body = {'metadata': {'labels': {'a': 'value', 'b': '...'},
                                'annotations': {'x': 'value', 'y': '...'},
-                               'finalizers': [FINALIZER]}}
+                               'finalizers': [finalizer]}}
     await simulate_cycle(event_body)
 
     await dummy.steps['called'].wait()
@@ -42,7 +42,7 @@ async def test_daemon_filtration_satisfied(
     ({'a': 'value'}, {'x': 'value', 'y': '...'}),
 ])
 async def test_daemon_filtration_mismatched(
-        registry, resource, mocker, labels, annotations,
+        registry, settings, resource, mocker, labels, annotations,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
     spawn_resource_daemons = mocker.patch('kopf.reactor.daemons.spawn_resource_daemons')
@@ -53,9 +53,10 @@ async def test_daemon_filtration_mismatched(
     async def fn(**kwargs):
         pass
 
+    finalizer = settings.persistence.finalizer
     event_body = {'metadata': {'labels': labels,
                                'annotations': annotations,
-                               'finalizers': [FINALIZER]}}
+                               'finalizers': [finalizer]}}
     await simulate_cycle(event_body)
 
     assert spawn_resource_daemons.called

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -4,11 +4,10 @@ import logging
 import pytest
 
 import kopf
-from kopf.storage.finalizers import FINALIZER
 
 
 async def test_daemon_exits_gracefully_and_instantly_via_stopper(
-        registry, resource, dummy, simulate_cycle,
+        registry, settings, resource, dummy, simulate_cycle,
         caplog, assert_logs, k8s_mocked, frozen_time, mocker, timer):
     caplog.set_level(logging.DEBUG)
 
@@ -20,7 +19,8 @@ async def test_daemon_exits_gracefully_and_instantly_via_stopper(
         await kwargs['stopped'].wait()
 
     # 0th cycle:tTrigger spawning and wait until ready. Assume the finalizers are already added.
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
     await dummy.steps['called'].wait()
 
@@ -41,7 +41,7 @@ async def test_daemon_exits_gracefully_and_instantly_via_stopper(
 
 
 async def test_daemon_exits_via_cancellation_with_backoff(
-        registry, resource, dummy, simulate_cycle,
+        registry, settings, resource, dummy, simulate_cycle,
         caplog, assert_logs, k8s_mocked, frozen_time, mocker):
     caplog.set_level(logging.DEBUG)
 
@@ -54,7 +54,8 @@ async def test_daemon_exits_via_cancellation_with_backoff(
         await asyncio.Event().wait()  # this one is cancelled.
 
     # Trigger spawning and wait until ready. Assume the finalizers are already added.
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
     await dummy.steps['called'].wait()
 
@@ -90,7 +91,7 @@ async def test_daemon_exits_via_cancellation_with_backoff(
 
 
 async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
-        registry, resource, dummy, simulate_cycle,
+        registry, settings, resource, dummy, simulate_cycle,
         caplog, assert_logs, k8s_mocked, frozen_time, mocker):
     caplog.set_level(logging.DEBUG)
 
@@ -106,7 +107,8 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
             await dummy.steps['finish'].wait()  # simulated disobedience to be cancelled.
 
     # 0th cycle:tTrigger spawning and wait until ready. Assume the finalizers are already added.
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
     await dummy.steps['called'].wait()
 

--- a/tests/handling/daemons/test_timer_errors.py
+++ b/tests/handling/daemons/test_timer_errors.py
@@ -1,11 +1,10 @@
 import logging
 
 import kopf
-from kopf.storage.finalizers import FINALIZER
 
 
 async def test_timer_stopped_on_permanent_error(
-        registry, resource, dummy,
+        registry, settings, resource, dummy,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
@@ -18,7 +17,7 @@ async def test_timer_stopped_on_permanent_error(
         kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
         raise kopf.PermanentError("boo!")
 
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    event_object = {'metadata': {'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_object)
 
     await dummy.steps['called'].wait()
@@ -36,7 +35,7 @@ async def test_timer_stopped_on_permanent_error(
 
 
 async def test_timer_stopped_on_arbitrary_errors_with_mode_permanent(
-        registry, resource, dummy,
+        registry, settings, resource, dummy,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
@@ -49,7 +48,7 @@ async def test_timer_stopped_on_arbitrary_errors_with_mode_permanent(
         kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
         raise Exception("boo!")
 
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    event_object = {'metadata': {'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_object)
 
     await dummy.steps['called'].wait()
@@ -83,7 +82,7 @@ async def test_timer_retried_on_temporary_error(
             kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
             dummy.steps['finish'].set()
 
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    event_object = {'metadata': {'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_object)
 
     await dummy.steps['called'].wait()
@@ -101,7 +100,7 @@ async def test_timer_retried_on_temporary_error(
 
 
 async def test_timer_retried_on_arbitrary_error_with_mode_temporary(
-        registry, resource, dummy,
+        registry, settings, resource, dummy,
         caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
@@ -117,7 +116,7 @@ async def test_timer_retried_on_arbitrary_error_with_mode_temporary(
             kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
             dummy.steps['finish'].set()
 
-    event_object = {'metadata': {'finalizers': [FINALIZER]}}
+    event_object = {'metadata': {'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_object)
 
     await dummy.steps['called'].wait()

--- a/tests/handling/daemons/test_timer_filtration.py
+++ b/tests/handling/daemons/test_timer_filtration.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 
 import kopf
-from kopf.storage.finalizers import FINALIZER
 
 
 # We assume that the handler filtering is tested in details elsewhere (for all handlers).
@@ -11,7 +10,7 @@ from kopf.storage.finalizers import FINALIZER
 
 
 async def test_timer_filtration_satisfied(
-        registry, resource, dummy,
+        registry, settings, resource, dummy,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
@@ -24,7 +23,7 @@ async def test_timer_filtration_satisfied(
 
     event_body = {'metadata': {'labels': {'a': 'value', 'b': '...'},
                                'annotations': {'x': 'value', 'y': '...'},
-                               'finalizers': [FINALIZER]}}
+                               'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_body)
 
     await dummy.steps['called'].wait()
@@ -42,7 +41,7 @@ async def test_timer_filtration_satisfied(
     ({'a': 'value'}, {'x': 'value', 'y': '...'}),
 ])
 async def test_timer_filtration_mismatched(
-        registry, resource, mocker, labels, annotations,
+        registry, settings, resource, mocker, labels, annotations,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
     spawn_resource_daemons = mocker.patch('kopf.reactor.daemons.spawn_resource_daemons')
@@ -55,7 +54,7 @@ async def test_timer_filtration_mismatched(
 
     event_body = {'metadata': {'labels': labels,
                                'annotations': annotations,
-                               'finalizers': [FINALIZER]}}
+                               'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_body)
 
     assert spawn_resource_daemons.called

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -6,7 +6,6 @@ import pytest
 import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.storage.diffbase import LAST_SEEN_ANNOTATION
-from kopf.storage.finalizers import FINALIZER
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import Reason
 
@@ -101,7 +100,8 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
                       caplog, assert_logs, k8s_mocked):
     caplog.set_level(logging.DEBUG)
     cause_mock.reason = Reason.DELETE
-    event_body = {'metadata': {'deletionTimestamp': '...', 'finalizers': [FINALIZER]}}
+    finalizer = settings.persistence.finalizer
+    event_body = {'metadata': {'deletionTimestamp': '...', 'finalizers': [finalizer]}}
 
     event_queue = asyncio.Queue()
     await process_resource_event(

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -8,7 +8,6 @@ import pytest
 import kopf
 from kopf.reactor.handling import TemporaryError
 from kopf.reactor.processing import process_resource_event, WAITING_KEEPALIVE_INTERVAL
-from kopf.storage.finalizers import FINALIZER
 from kopf.storage.states import HandlerState
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import Reason, HANDLER_REASONS
@@ -77,7 +76,7 @@ async def test_delayed_handlers_sleep(
     delayed_dt = datetime.datetime.fromisoformat(delayed_iso)
     event_type = None if cause_reason == Reason.RESUME else 'irrelevant'
     event_body = {
-        'metadata': {'finalizers': [FINALIZER]},
+        'metadata': {'finalizers': [settings.persistence.finalizer]},
         'status': {'kopf': {'progress': {
             'create_fn': HandlerState(started=started_dt, delayed=delayed_dt).as_in_storage(),
             'update_fn': HandlerState(started=started_dt, delayed=delayed_dt).as_in_storage(),

--- a/tests/test_finalizers.py
+++ b/tests/test_finalizers.py
@@ -1,12 +1,12 @@
 import pytest
 
-from kopf.storage.finalizers import FINALIZER, LEGACY_FINALIZER
+from kopf.storage.finalizers import LEGACY_FINALIZER
 from kopf.storage.finalizers import block_deletion, allow_deletion
 from kopf.storage.finalizers import is_deletion_ongoing, is_deletion_blocked
 
 
-def test_finalizer_is_fqdn():
-    assert FINALIZER.startswith('kopf.zalando.org/')
+def test_finalizer_is_fqdn(settings):
+    assert settings.persistence.finalizer.startswith('kopf.zalando.org/')
 
 
 @pytest.mark.parametrize('expected, body', [
@@ -25,56 +25,56 @@ def test_is_deleted(expected, body):
     pytest.param(False, {'metadata': {}}, id='no-finalizers'),
     pytest.param(False, {'metadata': {'finalizers': []}}, id='empty'),
     pytest.param(False, {'metadata': {'finalizers': ['other']}}, id='others'),
-    pytest.param(True, {'metadata': {'finalizers': [FINALIZER]}}, id='normal'),
+    pytest.param(True, {'metadata': {'finalizers': ['fin']}}, id='normal'),
+    pytest.param(True, {'metadata': {'finalizers': ['other', 'fin']}}, id='mixed'),
     pytest.param(True, {'metadata': {'finalizers': [LEGACY_FINALIZER]}}, id='legacy'),
-    pytest.param(True, {'metadata': {'finalizers': ['other', FINALIZER]}}, id='mixed'),
 ])
 def test_has_finalizers(expected, body):
-    result = is_deletion_blocked(body=body)
+    result = is_deletion_blocked(body=body, finalizer='fin')
     assert result == expected
 
 
 def test_append_finalizers_to_others():
     body = {'metadata': {'finalizers': ['other1', 'other2']}}
     patch = {}
-    block_deletion(body=body, patch=patch)
-    assert patch == {'metadata': {'finalizers': ['other1', 'other2', FINALIZER]}}
+    block_deletion(body=body, patch=patch, finalizer='fin')
+    assert patch == {'metadata': {'finalizers': ['other1', 'other2', 'fin']}}
 
 
 def test_append_finalizers_to_empty():
     body = {}
     patch = {}
-    block_deletion(body=body, patch=patch)
-    assert patch == {'metadata': {'finalizers': [FINALIZER]}}
+    block_deletion(body=body, patch=patch, finalizer='fin')
+    assert patch == {'metadata': {'finalizers': ['fin']}}
 
 
 def test_append_finalizers_when_present():
-    body = {'metadata': {'finalizers': ['other1', FINALIZER, 'other2']}}
+    body = {'metadata': {'finalizers': ['other1', 'fin', 'other2']}}
     patch = {}
-    block_deletion(body=body, patch=patch)
+    block_deletion(body=body, patch=patch, finalizer='fin')
     assert patch == {}
 
 
 @pytest.mark.parametrize('finalizer', [
     pytest.param(LEGACY_FINALIZER, id='legacy'),
-    pytest.param(FINALIZER, id='normal'),
+    pytest.param('fin', id='normal'),
 ])
 def test_remove_finalizers_keeps_others(finalizer):
     body = {'metadata': {'finalizers': ['other1', finalizer, 'other2']}}
     patch = {}
-    allow_deletion(body=body, patch=patch)
+    allow_deletion(body=body, patch=patch, finalizer='fin')
     assert patch == {'metadata': {'finalizers': ['other1', 'other2']}}
 
 
 def test_remove_finalizers_when_absent():
     body = {'metadata': {'finalizers': ['other1', 'other2']}}
     patch = {}
-    allow_deletion(body=body, patch=patch)
+    allow_deletion(body=body, patch=patch, finalizer='fin')
     assert patch == {}
 
 
 def test_remove_finalizers_when_empty():
     body = {}
     patch = {}
-    allow_deletion(body=body, patch=patch)
+    allow_deletion(body=body, patch=patch, finalizer='fin')
     assert patch == {}


### PR DESCRIPTION
## What do these changes do?

Make finalizer's name configurable, thus allowing multiple operator with different identities to handle the same resources with advanced handlers (anything different than `on.event`).

## Description

As a side-effect of #331, the operator gained possibility to change its own identity by using different prefixes or fields instead of the hard-coded Kopf's names/domains. This allowed multiple operators handling the same resources with advanced handlers (anything different than `on.event`; e.g. `on.create`, `on.update`, `on.delete`, etc; also, `kopf.daemon` & `kopf.timer`).

However, only one finalizer was used for all operators: `kopf.zalando.org/KopfFinalizerMarker` (hard-coded). This could lead to different operators possibly colliding with each other.

With this PR, it is now possible to also configure the finalizer's name/domain. This is the final thing with operator's identity left that could not be configured.


## Issues/PRs

> Issues: #23 #283 


## Type of changes

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
