### PR TITLE
Wait for instantly exiting daemons/timers for more than one asyncio cycle

### DIFF
--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -361,7 +361,8 @@ async def _resource_daemon(
             cause.patch.clear()
 
         # The in-memory sleep does not react to resource changes, but only to stopping.
-        await sleeping.sleep_or_wait(state.delay, cause.stopper)
+        if state.delay:
+            await sleeping.sleep_or_wait(state.delay, cause.stopper)
 
     if cause.stopper.is_set():
         logger.debug(f"{handler} has exited on request and will not be retried or restarted.")

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -318,7 +318,7 @@ async def process_resource_spawning_cause(
     if finalizers.is_deletion_ongoing(cause.body):
         stopping_delays = await daemons.stop_resource_daemons(
             settings=settings,
-            daemons=memory.daemons,
+            daemons=memory.running_daemons,
         )
         return stopping_delays
 
@@ -329,14 +329,14 @@ async def process_resource_spawning_cause(
         )
         spawning_delays = await daemons.spawn_resource_daemons(
             settings=settings,
-            daemons=memory.daemons,
+            daemons=memory.running_daemons,
             cause=cause,
             memory=memory,
             handlers=handlers,
         )
         matching_delays = await daemons.match_resource_daemons(
             settings=settings,
-            daemons=memory.daemons,
+            daemons=memory.running_daemons,
             handlers=handlers,
         )
         return list(spawning_delays) + list(matching_delays)

--- a/kopf/structs/configuration.py
+++ b/kopf/structs/configuration.py
@@ -186,10 +186,25 @@ class PersistenceSettings:
 
 
 @dataclasses.dataclass
+class BackgroundSettings:
+    """
+    Settings for background routines in general, daemons & timers specifically.
+    """
+
+    cancellation_polling: float = 60
+    """
+    How often (in seconds) to poll the status of an exiting daemon/timer
+    when it has no cancellation timeout set (i.e. when it is assumed to
+    exit gracefully by its own, but it does not).
+    """
+
+
+@dataclasses.dataclass
 class OperatorSettings:
     logging: LoggingSettings = dataclasses.field(default_factory=LoggingSettings)
     posting: PostingSettings = dataclasses.field(default_factory=PostingSettings)
     watching: WatchingSettings = dataclasses.field(default_factory=WatchingSettings)
     batching: BatchingSettings = dataclasses.field(default_factory=BatchingSettings)
     execution: ExecutionSettings = dataclasses.field(default_factory=ExecutionSettings)
+    background: BackgroundSettings = dataclasses.field(default_factory=BackgroundSettings)
     persistence: PersistenceSettings = dataclasses.field(default_factory=PersistenceSettings)

--- a/kopf/structs/configuration.py
+++ b/kopf/structs/configuration.py
@@ -198,6 +198,51 @@ class BackgroundSettings:
     exit gracefully by its own, but it does not).
     """
 
+    instant_exit_timeout: Optional[float] = None
+    """
+    For how long (in seconds) to wait for a daemon/timer to exit instantly.
+
+    If they continue running after the stopper is set for longer than this time,
+    then external polling is initiated via the resource's persistence storages,
+    as for regular handlers.
+
+    The "instant exit" timeout is neither combined with any other timeouts, nor
+    deducted from any other timeouts, such as the daemon cancellation timeout.
+    
+    So, keep the timeout low: 0.001, 0.01, or 0.1 are good enough; 1.0 is risky.
+    Big delays can cause slower operator reaction to the resource deletion
+    or operator exiting, but can reduce the amount of unnecessary patches.
+
+    If the timeout is not set (the default), then a limited amount of zero-time
+    asyncio event loop cycles is used instead.
+    """
+
+    instant_exit_zero_time_cycles: Optional[int] = 10
+    """
+    How many asyncio cycles to give to a daemon/timer to exit instantly. 
+
+    There is a speed-up hack to let the daemons/timers to exit instantly,
+    without external patching & polling. For this, ``asyncio.sleep(0)`` is used
+    to give control back to the event loop and their coroutines. However,
+    the daemons/timers can do extra `await` calls (even zero-time) before
+    actually exiting, which prematurely returns the control flow back
+    to the daemon-stopper coroutine.
+
+    This configuration value is a maximum amount of zero-time `await` statements
+    that can happen before exiting: both in the daemon and in the framework.
+
+    It the daemons/timers coroutines exit earlier, extra cycles are not used.
+    If they continue running after that, then external polling is initiated
+    via the resource's persistence storages, as for regular handlers.
+
+    All of this happens with zero delays, so no slowdown is expected
+    (but a bit of CPU will be consumed).
+
+    If an "instant exit" timeout is set, the zero-time cycles are not used.
+
+    PS: The default value is a rough guess on a typical code complexity.
+    """
+
 
 @dataclasses.dataclass
 class OperatorSettings:

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -25,8 +25,6 @@ else:
     asyncio_Task = asyncio.Task
     asyncio_Future = asyncio.Future
 
-DaemonId = NewType('DaemonId', str)
-
 
 @dataclasses.dataclass(frozen=True)
 class Daemon:
@@ -70,7 +68,7 @@ class ResourceMemory:
     live_fresh_body: Optional[bodies.Body] = None
     idle_reset_time: float = dataclasses.field(default_factory=time.monotonic)
     forever_stopped: Set[handlers.HandlerId] = dataclasses.field(default_factory=set)
-    daemons: Dict[DaemonId, Daemon] = dataclasses.field(default_factory=dict)
+    running_daemons: Dict[handlers.HandlerId, Daemon] = dataclasses.field(default_factory=dict)
 
 
 class ResourceMemories:

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -25,8 +25,7 @@ async def test_daemon_stopped_on_permanent_error(
 
     assert dummy.mock.call_count == 1
     assert k8s_mocked.patch_obj.call_count == 0
-    assert k8s_mocked.sleep_or_wait.call_count == 1  # one for each retry
-    assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] is None
+    assert k8s_mocked.sleep_or_wait.call_count == 0
 
     assert_logs([
         "Daemon 'fn' failed permanently: boo!",
@@ -57,8 +56,7 @@ async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
     await dummy.wait_for_daemon_done()
 
     assert dummy.mock.call_count == 1
-    assert k8s_mocked.sleep_or_wait.call_count == 1  # one for each retry
-    assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] is None
+    assert k8s_mocked.sleep_or_wait.call_count == 0
 
     assert_logs([
         "Daemon 'fn' failed with an exception. Will stop.",
@@ -92,9 +90,8 @@ async def test_daemon_retried_on_temporary_error(
     await dummy.steps['finish'].wait()
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep_or_wait.call_count == 2  # one for each retry
+    assert k8s_mocked.sleep_or_wait.call_count == 1  # one for each retry
     assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
-    assert k8s_mocked.sleep_or_wait.call_args_list[1][0][0] is None
 
     assert_logs([
         "Daemon 'fn' failed temporarily: boo!",
@@ -127,9 +124,8 @@ async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
     await dummy.steps['finish'].wait()
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep_or_wait.call_count == 2  # one for each retry
+    assert k8s_mocked.sleep_or_wait.call_count == 1  # one for each retry
     assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
-    assert k8s_mocked.sleep_or_wait.call_args_list[1][0][0] is None
 
     assert_logs([
         "Daemon 'fn' failed with an exception. Will retry.",
@@ -154,11 +150,10 @@ async def test_daemon_retried_until_retries_limit(
     await dummy.steps['called'].wait()
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep_or_wait.call_count == 4  # one for each retry
+    assert k8s_mocked.sleep_or_wait.call_count == 3  # one for each retry
     assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
     assert k8s_mocked.sleep_or_wait.call_args_list[1][0][0] == 1.0  # [call#][args/kwargs][arg#]
     assert k8s_mocked.sleep_or_wait.call_args_list[2][0][0] == 1.0  # [call#][args/kwargs][arg#]
-    assert k8s_mocked.sleep_or_wait.call_args_list[3][0][0] is None
 
 
 async def test_daemon_retried_until_timeout(
@@ -177,8 +172,7 @@ async def test_daemon_retried_until_timeout(
     await dummy.steps['called'].wait()
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep_or_wait.call_count == 4  # one for each retry
+    assert k8s_mocked.sleep_or_wait.call_count == 3  # one for each retry
     assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
     assert k8s_mocked.sleep_or_wait.call_args_list[1][0][0] == 1.0  # [call#][args/kwargs][arg#]
     assert k8s_mocked.sleep_or_wait.call_args_list[2][0][0] == 1.0  # [call#][args/kwargs][arg#]
-    assert k8s_mocked.sleep_or_wait.call_args_list[3][0][0] is None

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -34,13 +34,58 @@ async def test_daemon_exits_gracefully_and_instantly_via_stopper(
         await dummy.wait_for_daemon_done()
 
     assert timer.seconds < 0.01  # near-instantly
-    assert k8s_mocked.sleep_or_wait.call_count == 1
-    assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] is None
+    assert k8s_mocked.sleep_or_wait.call_count == 0
     assert k8s_mocked.patch_obj.call_count == 1
     assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['metadata']['finalizers'] == []
 
 
-async def test_daemon_exits_via_cancellation_with_backoff(
+async def test_daemon_exits_instantly_via_cancellation_with_backoff(
+        registry, settings, resource, dummy, simulate_cycle,
+        caplog, assert_logs, k8s_mocked, frozen_time, mocker):
+    caplog.set_level(logging.DEBUG)
+    dummy.steps['finish'].set()
+
+    # A daemon-under-test.
+    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+                 cancellation_backoff=5, cancellation_timeout=10)
+    async def fn(**kwargs):
+        dummy.kwargs = kwargs
+        dummy.steps['called'].set()
+        try:
+            await asyncio.Event().wait()  # this one is cancelled.
+        except asyncio.CancelledError:
+            await dummy.steps['finish'].wait()  # simulated slow (non-instant) exiting.
+
+    # Trigger spawning and wait until ready. Assume the finalizers are already added.
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
+    await simulate_cycle(event_object)
+    await dummy.steps['called'].wait()
+
+    # 1st stage: trigger termination due to resource deletion. Wait for backoff.
+    mocker.resetall()
+    event_object.setdefault('metadata', {}).update({'deletionTimestamp': '...'})
+    await simulate_cycle(event_object)
+
+    assert k8s_mocked.sleep_or_wait.call_count == 1
+    assert k8s_mocked.sleep_or_wait.call_args_list[0][0][0] == 5.0
+    assert k8s_mocked.patch_obj.call_count == 1
+    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['status']['kopf']['dummy']
+
+    # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
+    mocker.resetall()
+    frozen_time.tick(5)  # backoff time or slightly above it
+    await simulate_cycle(event_object)
+
+    assert k8s_mocked.sleep_or_wait.call_count == 0
+    assert k8s_mocked.patch_obj.call_count == 1
+    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['metadata']['finalizers'] == []
+
+    # Cleanup.
+    await dummy.wait_for_daemon_done()
+
+
+async def test_daemon_exits_slowly_via_cancellation_with_backoff(
         registry, settings, resource, dummy, simulate_cycle,
         caplog, assert_logs, k8s_mocked, frozen_time, mocker):
     caplog.set_level(logging.DEBUG)
@@ -51,7 +96,10 @@ async def test_daemon_exits_via_cancellation_with_backoff(
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
-        await asyncio.Event().wait()  # this one is cancelled.
+        try:
+            await asyncio.Event().wait()  # this one is cancelled.
+        except asyncio.CancelledError:
+            await dummy.steps['finish'].wait()  # simulated slow (non-instant) exiting.
 
     # Trigger spawning and wait until ready. Assume the finalizers are already added.
     finalizer = settings.persistence.finalizer
@@ -82,6 +130,8 @@ async def test_daemon_exits_via_cancellation_with_backoff(
     # 3rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()
     frozen_time.tick(1)  # any time below timeout
+    dummy.steps['finish'].set()
+    await asyncio.sleep(0)
     await simulate_cycle(event_object)
     await dummy.wait_for_daemon_done()
 


### PR DESCRIPTION
## What do these changes do?

Fix an issue in 0.27rc5 when resource deletion hangs for daemons/timers combined with other handlers — due to not allowing them a fair chance to exit instantly, despite they can.


## Description

Previously, when a daemon/timer was capable of exiting instantly, it didn't have enough event loop cycles to do that — only one cycle was given with only one `asyncio.sleep(0)`, while there could be a few `await` calls both in the daemon itself and in the framework's wrapping routines (even if it is zero-time, `await` gives control back to the event loop). 

This is especially important for timers, which spent most of their time in sleeping until the next trigger, so they definitely can exit instantly, but didn't have a chance due to 2-3 `await` uses internally.

Now, Kopf will give 10 zero-time asyncio cycles to such daemons/timers — i.e. up to 10 potential `await` statements since the stopper is set or the task is cancelled — and this is configurable. Alternatively, instead of the cycles, a short timeout can be used (e.g. 0.001-0.01-0.1 seconds or so) — also configurable.

This PR fixes the most common case when #356 can happen: in case of daemons and timers with "instant exit" implementation. The issue is still possible in case of actually slowly existing daemons combined with specific operator setup (due to no-op patches) — to be fixed separately in #???.

---

Additionally, some cleanup is performed in the code:

* Module-level constants are moved to configuration settings.
* Better log presentation is used for daemons/timers.
* `daemon_id` is removed since it is not needed anymore.


## Issues/PRs

> Issues: #356 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] ~Documentation reflects the changes~
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

_The settings are intentionally not documented in the docs, in order to not over-complicate the docs. These settings are extremely advanced, and the defaults should be enough for most or all uses-cases. Those who might ever need to change it, will probably dive deep to the source code to find it themselves._