### PR TITLE
Prevent premature finalizers removal for 2+ deletion handlers

### DIFF
--- a/kopf/storage/states.py
+++ b/kopf/storage/states.py
@@ -244,9 +244,9 @@ class State(Mapping[handlers_.HandlerId, HandlerState]):
         """
         now = datetime.datetime.utcnow()
         return [
-            max(0, (handler_state.delayed - now).total_seconds())
+            max(0, (handler_state.delayed - now).total_seconds()) if handler_state.delayed else 0
             for handler_state in self._states.values()
-            if handler_state.delayed
+            if not handler_state.finished
         ]
 
 

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -92,7 +92,8 @@ def handlers(clear_default_registry):
         return event_mock(**kwargs)
 
     # Keep on-resume on top, to catch any issues with the test design (where it could be skipped).
-    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn', timeout=600, retries=100)
+    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn', timeout=600, retries=100,
+                    deleted=True)  # only for resuming handles, to cover the resource being deleted.
     async def resume_fn(**kwargs):
         return resume_mock(**kwargs)
 
@@ -135,7 +136,8 @@ def extrahandlers(clear_default_registry, handlers):
         return event_mock(**kwargs)
 
     # Keep on-resume on top, to catch any issues with the test design (where it could be skipped).
-    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn2')
+    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn2',
+                    deleted=True)  # only for resuming handles, to cover the resource being deleted.
     async def resume_fn2(**kwargs):
         return resume_mock(**kwargs)
 


### PR DESCRIPTION
## What do these changes do?

Fix a bug when the finalizer was removed after the 1st deletion handler, preventing the 2nd and other deletion handlers from being invoked. 

This was not an issue for other (non-deletion) handlers.

## Description

Due to a recent change of criteria of "done" for handlers from "when done and reason=DELETE" to "when no delays left and deletionTimestamp is there" (commit 7adba026d949f9fe8d3b1420e296161b5eb207c3, PR #330), the actual "done" criterion was not used. The delays were empty all the time, which was mistakenly treated as "all is done".

With this fix, the unfinished (but not delayed) handlers will report a required delay of 0 seconds (meaning "try me immediately"). This, in turn, will prevent finalizers removal until all handlers are finished (i.e. none of them reported even a 0 delay).



## Issues/PRs

> Related: detected in #360, introduced in #330


## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
