### PR TITLE
Deprecate old K8s versions (1.12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ env:
   matrix:
     - KUBERNETES_VERSION=latest CLIENT=yes  # only one "yes" is enough
     - KUBERNETES_VERSION=latest CLIENT=no
-    - KUBERNETES_VERSION=v1.16.0 CLIENT=no
+    - KUBERNETES_VERSION=v1.17.0 CLIENT=no
+    - KUBERNETES_VERSION=v1.16.0 CLIENT=no  # starting from 1.16, use CRD API v1.
     - KUBERNETES_VERSION=v1.16.0 CLIENT=no CRDAPI=v1beta1
     - KUBERNETES_VERSION=v1.15.0 CLIENT=no CRDAPI=v1beta1
     - KUBERNETES_VERSION=v1.14.0 CLIENT=no CRDAPI=v1beta1

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ env:
     - KUBERNETES_VERSION=v1.15.0 CLIENT=no CRDAPI=v1beta1
     - KUBERNETES_VERSION=v1.14.0 CLIENT=no CRDAPI=v1beta1
     - KUBERNETES_VERSION=v1.13.0 CLIENT=no CRDAPI=v1beta1
-    - KUBERNETES_VERSION=v1.12.0 CLIENT=no CRDAPI=v1beta1
-#    - KUBERNETES_VERSION=v1.11.10  # Minikube fails on CRI preflight checks
-#    - KUBERNETES_VERSION=v1.10.13  # CRDs require spec.version, which fails on 1.14
 
 # Only one Python version is tested with all supported K8s versions: to check for API compatibility.
 # Other Python versions are tested with only one K8s version: if it works for one, it works for all.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ env:
   matrix:
     - KUBERNETES_VERSION=latest CLIENT=yes  # only one "yes" is enough
     - KUBERNETES_VERSION=latest CLIENT=no
-    - KUBERNETES_VERSION=v1.17.0 CLIENT=no
-    - KUBERNETES_VERSION=v1.16.0 CLIENT=no  # starting from 1.16, use CRD API v1.
-    - KUBERNETES_VERSION=v1.16.0 CLIENT=no CRDAPI=v1beta1
-    - KUBERNETES_VERSION=v1.15.0 CLIENT=no CRDAPI=v1beta1
-    - KUBERNETES_VERSION=v1.14.0 CLIENT=no CRDAPI=v1beta1
-    - KUBERNETES_VERSION=v1.13.0 CLIENT=no CRDAPI=v1beta1
+    - KUBERNETES_VERSION=v1.17.6 CLIENT=no
+    - KUBERNETES_VERSION=v1.16.10 CLIENT=no  # starting from 1.16, use CRD API v1.
+    - KUBERNETES_VERSION=v1.16.10 CLIENT=no CRDAPI=v1beta1
+    - KUBERNETES_VERSION=v1.15.12 CLIENT=no CRDAPI=v1beta1
+    - KUBERNETES_VERSION=v1.14.10 CLIENT=no CRDAPI=v1beta1
+    - KUBERNETES_VERSION=v1.13.12 CLIENT=no CRDAPI=v1beta1
 
 # Only one Python version is tested with all supported K8s versions: to check for API compatibility.
 # Other Python versions are tested with only one K8s version: if it works for one, it works for all.


### PR DESCRIPTION
## What do these changes do?

Drop old K8s versions (up to 1.12) from testing.

## Description

Minikube does not support K8s 1.12 anymore, the builds fail: 

* https://travis-ci.org/github/zalando-incubator/kopf/jobs/696167018

This does not break the code itself, and the existing releases are fine, but all new PRs will fail at this test step.

So, we can drop the old enough version of K8s. Instead, enlist 1.17 explicitly, since the "latest" now refers to 1.18.

## Issues/PRs

> Issues: #13 



## Type of changes

- Mostly CI/CD automation, contribution experience


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
