### PR TITLE
Provide helpers to combine few callbacks for body-/meta-filters

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -83,3 +83,25 @@ By arbitrary callbacks
                     annotations={'some-annotation': check_value})
     def my_handler(spec, **_):
         pass
+
+Kopf provides few helpers to combine multiple callbacks into one
+(the semantics is the same as for Python's built-in functions)::
+
+    import kopf
+
+    def whole_fn1(name, **_): return name.startswith('kopf-')
+    def whole_fn2(spec, **_): return spec.get('field') == 'value'
+    def value_fn1(value, **_): return value.startswith('some')
+    def value_fn2(value, **_): return value.endswith('label')
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
+                    when=kopf.all_([whole_fn1, whole_fn2]),
+                    labels={'somelabel': kopf.all_([value_fn1, value_fn2])})
+    def create_fn1(**_):
+        pass
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
+                    when=kopf.any_([whole_fn1, whole_fn2]),
+                    labels={'somelabel': kopf.any_([value_fn1, value_fn2])})
+    def create_fn2(**_):
+        pass

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -105,3 +105,10 @@ Kopf provides few helpers to combine multiple callbacks into one
                     labels={'somelabel': kopf.any_([value_fn1, value_fn2])})
     def create_fn2(**_):
         pass
+
+The following wrappers are available:
+
+* `kopf.not_(fn)` -- the function must return ``False`` to pass the filters.
+* `kopf.any_([...])` -- at least one of the functions must return ``True``.
+* `kopf.all_([...])` -- all of the functions must return ``True``.
+* `kopf.none_([...])` -- all of the functions must return ``False``.

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -95,8 +95,10 @@ from kopf.structs.bodies import (
     build_owner_reference,
 )
 from kopf.structs.callbacks import (
+    not_,
     all_,
     any_,
+    none_,
 )
 from kopf.structs.configuration import (
     OperatorSettings,
@@ -166,8 +168,10 @@ __all__ = [
     'event', 'info', 'warn', 'exception',
     'spawn_tasks', 'run_tasks', 'operator', 'run', 'create_tasks',
     'adopt', 'label',
+    'not_',
     'all_',
     'any_',
+    'none_',
     'get_default_lifecycle', 'set_default_lifecycle',
     'build_object_reference', 'build_owner_reference',
     'append_owner_reference', 'remove_owner_reference',

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -94,6 +94,10 @@ from kopf.structs.bodies import (
     build_object_reference,
     build_owner_reference,
 )
+from kopf.structs.callbacks import (
+    all_,
+    any_,
+)
 from kopf.structs.configuration import (
     OperatorSettings,
 )
@@ -162,6 +166,8 @@ __all__ = [
     'event', 'info', 'warn', 'exception',
     'spawn_tasks', 'run_tasks', 'operator', 'run', 'create_tasks',
     'adopt', 'label',
+    'all_',
+    'any_',
     'get_default_lifecycle', 'set_default_lifecycle',
     'build_object_reference', 'build_owner_reference',
     'append_owner_reference', 'remove_owner_reference',

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -176,49 +176,25 @@ class MetaFilterFn(Protocol):
 _FnT = TypeVar('_FnT', WhenFilterFn, MetaFilterFn)
 
 
+def not_(fn: _FnT) -> _FnT:
+    def not_fn(*args: Any, **kwargs: Any) -> bool:
+        return not fn(*args, **kwargs)
+    return not_fn
+
+
 def all_(fns: Collection[_FnT]) -> _FnT:
-    """
-    Combine few callbacks into one::
-
-        import kopf
-
-        def whole_fn1(name, **_): return name.startswith('kopf-')
-        def whole_fn2(spec, **_): return spec.get('field') == 'value'
-        def value_fn1(value, **_): return value.startswith('some')
-        def value_fn2(value, **_): return value.endswith('label')
-
-        @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
-                        when=kopf.all_([whole_fn1, whole_fn2]),
-                        labels={'somelabel': kopf.all_([value_fn1, value_fn2])})
-        def create_fn(**_):
-            pass
-
-    The semantics is the same as for Python's built-in :func:`all`.
-    """
     def all_fn(*args: Any, **kwargs: Any) -> bool:
         return all(fn(*args, **kwargs) for fn in fns)
     return all_fn
 
 
 def any_(fns: Collection[_FnT]) -> _FnT:
-    """
-    Combine few callbacks into one::
-
-        import kopf
-
-        def whole_fn1(name, **_): return name.startswith('kopf-')
-        def whole_fn2(spec, **_): return spec.get('field') == 'value'
-        def value_fn1(value, **_): return value.startswith('some')
-        def value_fn2(value, **_): return value.endswith('label')
-
-        @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
-                        when=kopf.any_([whole_fn1, whole_fn2]),
-                        labels={'somelabel': kopf.any_([value_fn1, value_fn2])})
-        def create_fn(**_):
-            pass
-
-    The semantics is the same as for Python's built-in :func:`any`.
-    """
     def any_fn(*args: Any, **kwargs: Any) -> bool:
         return any(fn(*args, **kwargs) for fn in fns)
     return any_fn
+
+
+def none_(fns: Collection[_FnT]) -> _FnT:
+    def none_fn(*args: Any, **kwargs: Any) -> bool:
+        return not any(fn(*args, **kwargs) for fn in fns)
+    return none_fn

--- a/tests/test_filtering_helpers.py
+++ b/tests/test_filtering_helpers.py
@@ -17,49 +17,85 @@ def _always2(*_, **__):
     return True
 
 
-def test_all_when_all_are_true():
+def test_notfn_when_true():
+    combined = kopf.not_(_always1)
+    result = combined()
+    assert result is False
+
+
+def test_notfn_when_false():
+    combined = kopf.not_(_never1)
+    result = combined()
+    assert result is True
+
+
+def test_allfn_when_all_are_true():
     combined = kopf.all_([_always1, _always2])
     result = combined()
     assert result is True
 
 
-def test_all_when_one_is_false():
+def test_allfn_when_one_is_false():
     combined = kopf.all_([_always1, _never1])
     result = combined()
     assert result is False
 
 
-def test_all_when_all_are_false():
+def test_allfn_when_all_are_false():
     combined = kopf.all_([_never1, _never2])
     result = combined()
     assert result is False
 
 
-def test_all_when_no_functions():
+def test_allfn_when_no_functions():
     combined = kopf.all_([])
     result = combined()
     assert result is True
 
 
-def test_any_when_all_are_true():
+def test_anyfn_when_all_are_true():
     combined = kopf.any_([_always1, _always2])
     result = combined()
     assert result is True
 
 
-def test_any_when_one_is_false():
+def test_anyfn_when_one_is_false():
     combined = kopf.any_([_always1, _never1])
     result = combined()
     assert result is True
 
 
-def test_any_when_all_are_false():
+def test_anyfn_when_all_are_false():
     combined = kopf.any_([_never1, _never2])
     result = combined()
     assert result is False
 
 
-def test_any_when_no_functions():
+def test_anyfn_when_no_functions():
     combined = kopf.any_([])
     result = combined()
     assert result is False
+
+
+def test_nonefn_when_all_are_true():
+    combined = kopf.none_([_always1, _always2])
+    result = combined()
+    assert result is False
+
+
+def test_nonefn_when_one_is_false():
+    combined = kopf.none_([_always1, _never1])
+    result = combined()
+    assert result is False
+
+
+def test_nonefn_when_all_are_false():
+    combined = kopf.none_([_never1, _never2])
+    result = combined()
+    assert result is True
+
+
+def test_nonefn_when_no_functions():
+    combined = kopf.none_([])
+    result = combined()
+    assert result is True

--- a/tests/test_filtering_helpers.py
+++ b/tests/test_filtering_helpers.py
@@ -1,0 +1,65 @@
+import kopf
+
+
+def _never1(*_, **__):
+    return False
+
+
+def _never2(*_, **__):
+    return False
+
+
+def _always1(*_, **__):
+    return True
+
+
+def _always2(*_, **__):
+    return True
+
+
+def test_all_when_all_are_true():
+    combined = kopf.all_([_always1, _always2])
+    result = combined()
+    assert result is True
+
+
+def test_all_when_one_is_false():
+    combined = kopf.all_([_always1, _never1])
+    result = combined()
+    assert result is False
+
+
+def test_all_when_all_are_false():
+    combined = kopf.all_([_never1, _never2])
+    result = combined()
+    assert result is False
+
+
+def test_all_when_no_functions():
+    combined = kopf.all_([])
+    result = combined()
+    assert result is True
+
+
+def test_any_when_all_are_true():
+    combined = kopf.any_([_always1, _always2])
+    result = combined()
+    assert result is True
+
+
+def test_any_when_one_is_false():
+    combined = kopf.any_([_always1, _never1])
+    result = combined()
+    assert result is True
+
+
+def test_any_when_all_are_false():
+    combined = kopf.any_([_never1, _never2])
+    result = combined()
+    assert result is False
+
+
+def test_any_when_no_functions():
+    combined = kopf.any_([])
+    result = combined()
+    assert result is False


### PR DESCRIPTION
## What do these changes do?

Little helpers to combined few callbacks for `when=` or labels/annotations filters.


## Description

Nothing more that a little bit of syntax sugar with `kopf.all_()` and `kopf.any_()`:

```python

import kopf

def whole_fn1(name, **_): return name.startswith('kopf-')
def whole_fn2(spec, **_): return spec.get('field') == 'value'
def value_fn1(value, **_): return value.startswith('some')
def value_fn2(value, **_): return value.endswith('label')

@kopf.on.create('zalando.org', 'v1', 'kopfexamples',
                when=kopf.all_([whole_fn1, whole_fn2]),
                labels={'somelabel': kopf.all_([value_fn1, value_fn2])})
def create_fn1(**_):
    pass

@kopf.on.create('zalando.org', 'v1', 'kopfexamples',
                when=kopf.any_([whole_fn1, whole_fn2]),
                labels={'somelabel': kopf.any_([value_fn1, value_fn2])})
def create_fn2(**_):
    pass
```

Based on the experience when few arbitrary criteria should be combined onto one criterion, but it looks ugly to add too many one-liner single-use functions that call real meaningful functions with `and`/`or` operators.


## Issues/PRs

> Issues: #123 #98 


## Type of changes

- New feature (non-breaking change which adds functionality)


## Checklist

- [X] The code addresses only the mentioned problem, and this problem only
- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
