### PR TITLE
Limit persistence annotations to 63 chars

### DIFF
--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+
+from kopf.structs.bodies import Body
+from kopf.structs.handlers import HandlerId
+from kopf.structs.patches import Patch
+from kopf.storage.progress import ProgressRecord, AnnotationsProgressStorage, SmartProgressStorage
+
+ANNOTATIONS_POPULATING_STORAGES = [AnnotationsProgressStorage, SmartProgressStorage]
+
+CONTENT_DATA = ProgressRecord(
+    started='2020-01-01T00:00:00',
+    stopped='2020-12-31T23:59:59',
+    delayed='3000-01-01T00:00:00',
+    retries=0,
+    success=False,
+    failure=False,
+    message=None,
+)
+
+CONTENT_JSON = json.dumps(CONTENT_DATA)  # the same serialisation for all environments
+
+
+keys = pytest.mark.parametrize('prefix, provided_key, expected_key', [
+
+    # For character replacements (only those that happen in our own ids, not all of them).
+    ['my-operator.example.com', 'a_b.c-d/e', 'my-operator.example.com/a_b.c-d.e'],
+    [None, 'a_b.c-d/e', 'a_b.c-d.e'],
+
+    # For length cutting. Hint: the prefix length is 23, the remaining space is 63 - 23 - 1 = 39.
+    # The suffix itself (if appended) takes 9, so it is 30 left. The same math for no prefix.
+    ['my-operator.example.com', 'x', 'my-operator.example.com/x'],
+    ['my-operator.example.com', 'x' * 39, 'my-operator.example.com/' + 'x' * 39],
+    ['my-operator.example.com', 'x' * 40, 'my-operator.example.com/' + 'x' * 30 + '-tEokcg--'],
+    ['my-operator.example.com', 'y' * 40, 'my-operator.example.com/' + 'y' * 30 + '-VZlvhw--'],
+    ['my-operator.example.com', 'z' * 40, 'my-operator.example.com/' + 'z' * 30 + '-LlPQyA--'],
+    [None, 'x', 'x'],
+    [None, 'x' * 63, 'x' * 63],
+    [None, 'x' * 64, 'x' * 54 + '-SItAqA--'],
+    [None, 'y' * 64, 'y' * 54 + '-0d251g--'],
+    [None, 'z' * 64, 'z' * 54 + '-E7wvIA--'],
+
+    # For special chars in base64 encoding ("+" and "/"), which are not compatible with K8s.
+    # The numbers are found empirically so that both "/" and "+" are found in the base64'ed digest.
+    ['my-operator.example.com', 'fn' * 323, 'my-operator.example.com/' + 'fn' * 15 + '-Az-r.g--'],
+    [None, 'fn' * 323, 'fn' * 27 + '-Az-r.g--'],
+
+])
+
+
+@keys
+def test_key_hashing(prefix, provided_key, expected_key):
+    storage = AnnotationsProgressStorage(prefix=prefix)
+    returned_key = storage.make_key(provided_key)
+    assert returned_key == expected_key
+
+
+@keys
+@pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
+def test_keys_hashed_on_fetching(cls, prefix, provided_key, expected_key):
+    storage = cls(prefix=prefix)
+    body = Body({'metadata': {'annotations': {expected_key: CONTENT_JSON}}})
+    record = storage.fetch(body=body, key=HandlerId(provided_key))
+    assert record is not None
+    assert record == CONTENT_DATA
+
+
+@keys
+@pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
+def test_keys_normalized_on_storing(cls, prefix, provided_key, expected_key):
+    storage = cls(prefix=prefix)
+    patch = Patch()
+    body = Body({'metadata': {'annotations': {expected_key: 'null'}}})
+    storage.store(body=body, patch=patch, key=HandlerId(provided_key), record=CONTENT_DATA)
+    assert set(patch.metadata.annotations) == {expected_key}
+
+
+@keys
+@pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
+def test_keys_normalized_on_purging(cls, prefix, provided_key, expected_key):
+    storage = cls(prefix=prefix)
+    patch = Patch()
+    body = Body({'metadata': {'annotations': {expected_key: 'null'}}})
+    storage.purge(body=body, patch=patch, key=HandlerId(provided_key))
+    assert set(patch.metadata.annotations) == {expected_key}
+
+
+@keys
+@pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
+def test_keys_normalized_on_touching(cls, prefix, provided_key, expected_key):
+    storage = cls(prefix=prefix, touch_key=provided_key)
+    patch = Patch()
+    body = Body({})
+    storage.touch(body=body, patch=patch, value='irrelevant')
+    assert set(patch.metadata.annotations) == {expected_key}


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes (1-3 sentences). -->


## Description

An issue found the hard way (though we hit it before): when an annotation's name is 64 or more characters, it is not accepted by K8s API. This is [documented](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).

For example if we have a prefix, a long function name, and maybe a field suffix: `kopf.zalando.org/some_resource_of_interest_created.status.childname` — and oops, it is 67 already, while 63 is allowed.

This PR fixes the issue with lengthy handler ids by cutting their tail, and replacing it with some consistent one-way hash — this makes the annotation unique enough, and still recognisable/readable for the primary part of its name.


## Issues/PRs

> Issues: #331 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
