### PR TITLE
Use correct name of kopf.AnnotationsDiffBaseStorage

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -314,7 +314,7 @@ The default is an equivalent of:
 
     @kopf.on.startup()
     def configure(settings: kopf.OperatorSettings, **_):
-        settings.persistence.diffbase_storage = kopf.AnnotationsDiffBaseStore(
+        settings.persistence.diffbase_storage = kopf.AnnotationsDiffBaseStorage(
             name='kopf.zalando.org/last-handled-configuration',
         )
 
@@ -353,7 +353,7 @@ for diff-base storage, apply this configuration:
     def configure(settings: kopf.OperatorSettings, **_):
         settings.persistence.diffbase_storage = kopf.MiltiDiffBaseStorage([
             kopf.StatusDiffBaseStorage(field='status.diff-base'),
-            kopf.AnnotationsDiffBaseStore('kopf.zalando.org/last-handled-configuration'),
+            kopf.AnnotationsDiffBaseStorage('kopf.zalando.org/last-handled-configuration'),
         ])
 
 Run the operator for some time. Let all resources to change or force this:


### PR DESCRIPTION
## What do these changes do?

Use correct name of kopf.AnnotationsDiffBaseStorage in docs.

## Description

Use correct name of kopf.AnnotationsDiffBaseStorage in docs.

## Issues/PRs


Fix #388

## Type of changes

- Mostly documentation and examples (no code changes)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
