### PR TITLE
Force annotations to end strictly with alphanumeric characters

### DIFF
--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -232,13 +232,14 @@ class AnnotationsProgressStorage(ProgressStorage):
 
         # K8s has a limitation of 63 chars per annotation/label key.
         # Force it to 63 chars by replacing the tail with a consistent hash (with full alphabet).
+        # Force it to end with alnums instead of altchars or trailing chars (K8s requirement).
         prefix = f'{self.prefix}/' if self.prefix else ''
         if len(safe_key) <= max_length - len(prefix):
             suffix = ''
         else:
             digest = hashlib.blake2b(safe_key.encode('utf-8'), digest_size=4).digest()
-            alnums = base64.b64encode(digest, altchars=b'-.').replace(b'=', b'-').decode('ascii')
-            suffix = f'-{alnums}'
+            alnums = base64.b64encode(digest, altchars=b'-.').decode('ascii')
+            suffix = f'-{alnums}'.rstrip('=-.')
 
         full_key = f'{prefix}{safe_key[:max_length - len(prefix) - len(suffix)]}{suffix}'
         return full_key

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -32,19 +32,19 @@ keys = pytest.mark.parametrize('prefix, provided_key, expected_key', [
     # The suffix itself (if appended) takes 9, so it is 30 left. The same math for no prefix.
     ['my-operator.example.com', 'x', 'my-operator.example.com/x'],
     ['my-operator.example.com', 'x' * 39, 'my-operator.example.com/' + 'x' * 39],
-    ['my-operator.example.com', 'x' * 40, 'my-operator.example.com/' + 'x' * 30 + '-tEokcg--'],
-    ['my-operator.example.com', 'y' * 40, 'my-operator.example.com/' + 'y' * 30 + '-VZlvhw--'],
-    ['my-operator.example.com', 'z' * 40, 'my-operator.example.com/' + 'z' * 30 + '-LlPQyA--'],
+    ['my-operator.example.com', 'x' * 40, 'my-operator.example.com/' + 'x' * 30 + 'xx-tEokcg'],
+    ['my-operator.example.com', 'y' * 40, 'my-operator.example.com/' + 'y' * 30 + 'yy-VZlvhw'],
+    ['my-operator.example.com', 'z' * 40, 'my-operator.example.com/' + 'z' * 30 + 'zz-LlPQyA'],
     [None, 'x', 'x'],
     [None, 'x' * 63, 'x' * 63],
-    [None, 'x' * 64, 'x' * 54 + '-SItAqA--'],
-    [None, 'y' * 64, 'y' * 54 + '-0d251g--'],
-    [None, 'z' * 64, 'z' * 54 + '-E7wvIA--'],
+    [None, 'x' * 64, 'x' * 54 + 'xx-SItAqA'],  # base64: SItAqA==
+    [None, 'y' * 64, 'y' * 54 + 'yy-0d251g'],  # base64: 0d251g==
+    [None, 'z' * 64, 'z' * 54 + 'zz-E7wvIA'],  # base64: E7wvIA==
 
     # For special chars in base64 encoding ("+" and "/"), which are not compatible with K8s.
     # The numbers are found empirically so that both "/" and "+" are found in the base64'ed digest.
-    ['my-operator.example.com', 'fn' * 323, 'my-operator.example.com/' + 'fn' * 15 + '-Az-r.g--'],
-    [None, 'fn' * 323, 'fn' * 27 + '-Az-r.g--'],
+    ['my-operator.example.com', 'fn' * 323, 'my-operator.example.com/' + 'fn' * 15 + 'fn-Az-r.g'],
+    [None, 'fn' * 323, 'fn' * 27 + 'fn-Az-r.g'],  # base64: Az-r.g==
 
 ])
 


### PR DESCRIPTION
## What do these changes do?

Force annotation names to end strictly with alphanumeric characters, not only to fit into 63 chars.

_"Learning Kubernetes the hard way."_

## Description

The annotation names are not only limited to 63 characters, and not only to a specific alphabet, but also to the beginning/ending characters. Otherwise, it fails to patch:

```
$ kubectl patch … --type=merge -p '{"metadata": {"annotations": {"kopf.zalando.org/long.handler.id.here-WumEzA--": "{}"}}}'

The … is invalid: metadata.annotations: Invalid value: "kopf.zalando.org/long.handler.id.here-WumEzA--": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')
```

Since base64 of a digest was used to make the shortened annotations names unique in #346, it can end with `=` characters, for example. 

In this case, we do not need the actual base64'ed value, we just need a persistent and unique suffix. So, cutting those special non-alphanumeric characters is fine.

The change is backward compatible (despite the hashing function change since 0.27rc4): first, it was never released beyond RC; second, it was not working for non-alphanumeric annotations anyway. Proper alphanumeric annotations will remain the same as in 0.27rc4.


## Issues/PRs

> Issues: #331 

> Related: #346 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
