### PR TITLE
Suspend the repo, redirect to a new place

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,1 @@
 Sergey Vasilyev <sergey.vasilyev@zalando.de>
-Chiara Mezzavilla <chiara.mezzavilla@zalando.de>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+**This repository is suspended and not maintained.**
+
+It is kept in place for historic reference, so that all links remain valid,
+and the issues' & PRs' discussions are preserved for debugging & investigations.
+
+Kopf's development currently happens here:
+
+* https://github.com/nolar/kopf
+
+Please send new issues and pull requests there.
+
+---
+
 # Kubernetes Operator Pythonic Framework (Kopf)
 
 [![Build Status](https://travis-ci.org/zalando-incubator/kopf.svg?branch=master)](https://travis-ci.org/zalando-incubator/kopf)

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
     long_description_content_type='text/markdown',
     author='Sergey Vasilyev',
     author_email='sergey.vasilyev@zalando.de',
-    maintainer='Sergey Vasilyev, Chiara Mezzavilla',
-    maintainer_email='sergey.vasilyev@zalando.de, chiara.mezzavilla@zalando.de',
+    maintainer='Sergey Vasilyev',
+    maintainer_email='sergey.vasilyev@zalando.de',
     keywords=['kubernetes', 'operator', 'framework', 'python', 'k8s'],
     license='MIT',
 


### PR DESCRIPTION
New code and new features are located at:

* https://github.com/nolar/kopf

Announcement: 

* https://medium.com/@nolar/kopf-is-forked-cdca40026ea7?source=friends_link&sk=d476cc32ec728382d664506d2cf08b69

That new repo is already far ahead:

* https://github.com/nolar/kopf/compare/0.27...master