### PR TITLE
Make coveralls optional in CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 
 script:
   - pytest --cov=kopf --cov-branch
-  - coveralls
+  - coveralls || true
   - codecov --flags unit
   - pytest --only-e2e  # NB: after the coverage uploads!
   - mypy kopf --strict --pretty


### PR DESCRIPTION
##  What do these changes do?

Fix sporadic issues with coveralls API: either 500s, or 422 Unprocessable Entity — by ignoring them.

## Description

It fails often with HTTP 422 Unprocessable Entity when posting results, especially after the retries. Make it optional. E.g. https://travis-ci.org/github/zalando-incubator/kopf/jobs/684865883

This might damage the assumulated coverage data, but failing our builds with no way of retrying (without fake commits) is more troublesome.

Sometimes, it fails with 5xx due to API overload. Retrying would be fine, but then it hits 422.


## Issues/PRs

> Issues:  #99 


## Type of changes

- Mostly CI/CD automation, contribution experience


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
