### PR TITLE
Crash the whole operator on unrecoverable errors in watchers/workers

### DIFF
--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -224,17 +224,16 @@ async def daemon_killer(
     # Sleep forever, or until cancelled, which happens when the operator begins its shutdown.
     try:
         await asyncio.Event().wait()
-    except asyncio.CancelledError:
-        pass
 
     # Terminate all running daemons when the operator exits (and this task is cancelled).
-    coros = [
-        stop_daemon(daemon=daemon, settings=settings)
-        for memory in memories.iter_all_memories()
-        for daemon in memory.running_daemons.values()
-    ]
-    if coros:
-        await asyncio.wait(coros)
+    finally:
+        coros = [
+            stop_daemon(daemon=daemon, settings=settings)
+            for memory in memories.iter_all_memories()
+            for daemon in memory.running_daemons.values()
+        ]
+        if coros:
+            await asyncio.wait(coros)
 
 
 async def stop_daemon(

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -73,7 +73,6 @@ ObjectRef = Tuple[resources.Resource, ObjectUid]
 Streams = MutableMapping[ObjectRef, Stream]
 
 
-# TODO: add the label_selector support for the dev-mode?
 async def watcher(
         namespace: Union[None, str],
         settings: configuration.OperatorSettings,
@@ -186,8 +185,7 @@ async def worker(
             try:
                 await processor(raw_event=raw_event, replenished=replenished)
             except Exception:
-                # TODO: processor is a functools.partial. make the prints a bit nicer by removing it.
-                logger.exception(f"{processor} failed with an exception. Ignoring the event.")
+                logger.exception("Event processing failed with an exception. Ignoring the event.")
                 # raise
 
     finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e .
 
 # Everything needed to develop (test, debug) the framework.
-coverage<5.0  # manual enforcement where pip fails, see #272.
+coverage
 pytest-aiohttp
 pytest-asyncio==0.10.0  # until fixed: https://github.com/pytest-dev/pytest-asyncio/issues/154
 pytest-mock

--- a/tests/reactor/conftest.py
+++ b/tests/reactor/conftest.py
@@ -54,6 +54,7 @@ def watcher_in_background(settings, resource, event_loop, worker_spy, stream):
         resource=resource,
         settings=settings,
         processor=do_nothing,
+        fatal_flag=asyncio.Event(),
     )
     task = event_loop.create_task(coro)
 

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -60,6 +60,7 @@ async def test_watchevent_demultiplexing(worker_mock, timer, resource, processor
             resource=resource,
             settings=settings,
             processor=processor,
+            fatal_flag=asyncio.Event(),
         )
 
     # The streams are not cleared by the mocked worker, but the worker exits fast.
@@ -135,6 +136,7 @@ async def test_watchevent_batching(settings, resource, processor, timer,
             resource=resource,
             settings=settings,
             processor=processor,
+            fatal_flag=asyncio.Event(),
         )
 
     # Significantly less than the queue getting timeout, but sufficient to run.


### PR DESCRIPTION
## What do these changes do?

When a fatal error happens in the operator's watching, queueing, multiplexing, or processing, including API PATCH'ing, then stop the whole operator instead of ignoring and continuing.

## Description

This issue was detected in an incident when PATCH request failed due to HTTP 422 "Unprocessable Entity" (#346). Instead of stopping or slowing down any attempts, the operator continued handling repeatedly with 1-2 attempts per second.

On a wider scope, if _anything_ goes wrong in the top-level processing, i.e. before handlers (which have their own error handling and backoff intervals), then crash the whole operator, and let Kubernetes to deal with a broken pod. 

This does not prevent incidents with repeated handling completely, but will slow them down at least (restarts are not fast). 

All in all, this should protect the users from the framework/operators misbehaviour in some rare cases. In all other cases, nothing changes for the users.


---

**Note:** A separate fix will be made (#351) with throttling of unrecoverable errors on a per-resource basis from approximately when the processing begins, and until the handlers (this covers resource PATCH'ing). The operator will stop anyway for errors from watching to that point of processing, but this is a much more narrow scope.

**Implementation note:** there is already a safety net for the root tasks, such as watchers: if they fail, the operator stops. But the workers are not covered by this, since they are fire-and-forget kind of tasks. So, they should "escalate" the errors their own way — via fatal-flag-setting and own stack trace dumping.

---

Side-changes:

* Log daemon-killer's exit reason as "cancelled" (as all other tasks), not as "exited unexpectedly" — due to no `asyncio.CancelledError` raised from inside.
* Cover the queue pulling and event batching by this unexpected errors safety net too — by shifting the `except:` block left. This is unlikely to happen, but just in case.
* Stop logging the `functools.partial` objects (processors) with all their arguments. This could eventually lead to some data leaks to the logs.


## Issues/PRs

> Issues: #346 

> Related: #331 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
