### PR TITLE
Fix an issue with client connection errors raised from initial request

### DIFF
--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -207,29 +207,30 @@ async def watch_objs(
     if timeout is not None:
         params['timeoutSeconds'] = str(timeout)
 
-    # Talk to the API and initiate a streaming response.
-    response = await context.session.get(
-        url=resource.get_url(server=context.server, namespace=namespace, params=params),
-        timeout=aiohttp.ClientTimeout(
-            total=settings.watching.client_timeout,
-            sock_connect=settings.watching.connect_timeout,
-        ),
-    )
-    response.raise_for_status()
-
     # Stream the parsed events from the response until it is closed server-side,
     # or until it is closed client-side by the freeze-waiting future's callbacks.
-    response_close_callback = lambda _: response.close()
-    freeze_waiter.add_done_callback(response_close_callback)
     try:
-        async with response:
-            async for line in _iter_jsonlines(response.content):
-                raw_input = cast(bodies.RawInput, json.loads(line.decode("utf-8")))
-                yield raw_input
+        response = await context.session.get(
+            url=resource.get_url(server=context.server, namespace=namespace, params=params),
+            timeout=aiohttp.ClientTimeout(
+                total=settings.watching.client_timeout,
+                sock_connect=settings.watching.connect_timeout,
+            ),
+        )
+        response.raise_for_status()
+
+        response_close_callback = lambda _: response.close()
+        freeze_waiter.add_done_callback(response_close_callback)
+        try:
+            async with response:
+                async for line in _iter_jsonlines(response.content):
+                    raw_input = cast(bodies.RawInput, json.loads(line.decode("utf-8")))
+                    yield raw_input
+        finally:
+            freeze_waiter.remove_done_callback(response_close_callback)
+
     except (aiohttp.ClientConnectionError, aiohttp.ClientPayloadError):
         pass
-    finally:
-        freeze_waiter.remove_done_callback(response_close_callback)
 
 
 async def _iter_jsonlines(


### PR DESCRIPTION
# What do these changes do?

Suppress all connection errors from the initial streaming request the same way as all connection errors from the continuous stream itself.

## Description

An issue was caused by an `aiohttp.client_exceptions.ServerDisconnectedError` raised from the initial streaming request:

```
[2020-05-25 10:44:44,924] kopf.reactor.running [ERROR ] Root task 'watcher of pods' is failed:	
Traceback (most recent call last):	
File "/usr/local/lib/python3.7/dist-packages/kopf/reactor/running.py", line 453, in _root_task_checker	
await coro	
File "/usr/local/lib/python3.7/dist-packages/kopf/reactor/queueing.py", line 109, in watcher	
async for raw_event in stream:	
File "/usr/local/lib/python3.7/dist-packages/kopf/clients/watching.py", line 75, in infinite_watch	
async for raw_event in stream:	
File "/usr/local/lib/python3.7/dist-packages/kopf/clients/watching.py", line 112, in streaming_watch	
async for raw_event in stream:	
File "/usr/local/lib/python3.7/dist-packages/kopf/clients/watching.py", line 146, in continuous_watch	
async for raw_input in stream:	
File "/usr/local/lib/python3.7/dist-packages/kopf/clients/auth.py", line 78, in wrapper	
async for item in fn(*args, **kwargs, context=context):	
File "/usr/local/lib/python3.7/dist-packages/kopf/clients/watching.py", line 215, in watch_objs	
sock_connect=settings.watching.connect_timeout,	
File "/usr/local/lib/python3.7/dist-packages/aiohttp/client.py", line 504, in _request	
await resp.start(conn)	
File "/usr/local/lib/python3.7/dist-packages/aiohttp/client_reqrep.py", line 847, in start	
message, payload = await self._protocol.read() # type: ignore # noqa	
File "/usr/local/lib/python3.7/dist-packages/aiohttp/streams.py", line 591, in read	
await self._waiter	
aiohttp.client_exceptions.ServerDisconnectedError
```

The issue is not with the stream itself broken, but with the initial streaming handshake broken.

This kind of errors should be treated the same as the streaming error: i.e., by ignoring them and restarting the stream request.


## Issues/PRs

> Issues: fixes #369


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Refactoring (non-breaking change which does not alter the behaviour)
- Mostly documentation and examples (no code changes)
- Mostly CI/CD automation, contribution experience


## Checklist

- [ ] The code addresses only the mentioned problem, and this problem only
- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
